### PR TITLE
Fix access to an old BAM index

### DIFF
--- a/src/cljam/bam/reader.clj
+++ b/src/cljam/bam/reader.clj
@@ -172,9 +172,9 @@
 (defn read-blocks*
   [^BAMReader rdr
    ^String chr ^Long start ^Long end]
-  (when (nil? (.index rdr))
+  (when (nil? @(.index-delay rdr))
     (throw (Exception. "BAM index not found")))
-  (let [^BAMIndex bai (.index rdr)
+  (let [^BAMIndex bai @(.index-delay rdr)
         spans (get-spans bai (ref-id (.refs rdr) chr) start end)
         window (fn [^clojure.lang.PersistentHashMap a]
                  (let [^Long left (:pos a)]


### PR DESCRIPTION
I forgot to replace some accessors to an old BAM index (non-delay bai, e.g. `(.index bam-rdr)`)...:pensive:

This PR fixes them.