### PR TITLE
Add VCF reader

### DIFF
--- a/src/cljam/vcf.clj
+++ b/src/cljam/vcf.clj
@@ -1,0 +1,33 @@
+(ns cljam.vcf
+  "Functions to read and write the Variant Call Format (VCF)."
+  (:require [clojure.java.io :as io]
+            [cljam.vcf.reader :as vcf-reader])
+  (:import cljam.vcf.reader.VCFReader))
+
+(defn ^VCFReader reader
+  "Returns an open cljam.vcf.reader.VCFReader of f. Should be used inside
+  with-open to ensure the Reader is properly closed."
+  [f]
+  (let [meta-info (with-open [r (io/reader f)]
+                    (vcf-reader/load-meta-info r))
+        header (with-open [r (io/reader f)]
+                 (vcf-reader/load-header r))]
+    (VCFReader. (.getAbsolutePath (io/file f)) meta-info header
+                (io/reader f))))
+
+(defn meta-info
+  "Returns meta-information of the VCF from rdr as a map."
+  [^VCFReader rdr]
+  (.meta-info rdr))
+
+(defn header
+  "Returns header of the VCF from rdr as a vector including header field
+  strings."
+  [^VCFReader rdr]
+  (.header rdr))
+
+(defn read-variants
+  "Returns data lines of the VCF from rdr as a lazy sequence of maps. rdr must
+  implement cljam.vcf.reader.VCFReader."
+  [rdr]
+  (vcf-reader/read-variants rdr))

--- a/src/cljam/vcf/reader.clj
+++ b/src/cljam/vcf/reader.clj
@@ -1,0 +1,113 @@
+(ns cljam.vcf.reader
+  "A type of VCF reader and internal functions to read VCF contents. See
+  https://samtools.github.io/hts-specs/ for the detail VCF specifications."
+  (:require [clojure.string :as cstr]
+            [cljam.util :refer [str->long]]))
+
+;; VCFReader
+;; ---------
+
+(deftype VCFReader [f meta-info header reader]
+  java.io.Closeable
+  (close [this]
+    (.close ^java.io.Closeable (.reader this))))
+
+;; Utilities
+;; ---------
+
+(defn- dot->nil
+  [s]
+  (if (= s ".") nil s))
+
+;; Loading meta-information
+;; ------------------------
+
+(defn- meta-line?
+  [line]
+  (= (subs line 0 2) "##"))
+
+(defn- parse-structured-line
+  "e.g. (parse-structured-line \"ID=NS,Number=1,Type=Integer,Description=\"Number of Samples With Data\"\")
+        => {:id \"NS\" :number \"1\" :type \"Integer\"
+            :description \"Number of Samples With Data\"}"
+  [s]
+  (->> (re-seq #"([\w:/\.\?\-]*)=((?:\"(.*)\")|([\w:/\.\?\-]*))" s)
+       (map (fn [[_ k v1 v2 _]]
+              {(keyword (cstr/lower-case k)) (dot->nil (or v2 v1))}))
+       (apply merge)))
+
+(defn- parse-meta-info-info
+  [s]
+  (update (parse-structured-line s) :number str->long))
+
+(defn- parse-meta-info-line
+  [line]
+  (let [[_ k* v] (re-find #"^##([\w:/\.\?\-]*)=(.*)$" line)
+        k (keyword (cstr/lower-case k*))]
+    [k (if-let [[_ s] (re-find #"^<(.+)>$" v)]
+         (if (#{:info :format} k)
+           (parse-meta-info-info s)
+           (parse-structured-line s))
+         v)]))
+
+(defn load-meta-info
+  [^java.io.BufferedReader rdr]
+  (loop [line (.readLine rdr), meta-info {}]
+    (if (meta-line? line)
+      (let [[k v] (parse-meta-info-line line)]
+        (recur (.readLine rdr)
+               (if (#{:info :filter :format :alt :sample :pedigree} k)
+                 (if (get meta-info k)
+                   (update meta-info k conj v)
+                   (assoc meta-info k [v]))
+                 (assoc meta-info k v))))
+      meta-info)))
+
+;; Loading header
+;; --------------
+
+(defn- header-line?
+  [line]
+  (not (nil? (re-find #"^#[^#]*$" line))))
+
+(defn- parse-header-line
+  [line]
+  (->> (cstr/split (subs line 1) #"\t")
+       (mapv cstr/lower-case)))
+
+(defn load-header
+  [^java.io.BufferedReader rdr]
+  (loop [line (.readLine rdr)]
+    (if (header-line? line)
+      (parse-header-line line)
+      (recur (.readLine rdr)))))
+
+;; Reading data lines
+;; ------------------
+
+(defn- parse-data-line
+  [line header]
+  (let [[fields gt-fields] (->> (cstr/split line #"\t")
+                                (map dot->nil)
+                                (split-at 8))]
+    (merge {:chrom (first fields)
+            :pos (str->long (nth fields 1))
+            :id (nth fields 2)
+            :ref (nth fields 3)
+            :alt (nth fields 4)
+            :qual (some-> (nth fields 5) Double/parseDouble)
+            :filter (nth fields 6)
+            :info (nth fields 7)}
+           (zipmap (map keyword (drop 8 header)) gt-fields))))
+
+(defn- read-data-lines
+  [^java.io.BufferedReader rdr header]
+  (when-let [line (.readLine rdr)]
+    (if-not (or (meta-line? line) (header-line? line))
+      (cons (parse-data-line line header)
+            (lazy-seq (read-data-lines rdr header)))
+      (read-data-lines rdr header))))
+
+(defn read-variants
+  [^VCFReader rdr]
+  (read-data-lines (.reader rdr) (.header rdr)))

--- a/src/cljam/vcf/reader.clj
+++ b/src/cljam/vcf/reader.clj
@@ -94,7 +94,7 @@
             :pos (str->long (nth fields 1))
             :id (nth fields 2)
             :ref (nth fields 3)
-            :alt (nth fields 4)
+            :alt (some-> (nth fields 4) (cstr/split #","))
             :qual (some-> (nth fields 5) Double/parseDouble)
             :filter (nth fields 6)
             :info (nth fields 7)}

--- a/src/cljam/vcf/reader.clj
+++ b/src/cljam/vcf/reader.clj
@@ -72,8 +72,7 @@
 
 (defn- parse-header-line
   [line]
-  (->> (cstr/split (subs line 1) #"\t")
-       (mapv cstr/lower-case)))
+  (cstr/split (subs line 1) #"\t"))
 
 (defn load-header
   [^java.io.BufferedReader rdr]

--- a/test-resources/test.vcf
+++ b/test-resources/test.vcf
@@ -1,0 +1,34 @@
+##fileformat=VCFv4.0
+##fileDate=20090805
+##source=myImputationProgramV3.1
+##reference=1000GenomesPilot-NCBI36
+##phasing=partial
+##INFO=<ID=NS,Number=1,Type=Integer,Description="Number of Samples With Data">
+##INFO=<ID=AN,Number=1,Type=Integer,Description="Total number of alleles in called genotypes">
+##INFO=<ID=AC,Number=.,Type=Integer,Description="Allele count in genotypes, for each ALT allele, in the same order as listed">
+##INFO=<ID=DP,Number=1,Type=Integer,Description="Total Depth">
+##INFO=<ID=AF,Number=.,Type=Float,Description="Allele Frequency">
+##INFO=<ID=AA,Number=1,Type=String,Description="Ancestral Allele">
+##INFO=<ID=DB,Number=0,Type=Flag,Description="dbSNP membership, build 129">
+##INFO=<ID=H2,Number=0,Type=Flag,Description="HapMap2 membership">
+##FILTER=<ID=q10,Description="Quality below 10">
+##FILTER=<ID=s50,Description="Less than 50% of samples have data">
+##FORMAT=<ID=GT,Number=1,Type=String,Description="Genotype">
+##FORMAT=<ID=GQ,Number=1,Type=Integer,Description="Genotype Quality">
+##FORMAT=<ID=DP,Number=1,Type=Integer,Description="Read Depth">
+##FORMAT=<ID=HQ,Number=2,Type=Integer,Description="Haplotype Quality">
+##ALT=<ID=DEL:ME:ALU,Description="Deletion of ALU element">
+##ALT=<ID=CNV,Description="Copy number variable region">
+#CHROM	POS	ID	REF	ALT	QUAL	FILTER	INFO	FORMAT	NA00001	NA00002	NA00003
+19	111	.	A	C	9.6	.	.	GT:HQ	0|0:10,10	0|0:10,10	0/1:3,3
+19	112	.	A	G	10	.	.	GT:HQ	0|0:10,10	0|0:10,10	0/1:3,3
+20	14370	rs6054257	G	A	29	PASS	.	GT:GQ:DP:HQ	0|0:48:1:51,51	1|0:48:8:51,51	1/1:43:5:.,.
+20	17330	.	T	A	3	q10	.	GT:GQ:DP:HQ	0|0:49:3:58,50	0|1:3:5:65,3	0/0:41:3:.,.
+20	1110696	rs6040355	A	G,T	67	PASS	.	GT:GQ:DP:HQ	1|2:21:6:23,27	2|1:2:0:18,2	2/2:35:4:.,.
+20	1230237	.	T	.	47	PASS	.	GT:GQ:DP:HQ	0|0:54:.:56,60	0|0:48:4:51,51	0/0:61:2:.,.
+20	1234567	microsat1	G	GA,GAC	50	PASS	.	GT:GQ:DP	0/1:.:4	0/2:17:2	1/1:40:3
+20	1235237	.	T	.	.	.	.	GT	0/0	0|0	./.
+X	9	.	A	T	12.1	.	.	GT	0	0/1	1/0
+X	10	rsTest	AC	A,ATG	10	PASS	.	GT	0	0/1	0|2
+X	11	rsTest2	T	A,<DEL:ME:ALU>	10	q10;s50	.	GT:DP:GQ	.:3:10	./.:.:.	0|2:3:.
+X	12	.	T	A	13	.	.	GT	0	1/0	1/1

--- a/test/cljam/t_common.clj
+++ b/test/cljam/t_common.clj
@@ -346,39 +346,39 @@
    "na00002" "na00003"])
 
 (def test-vcf-variants
-  '({:format "GT:HQ", :alt "C", :ref "A", :pos 111, :na00001 "0|0:10,10",
+  '({:format "GT:HQ", :alt ["C"], :ref "A", :pos 111, :na00001 "0|0:10,10",
      :filter nil, :na00003 "0/1:3,3", :id nil, :info nil, :chrom "19",
      :qual 9.6, :na00002 "0|0:10,10"}
-    {:format "GT:HQ", :alt "G", :ref "A", :pos 112, :na00001 "0|0:10,10",
+    {:format "GT:HQ", :alt ["G"], :ref "A", :pos 112, :na00001 "0|0:10,10",
      :filter nil, :na00003 "0/1:3,3", :id nil, :info nil, :chrom "19",
      :qual 10.0, :na00002 "0|0:10,10"}
-    {:format "GT:GQ:DP:HQ", :alt "A", :ref "G", :pos 14370, :na00001 "0|0:48:1:51,51",
+    {:format "GT:GQ:DP:HQ", :alt ["A"], :ref "G", :pos 14370, :na00001 "0|0:48:1:51,51",
      :filter "PASS", :na00003 "1/1:43:5:.,.", :id "rs6054257", :info nil, :chrom "20",
      :qual 29.0, :na00002 "1|0:48:8:51,51"}
-    {:format "GT:GQ:DP:HQ", :alt "A", :ref "T", :pos 17330, :na00001 "0|0:49:3:58,50",
+    {:format "GT:GQ:DP:HQ", :alt ["A"], :ref "T", :pos 17330, :na00001 "0|0:49:3:58,50",
      :filter "q10", :na00003 "0/0:41:3:.,.", :id nil, :info nil, :chrom "20",
      :qual 3.0, :na00002 "0|1:3:5:65,3"}
-    {:format "GT:GQ:DP:HQ", :alt "G,T", :ref "A", :pos 1110696, :na00001 "1|2:21:6:23,27",
+    {:format "GT:GQ:DP:HQ", :alt ["G" "T"], :ref "A", :pos 1110696, :na00001 "1|2:21:6:23,27",
      :filter "PASS", :na00003 "2/2:35:4:.,.", :id "rs6040355", :info nil, :chrom "20",
      :qual 67.0, :na00002 "2|1:2:0:18,2"}
     {:format "GT:GQ:DP:HQ", :alt nil, :ref "T", :pos 1230237, :na00001 "0|0:54:.:56,60",
      :filter "PASS", :na00003 "0/0:61:2:.,.", :id nil, :info nil, :chrom "20",
      :qual 47.0, :na00002 "0|0:48:4:51,51"}
-    {:format "GT:GQ:DP", :alt "GA,GAC", :ref "G", :pos 1234567, :na00001 "0/1:.:4",
+    {:format "GT:GQ:DP", :alt ["GA" "GAC"], :ref "G", :pos 1234567, :na00001 "0/1:.:4",
      :filter "PASS", :na00003 "1/1:40:3", :id "microsat1", :info nil, :chrom "20",
      :qual 50.0, :na00002 "0/2:17:2"}
     {:format "GT", :alt nil, :ref "T", :pos 1235237, :na00001 "0/0",
      :filter nil, :na00003 "./.", :id nil, :info nil, :chrom "20",
      :qual nil, :na00002 "0|0"}
-    {:format "GT", :alt "T", :ref "A", :pos 9, :na00001 "0",
+    {:format "GT", :alt ["T"], :ref "A", :pos 9, :na00001 "0",
      :filter nil, :na00003 "1/0", :id nil, :info nil, :chrom "X",
      :qual 12.1, :na00002 "0/1"}
-    {:format "GT", :alt "A,ATG", :ref "AC", :pos 10, :na00001 "0",
+    {:format "GT", :alt ["A" "ATG"], :ref "AC", :pos 10, :na00001 "0",
      :filter "PASS", :na00003 "0|2", :id "rsTest", :info nil, :chrom "X",
      :qual 10.0, :na00002 "0/1"}
-    {:format "GT:DP:GQ", :alt "A,<DEL:ME:ALU>", :ref "T", :pos 11, :na00001 ".:3:10",
+    {:format "GT:DP:GQ", :alt ["A" "<DEL:ME:ALU>"], :ref "T", :pos 11, :na00001 ".:3:10",
      :filter "q10;s50", :na00003 "0|2:3:.", :id "rsTest2", :info nil, :chrom "X",
      :qual 10.0, :na00002 "./.:.:."}
-    {:format "GT", :alt "A", :ref "T", :pos 12, :na00001 "0",
+    {:format "GT", :alt ["A"], :ref "T", :pos 12, :na00001 "0",
      :filter nil, :na00003 "1/1", :id nil, :info nil, :chrom "X",
      :qual 13.0, :na00002 "1/0"}))

--- a/test/cljam/t_common.clj
+++ b/test/cljam/t_common.clj
@@ -92,6 +92,10 @@
 (def test-tabix-file "test-resources/test.gtf.gz.tbi")
 (def test-large-tabix-file (cavia/resource mycavia "large.tbi"))
 
+;; ### VCF files
+
+(def test-vcf-file "test-resources/test.vcf")
+
 (def test-sam
   {:header {:SQ [{:SN "ref", :LN 45} {:SN "ref2", :LN 40}]}
    :alignments
@@ -311,3 +315,70 @@
     {:name "SEQ_ID_3"
      :sequence "AAATTTGGGCCCAAATTTGGGCCCAAATTTGGGCCCAAATTTGGGCCCAAATTTGGGCCCAAATTTGGGCCCAAATTTGGGCCCAAATTTGGGC"
      :quality "!\"#$%&'()*+,-./0123456789:;<=>?@ABCDEFGHIJKLMNOPQRSTUVWXYZ[\\]^_`abcdefghijklmnopqrstuvwxyz{|}~"}))
+
+;; ### VCF
+
+(def test-vcf-meta-info
+  {:fileformat "VCFv4.0"
+   :filedate "20090805"
+   :source "myImputationProgramV3.1"
+   :reference "1000GenomesPilot-NCBI36"
+   :phasing "partial"
+   :info [{:id "NS", :number 1, :type "Integer", :description "Number of Samples With Data"}
+          {:id "AN", :number 1, :type "Integer", :description "Total number of alleles in called genotypes"}
+          {:id "AC", :number nil, :type "Integer", :description "Allele count in genotypes, for each ALT allele, in the same order as listed"}
+          {:id "DP", :number 1, :type "Integer", :description "Total Depth"}
+          {:id "AF", :number nil, :type "Float", :description "Allele Frequency"}
+          {:id "AA", :number 1, :type "String", :description "Ancestral Allele"}
+          {:id "DB", :number 0, :type "Flag", :description "dbSNP membership, build 129"}
+          {:id "H2", :number 0, :type "Flag", :description "HapMap2 membership"}]
+   :filter [{:id "q10", :description "Quality below 10"}
+            {:id "s50", :description "Less than 50% of samples have data"}]
+   :format [{:id "GT", :number 1, :type "String", :description "Genotype"}
+            {:id "GQ", :number 1, :type "Integer", :description "Genotype Quality"}
+            {:id "DP", :number 1, :type "Integer", :description "Read Depth"}
+            {:id "HQ", :number 2, :type "Integer", :description "Haplotype Quality"}]
+   :alt [{:id "DEL:ME:ALU", :description "Deletion of ALU element"}
+         {:id "CNV", :description "Copy number variable region"}]})
+
+(def test-vcf-header
+  ["chrom" "pos" "id" "ref" "alt" "qual" "filter" "info" "format" "na00001"
+   "na00002" "na00003"])
+
+(def test-vcf-variants
+  '({:format "GT:HQ", :alt "C", :ref "A", :pos 111, :na00001 "0|0:10,10",
+     :filter nil, :na00003 "0/1:3,3", :id nil, :info nil, :chrom "19",
+     :qual 9.6, :na00002 "0|0:10,10"}
+    {:format "GT:HQ", :alt "G", :ref "A", :pos 112, :na00001 "0|0:10,10",
+     :filter nil, :na00003 "0/1:3,3", :id nil, :info nil, :chrom "19",
+     :qual 10.0, :na00002 "0|0:10,10"}
+    {:format "GT:GQ:DP:HQ", :alt "A", :ref "G", :pos 14370, :na00001 "0|0:48:1:51,51",
+     :filter "PASS", :na00003 "1/1:43:5:.,.", :id "rs6054257", :info nil, :chrom "20",
+     :qual 29.0, :na00002 "1|0:48:8:51,51"}
+    {:format "GT:GQ:DP:HQ", :alt "A", :ref "T", :pos 17330, :na00001 "0|0:49:3:58,50",
+     :filter "q10", :na00003 "0/0:41:3:.,.", :id nil, :info nil, :chrom "20",
+     :qual 3.0, :na00002 "0|1:3:5:65,3"}
+    {:format "GT:GQ:DP:HQ", :alt "G,T", :ref "A", :pos 1110696, :na00001 "1|2:21:6:23,27",
+     :filter "PASS", :na00003 "2/2:35:4:.,.", :id "rs6040355", :info nil, :chrom "20",
+     :qual 67.0, :na00002 "2|1:2:0:18,2"}
+    {:format "GT:GQ:DP:HQ", :alt nil, :ref "T", :pos 1230237, :na00001 "0|0:54:.:56,60",
+     :filter "PASS", :na00003 "0/0:61:2:.,.", :id nil, :info nil, :chrom "20",
+     :qual 47.0, :na00002 "0|0:48:4:51,51"}
+    {:format "GT:GQ:DP", :alt "GA,GAC", :ref "G", :pos 1234567, :na00001 "0/1:.:4",
+     :filter "PASS", :na00003 "1/1:40:3", :id "microsat1", :info nil, :chrom "20",
+     :qual 50.0, :na00002 "0/2:17:2"}
+    {:format "GT", :alt nil, :ref "T", :pos 1235237, :na00001 "0/0",
+     :filter nil, :na00003 "./.", :id nil, :info nil, :chrom "20",
+     :qual nil, :na00002 "0|0"}
+    {:format "GT", :alt "T", :ref "A", :pos 9, :na00001 "0",
+     :filter nil, :na00003 "1/0", :id nil, :info nil, :chrom "X",
+     :qual 12.1, :na00002 "0/1"}
+    {:format "GT", :alt "A,ATG", :ref "AC", :pos 10, :na00001 "0",
+     :filter "PASS", :na00003 "0|2", :id "rsTest", :info nil, :chrom "X",
+     :qual 10.0, :na00002 "0/1"}
+    {:format "GT:DP:GQ", :alt "A,<DEL:ME:ALU>", :ref "T", :pos 11, :na00001 ".:3:10",
+     :filter "q10;s50", :na00003 "0|2:3:.", :id "rsTest2", :info nil, :chrom "X",
+     :qual 10.0, :na00002 "./.:.:."}
+    {:format "GT", :alt "A", :ref "T", :pos 12, :na00001 "0",
+     :filter nil, :na00003 "1/1", :id nil, :info nil, :chrom "X",
+     :qual 13.0, :na00002 "1/0"}))

--- a/test/cljam/t_common.clj
+++ b/test/cljam/t_common.clj
@@ -342,43 +342,31 @@
          {:id "CNV", :description "Copy number variable region"}]})
 
 (def test-vcf-header
-  ["chrom" "pos" "id" "ref" "alt" "qual" "filter" "info" "format" "na00001"
-   "na00002" "na00003"])
+  ["CHROM" "POS" "ID" "REF" "ALT" "QUAL" "FILTER" "INFO" "FORMAT" "NA00001"
+   "NA00002" "NA00003"])
 
 (def test-vcf-variants
-  '({:format "GT:HQ", :alt ["C"], :ref "A", :pos 111, :na00001 "0|0:10,10",
-     :filter nil, :na00003 "0/1:3,3", :id nil, :info nil, :chrom "19",
-     :qual 9.6, :na00002 "0|0:10,10"}
-    {:format "GT:HQ", :alt ["G"], :ref "A", :pos 112, :na00001 "0|0:10,10",
-     :filter nil, :na00003 "0/1:3,3", :id nil, :info nil, :chrom "19",
-     :qual 10.0, :na00002 "0|0:10,10"}
-    {:format "GT:GQ:DP:HQ", :alt ["A"], :ref "G", :pos 14370, :na00001 "0|0:48:1:51,51",
-     :filter "PASS", :na00003 "1/1:43:5:.,.", :id "rs6054257", :info nil, :chrom "20",
-     :qual 29.0, :na00002 "1|0:48:8:51,51"}
-    {:format "GT:GQ:DP:HQ", :alt ["A"], :ref "T", :pos 17330, :na00001 "0|0:49:3:58,50",
-     :filter "q10", :na00003 "0/0:41:3:.,.", :id nil, :info nil, :chrom "20",
-     :qual 3.0, :na00002 "0|1:3:5:65,3"}
-    {:format "GT:GQ:DP:HQ", :alt ["G" "T"], :ref "A", :pos 1110696, :na00001 "1|2:21:6:23,27",
-     :filter "PASS", :na00003 "2/2:35:4:.,.", :id "rs6040355", :info nil, :chrom "20",
-     :qual 67.0, :na00002 "2|1:2:0:18,2"}
-    {:format "GT:GQ:DP:HQ", :alt nil, :ref "T", :pos 1230237, :na00001 "0|0:54:.:56,60",
-     :filter "PASS", :na00003 "0/0:61:2:.,.", :id nil, :info nil, :chrom "20",
-     :qual 47.0, :na00002 "0|0:48:4:51,51"}
-    {:format "GT:GQ:DP", :alt ["GA" "GAC"], :ref "G", :pos 1234567, :na00001 "0/1:.:4",
-     :filter "PASS", :na00003 "1/1:40:3", :id "microsat1", :info nil, :chrom "20",
-     :qual 50.0, :na00002 "0/2:17:2"}
-    {:format "GT", :alt nil, :ref "T", :pos 1235237, :na00001 "0/0",
-     :filter nil, :na00003 "./.", :id nil, :info nil, :chrom "20",
-     :qual nil, :na00002 "0|0"}
-    {:format "GT", :alt ["T"], :ref "A", :pos 9, :na00001 "0",
-     :filter nil, :na00003 "1/0", :id nil, :info nil, :chrom "X",
-     :qual 12.1, :na00002 "0/1"}
-    {:format "GT", :alt ["A" "ATG"], :ref "AC", :pos 10, :na00001 "0",
-     :filter "PASS", :na00003 "0|2", :id "rsTest", :info nil, :chrom "X",
-     :qual 10.0, :na00002 "0/1"}
-    {:format "GT:DP:GQ", :alt ["A" "<DEL:ME:ALU>"], :ref "T", :pos 11, :na00001 ".:3:10",
-     :filter "q10;s50", :na00003 "0|2:3:.", :id "rsTest2", :info nil, :chrom "X",
-     :qual 10.0, :na00002 "./.:.:."}
-    {:format "GT", :alt ["A"], :ref "T", :pos 12, :na00001 "0",
-     :filter nil, :na00003 "1/1", :id nil, :info nil, :chrom "X",
-     :qual 13.0, :na00002 "1/0"}))
+  '({:chrom "19", :pos 111, :id nil, :ref "A", :alt ["C"], :qual 9.6, :filter nil, :info nil,
+     :FORMAT "GT:HQ", :NA00001 "0|0:10,10", :NA00002 "0|0:10,10", :NA00003 "0/1:3,3"}
+    {:chrom "19", :pos 112, :id nil, :ref "A", :alt ["G"], :qual 10.0, :filter nil, :info nil,
+     :FORMAT "GT:HQ", :NA00001 "0|0:10,10", :NA00002 "0|0:10,10", :NA00003 "0/1:3,3"}
+    {:chrom "20", :pos 14370, :id "rs6054257", :ref "G", :alt ["A"], :qual 29.0, :filter "PASS", :info nil,
+     :FORMAT "GT:GQ:DP:HQ", :NA00001 "0|0:48:1:51,51", :NA00002 "1|0:48:8:51,51", :NA00003 "1/1:43:5:.,."}
+    {:chrom "20", :pos 17330, :id nil, :ref "T", :alt ["A"], :qual 3.0, :filter "q10", :info nil,
+     :FORMAT "GT:GQ:DP:HQ", :NA00001 "0|0:49:3:58,50", :NA00002 "0|1:3:5:65,3", :NA00003 "0/0:41:3:.,."}
+    {:chrom "20", :pos 1110696, :id "rs6040355", :ref "A", :alt ["G" "T"], :qual 67.0, :filter "PASS", :info nil,
+     :FORMAT "GT:GQ:DP:HQ",:NA00001 "1|2:21:6:23,27", :NA00002 "2|1:2:0:18,2", :NA00003 "2/2:35:4:.,."}
+    {:chrom "20", :pos 1230237, :id nil, :ref "T", :alt nil, :qual 47.0, :filter "PASS", :info nil,
+     :FORMAT "GT:GQ:DP:HQ", :NA00001 "0|0:54:.:56,60", :NA00002 "0|0:48:4:51,51", :NA00003 "0/0:61:2:.,."}
+    {:chrom "20", :pos 1234567, :id "microsat1", :ref "G", :alt ["GA" "GAC"], :qual 50.0, :filter "PASS", :info nil,
+     :FORMAT "GT:GQ:DP", :NA00001 "0/1:.:4", :NA00002 "0/2:17:2", :NA00003 "1/1:40:3"}
+    {:chrom "20", :pos 1235237, :id nil, :ref "T", :alt nil, :qual nil, :filter nil, :info nil,
+     :FORMAT "GT", :NA00001 "0/0", :NA00002 "0|0", :NA00003 "./."}
+    {:chrom "X", :pos 9, :id nil, :ref "A", :alt ["T"], :qual 12.1, :filter nil, :info nil,
+     :FORMAT "GT", :NA00001 "0", :NA00002 "0/1", :NA00003 "1/0"}
+    {:chrom "X", :pos 10, :id "rsTest", :ref "AC", :alt ["A" "ATG"], :qual 10.0, :filter "PASS", :info nil,
+     :FORMAT "GT", :NA00001 "0", :NA00002 "0/1", :NA00003 "0|2"}
+    {:chrom "X", :pos 11, :id "rsTest2", :ref "T", :alt ["A" "<DEL:ME:ALU>"], :qual 10.0, :filter "q10;s50", :info nil,
+     :FORMAT "GT:DP:GQ", :NA00001 ".:3:10", :NA00002 "./.:.:.", :NA00003 "0|2:3:."}
+    {:chrom "X", :pos 12, :id nil, :ref "T", :alt ["A"], :qual 13.0, :filter nil, :info nil,
+     :FORMAT "GT", :NA00001 "0", :NA00002 "1/0", :NA00003 "1/1"}))

--- a/test/cljam/t_vcf.clj
+++ b/test/cljam/t_vcf.clj
@@ -1,0 +1,16 @@
+(ns cljam.t-vcf
+  (:require [midje.sweet :refer :all]
+            [cljam.t-common :refer :all]
+            [cljam.vcf :as vcf]))
+
+(fact "`meta-info` returns meta-information of the VCF as a map"
+  (with-open [rdr (vcf/reader test-vcf-file)]
+    (vcf/meta-info rdr) => test-vcf-meta-info))
+
+(fact "`header` returns header line of the VCF as a vector"
+  (with-open [rdr (vcf/reader test-vcf-file)]
+    (vcf/header rdr) => test-vcf-header))
+
+(fact "`read-variants` returns data lines of the VCF as a lazy sequence"
+  (with-open [rdr (vcf/reader test-vcf-file)]
+    (vcf/read-variants rdr) => test-vcf-variants))


### PR DESCRIPTION
This PR adds functions to read the Variant Call Format (VCF).

* Add `cljam.vcf`: public APIs of VCF I/O
* Add `cljam.vcf.reader`: internal reader functions of VCF
* Add `cljam.t-vcf`: test cases of `cljam.vcf`
* Add `test-resources/test.vcf`: a small VCF file for tests