### PR TITLE
Improve SAM/BAM convert performance

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -10,7 +10,7 @@
                  [pandect "0.5.4"]
                  [clj-sub-command "0.2.2"]
                  [bgzf4j "0.1.0"]
-                 [com.climate/claypoole "1.1.1"]
+                 [com.climate/claypoole "1.1.3"]
                  [camel-snake-kebab "0.4.0"]]
   :plugins [[lein-midje "3.2"]]
   :profiles {:dev {:dependencies [[org.clojure/clojure "1.8.0"]

--- a/src/cljam/bam/encoder.clj
+++ b/src/cljam/bam/encoder.clj
@@ -127,14 +127,11 @@
            \c nil
            \C nil
            \s nil
-           \S (let [bb (lsb/gen-byte-buffer)
-                    total-len (+ 1 4 (* 2 (count array)))]
-                ;; (lsb/write-bytes writer (byte-array 1 (byte \S)))
-                (.put bb (byte-array 1 (byte \S)) 1)
-                ;; (lsb/write-int writer (count array))
+           \S (let [total-len (+ 1 4 (* 2 (count array)))
+                    bb (lsb/gen-byte-buffer total-len)]
+                (.put bb (byte-array 1 (byte \S)) 0 1)
                 (.putInt bb (count array))
                 (doseq [v array]
-                  ;; (lsb/write-short writer (Short/parseShort v))
                   (.putShort bb (Short/parseShort v)))
                 (Arrays/copyOfRange (.array bb) 0 total-len))
            \i nil

--- a/src/cljam/bam/encoder.clj
+++ b/src/cljam/bam/encoder.clj
@@ -1,0 +1,209 @@
+(ns cljam.bam.encoder
+  "Encoder of BAM alignment blocks."
+  (:require [clojure.string :refer [split]]
+            (cljam [cigar :as cgr]
+                   [lsb :as lsb]
+                   [util :refer [string->bytes ubyte]])
+            [cljam.util.sam-util :refer [reg->bin normalize-bases fastq->phred
+                                         bytes->compressed-bases make-refs ref-id
+                                         stringify-header]]
+            [cljam.bam.common :refer [bam-magic fixed-block-size]])
+  (:import [java.util Arrays]))
+
+(def ^:private fixed-tag-size 3)
+(def ^:private fixed-binary-array-tag-size 5)
+
+(defn- get-pos [aln]
+  (dec (:pos aln)))
+
+(defn- get-end [aln]
+  (dec
+   (+ (:pos aln)
+      (cgr/count-ref (:cigar aln)))))
+
+(defn- get-l-seq [sam-alignment]
+  (count (:seq sam-alignment)))
+
+(defn- get-next-ref-id [sa refs]
+  (condp = (:rnext sa)
+    "*" -1
+    "=" (if-let [id (ref-id refs (:rname sa))] id -1)
+    (if-let [id (ref-id refs (:rnext sa))] id -1)))
+
+(defn- get-ref-id [aln refs]
+  (if-let [id (ref-id refs (:rname aln))] id -1))
+
+(defn- get-next-pos [sam-alignment]
+  (dec (:pnext sam-alignment)))
+
+(defn- get-tlen [sam-alignment]
+  (:tlen sam-alignment))
+
+(defn- get-read-name [sam-alignment]
+  (:qname sam-alignment))
+
+(defn- encode-cigar-op [op]
+  (case op
+    \M (byte 0)
+    \I (byte 1)
+    \D (byte 2)
+    \N (byte 3)
+    \S (byte 4)
+    \H (byte 5)
+    \P (byte 6)
+    \= (byte 7)
+    \X (byte 8)))
+
+(defn- encode-cigar [cigar]
+  (map #(bit-or (bit-shift-left (first %) 4)
+                (encode-cigar-op (second %)))
+       (cgr/parse cigar)))
+
+(defn- get-cigar [aln]
+  (encode-cigar (:cigar aln)))
+
+(defn- get-seq [sam-alignment]
+  (bytes->compressed-bases (normalize-bases (string->bytes (:seq sam-alignment)))))
+
+(defn- get-options-size [sam-alignment]
+  (->> (map
+        (fn [op]
+          (let [[tag value] (first (seq op))]
+            (+ fixed-tag-size
+               (case (first (:type value))
+                 \A 1
+                 \i 4
+                 \f 4
+                 \Z (inc (count (:value value)))
+                 \B (let [[array-type & array] (split (:value value) #",")]
+                      (+ fixed-binary-array-tag-size
+                         (* (count array)
+                            (case (first array-type)
+                              \c 1
+                              \C 1
+                              \s 2
+                              \S 2
+                              \i 4
+                              \I 4
+                              \f 4
+                              0))))))))
+        (:options sam-alignment))
+       (reduce +)))
+
+(defn- get-block-size [aln]
+  (let [read-length (count (normalize-bases (string->bytes (:seq aln))))
+        cigar-length (cgr/count-op (:cigar aln))]
+    (+ fixed-block-size (count (:qname aln)) 1
+       (* cigar-length 4)
+       (int (/ (inc read-length) 2))
+       read-length
+       (get-options-size aln))))
+
+(defn- encode-qual [sam-alignment]
+  (if (= (:qual sam-alignment) "*")
+    (byte-array (count (:seq sam-alignment)) (ubyte 0xff))
+    (fastq->phred (:qual sam-alignment))))
+
+(defn- encode-tag-value [val-type value]
+  (case val-type
+    \A (let [bb (lsb/gen-byte-buffer)]
+         (.putChar bb (char value))
+         (Arrays/copyOfRange (.array bb) 0 1))
+    \i (let [bb (lsb/gen-byte-buffer)]
+         (.putInt bb (int value))
+         (Arrays/copyOfRange (.array bb) 0 4))
+    \f (let [bb (lsb/gen-byte-buffer)]
+         (.putFloat bb (float value))
+         (Arrays/copyOfRange (.array bb) 0 4))
+    \Z (let [^String text value
+             text-size (count text)
+             buf (byte-array (inc text-size))]
+         (.getBytes text 0 text-size buf 0)
+         (aset-byte buf text-size 0)
+         buf)
+    ;; \H nil
+    \B (let [[array-type & array] (split value #",")]
+         (case (first array-type)
+           \c nil
+           \C nil
+           \s nil
+           \S (let [bb (lsb/gen-byte-buffer)
+                    total-len (+ 1 4 (* 2 (count array)))]
+                ;; (lsb/write-bytes writer (byte-array 1 (byte \S)))
+                (.put bb (byte-array 1 (byte \S)) 1)
+                ;; (lsb/write-int writer (count array))
+                (.putInt bb (count array))
+                (doseq [v array]
+                  ;; (lsb/write-short writer (Short/parseShort v))
+                  (.putShort bb (Short/parseShort v)))
+                (Arrays/copyOfRange (.array bb) 0 total-len))
+           \i nil
+           \I nil
+           \f nil))))
+
+(defn encode
+  [aln refs]
+  [(get-block-size aln)
+   (get-ref-id aln refs)
+   (get-pos aln)
+   (short (inc (count (:qname aln))))
+   (short (:mapq aln))
+   (reg->bin (:pos aln) (get-end aln))
+   (cgr/count-op (:cigar aln))
+   (:flag aln)
+   (get-l-seq aln)
+   (get-next-ref-id aln refs)
+   (get-next-pos aln)
+   (get-tlen aln)
+   (get-read-name aln)
+   (byte-array 1 (byte 0))
+   (get-cigar aln)
+   (get-seq aln)
+   (encode-qual aln)
+   (doall (map (fn [op]
+                 (let [[tag value] (first (seq op))]
+                   [(short (bit-or (bit-shift-left (byte (second (name tag))) 8)
+                                   (byte (first (name tag)))))
+                    (.getBytes ^String (:type value))
+                    (encode-tag-value (first (:type value)) (:value value))]))
+               (:options aln)))])
+
+(defn write-encoded-alignment
+  [w aln]
+  ;; block_size
+  (lsb/write-int w (nth aln 0))
+  ;; refID
+  (lsb/write-int w (nth aln 1))
+  ;; pos
+  (lsb/write-int w (nth aln 2))
+  ;; bin_mq_nl
+  (lsb/write-ubyte w (nth aln 3))
+  (lsb/write-ubyte w (nth aln 4))
+  (lsb/write-ushort w (nth aln 5))
+  ;; flag_nc
+  (lsb/write-ushort w (nth aln 6))
+  (lsb/write-ushort w (nth aln 7))
+  ;; l_seq
+  (lsb/write-int w (nth aln 8))
+  ;; next_refID
+  (lsb/write-int w (nth aln 9))
+  ;; next_pos
+  (lsb/write-int w (nth aln 10))
+  ;; tlen
+  (lsb/write-int w (nth aln 11))
+  ;; read_name
+  (lsb/write-string w (nth aln 12))
+  (lsb/write-bytes w (nth aln 13))
+  ;; cigar
+  (doseq [cigar (nth aln 14)]
+    (lsb/write-int w cigar))
+  ;; seq
+  (lsb/write-bytes w (nth aln 15))
+  ;; qual
+  (lsb/write-bytes w (nth aln 16))
+  ;; options
+  (doseq [v (nth aln 17)]
+    (lsb/write-short w (nth v 0))
+    (lsb/write-bytes w (nth v 1))
+    (when-not (nil? (nth v 2))
+      (lsb/write-bytes w (nth v 2)))))

--- a/src/cljam/cli.clj
+++ b/src/cljam/cli.clj
@@ -15,6 +15,7 @@
                    [fasta-indexer :as fai]
                    [dict :as dict]
                    [pileup :as plp]
+                   [convert :as convert]
                    [level :as level])
             [cljam.util.sam-util :refer [stringify-header stringify-alignment]])
   (:import [java.io BufferedWriter OutputStreamWriter]))
@@ -106,14 +107,11 @@
      (not= (count arguments) 2) (exit 1 (convert-usage summary))
      errors (exit 1 (error-msg errors)))
     (let [[in out] arguments]
-      (with-open [wtr (writer out)]
-        (with-open [rdr (reader in)]
-          (let [hdr (io/read-header rdr)]
-            (io/write-header wtr hdr)
-            (io/write-refs wtr hdr)
-            (doseq [alns (partition-all 10000 (io/read-alignments rdr {}))]
-              (io/write-alignments wtr alns hdr)))))))
-  nil)
+      (try
+        (convert/convert in out)
+        (catch Throwable e
+          (exit 1 (.getMessage e))))
+      nil)))
 
 ;; ### normalize command
 

--- a/src/cljam/cli.clj
+++ b/src/cljam/cli.clj
@@ -107,11 +107,8 @@
      (not= (count arguments) 2) (exit 1 (convert-usage summary))
      errors (exit 1 (error-msg errors)))
     (let [[in out] arguments]
-      (try
-        (convert/convert in out)
-        (catch Throwable e
-          (exit 1 (.getMessage e))))
-      nil)))
+      (convert/convert in out)))
+  nil)
 
 ;; ### normalize command
 

--- a/src/cljam/convert.clj
+++ b/src/cljam/convert.clj
@@ -1,0 +1,58 @@
+(ns cljam.convert
+  "Convert file from sam to bam, and vice versa"
+  (:require [cljam.core :as core]
+            [cljam.io :as io]
+            [cljam.bam.encoder :as encoder]
+            [cljam.util.sam-util :as sam-util]
+            [com.climate.claypoole :as cp]))
+
+(def ^:private default-num-block 10000)
+(def ^:private default-num-write-block 1000)
+
+(defn- _convert!
+  [in out num-block num-write-block alignments-writer]
+  (let [num-block (or num-block default-num-block)
+        num-write-block (or num-write-block default-num-write-block)]
+    (with-open [wtr (core/writer out)]
+      (with-open [rdr (core/reader in)]
+        (let [hdr (io/read-header rdr)]
+          (io/write-header wtr hdr)
+          (io/write-refs wtr hdr)
+          (alignments-writer rdr wtr hdr num-block num-write-block))))))
+
+(defn- sam-alignments-writer [rdr wtr hdr num-block num-write-block]
+  (doseq [alns (partition-all num-block (io/read-alignments rdr {}))]
+    (io/write-alignments wtr alns hdr)))
+
+(defn convert-bam-to-sam
+  "Read from input bam file, and write to output sam file"
+  [in out & [num-block num-write-block]]
+  (_convert! in out num-block num-write-block sam-alignments-writer))
+
+(defn- bam-alignments-writer [rdr wtr hdr num-block num-write-block]
+  (let [refs (sam-util/make-refs hdr)
+        w (.writer wtr)]
+    (cp/with-shutdown! [pool (cp/threadpool (cp/ncpus))]
+      (doseq [alns (partition-all num-block (io/read-alignments rdr {}))]
+        (let [blocks (doall (cp/pmap pool
+                                     (fn [lalns]
+                                       (doall (map #(encoder/encode % refs)
+                                                   lalns)))
+                                     (partition-all num-write-block alns)))]
+          (doseq [block blocks]
+            (doseq [e block]
+              (encoder/write-encoded-alignment w e))))))))
+
+(defn convert-sam-to-bam
+  "Read from input sam file, and write to output bam file"
+  [in out & [num-block num-write-block]]
+  (_convert! in out num-block num-write-block bam-alignments-writer))
+
+(defn convert
+  "Convert file format from input file to output file by file extension"
+  [in out & [num-block num-write-block]]
+  (condp re-find out
+    #"\.sam$" (convert-bam-to-sam in out num-block num-write-block)
+    #"\.bam$" (convert-sam-to-bam in out num-block num-write-block)
+    (throw (ex-info (str "Unsupported output file format " out) {})))
+  nil)

--- a/src/cljam/util.clj
+++ b/src/cljam/util.clj
@@ -29,7 +29,7 @@
 ;; string utils
 ;; ------------
 
-(defn string->bytes [^String s]
+(defn ^"[B" string->bytes [^String s]
   (let [buf (byte-array (count s))]
     (.getBytes s 0 (count buf) buf 0)
     buf))
@@ -70,6 +70,16 @@
         nil))
     nil))
 
+(defn str->float
+  [s]
+  (if-not (nil? s)
+    (try
+      (let [[n _ _ _] (re-matches #"(|-|\+)(\d+)\.?(\d*)" s)]
+        (Float. ^String n))
+      (catch Exception e
+        nil))
+    nil))
+
 (defn graph?
   "Returns true if c is a visible character, false if not."
   [c]
@@ -105,4 +115,3 @@
   [path]
   (let [filename (.getName (file path))]
     (first (cstr/split filename #"\.(?=[^\.]+$)"))))
-

--- a/src/cljam/util/sam_util.clj
+++ b/src/cljam/util/sam_util.clj
@@ -2,7 +2,7 @@
   "Utilities related to SAM/BAM format."
   (:require [clojure.string :as cstr]
             [cljam.cigar :refer [count-ref]]
-            [cljam.util :refer [ubyte str->int]]))
+            [cljam.util :refer [ubyte str->int str->float]]))
 
 ;;; parse
 
@@ -43,7 +43,7 @@
     \S (str->int val)
     \c (str->int val)
     \C (str->int val)
-    \f (float (str->int val))
+    \f (str->float val)
     \H nil ;;FIXME
     (throw (Exception. "Unrecognized tag type"))))
 
@@ -197,102 +197,130 @@
    :d  (ubyte 0xd0)
    :b  (ubyte 0xe0)})
 
-(defn char->compressed-base-low
+(defn- unfold-ksv-map [ksv-map]
+  (into {} (mapcat (fn [[ks v]]
+                     (map (fn [k] [k v]) ks))
+                   ksv-map)))
+
+(def ^:private _char->compressed-base-low
+  (unfold-ksv-map {[\=]       (:eq compressed-bases-low)
+                   [\a \A]    (:a  compressed-bases-low)
+                   [\c \C]    (:c  compressed-bases-low)
+                   [\g \G]    (:g  compressed-bases-low)
+                   [\t \T]    (:t  compressed-bases-low)
+                   [\n \N \.] (:n  compressed-bases-low)
+                   [\m \M]    (:m  compressed-bases-low)
+                   [\r \R]    (:r  compressed-bases-low)
+                   [\s \S]    (:s  compressed-bases-low)
+                   [\v \V]    (:v  compressed-bases-low)
+                   [\w \W]    (:w  compressed-bases-low)
+                   [\y \Y]    (:y  compressed-bases-low)
+                   [\h \H]    (:h  compressed-bases-low)
+                   [\k \K]    (:k  compressed-bases-low)
+                   [\d \D]    (:d  compressed-bases-low)
+                   [\b \B]    (:b  compressed-bases-low)}))
+
+(definline char->compressed-base-low
   "Convert from a char to BAM nybble representation of a base in low-order nybble."
   [base]
-  (condp #(some #{%2} %1) base
-    [\=]       (:eq compressed-bases-low)
-    [\a \A]    (:a  compressed-bases-low)
-    [\c \C]    (:c  compressed-bases-low)
-    [\g \G]    (:g  compressed-bases-low)
-    [\t \T]    (:t  compressed-bases-low)
-    [\n \N \.] (:n  compressed-bases-low)
-    [\m \M]    (:m  compressed-bases-low)
-    [\r \R]    (:r  compressed-bases-low)
-    [\s \S]    (:s  compressed-bases-low)
-    [\v \V]    (:v  compressed-bases-low)
-    [\w \W]    (:w  compressed-bases-low)
-    [\y \Y]    (:y  compressed-bases-low)
-    [\h \H]    (:h  compressed-bases-low)
-    [\k \K]    (:k  compressed-bases-low)
-    [\d \D]    (:d  compressed-bases-low)
-    [\b \B]    (:b  compressed-bases-low)
-    (throw (IllegalArgumentException. (str "Bad type: " base)))))
+  `(let [base# ~base]
+     (or
+       (_char->compressed-base-low base#)
+       (throw (IllegalArgumentException. (str "Bad type: " base#))))))
 
-(defn char->compressed-base-high
+(def ^:private _char->compressed-base-high
+  (unfold-ksv-map {[\=]       (:eq compressed-bases-high)
+                   [\a \A]    (:a  compressed-bases-high)
+                   [\c \C]    (:c  compressed-bases-high)
+                   [\g \G]    (:g  compressed-bases-high)
+                   [\t \T]    (:t  compressed-bases-high)
+                   [\n \N \.] (:n  compressed-bases-high)
+                   [\m \M]    (:m  compressed-bases-high)
+                   [\r \R]    (:r  compressed-bases-high)
+                   [\s \S]    (:s  compressed-bases-high)
+                   [\v \V]    (:v  compressed-bases-high)
+                   [\w \W]    (:w  compressed-bases-high)
+                   [\y \Y]    (:y  compressed-bases-high)
+                   [\h \H]    (:h  compressed-bases-high)
+                   [\k \K]    (:k  compressed-bases-high)
+                   [\d \D]    (:d  compressed-bases-high)
+                   [\b \B]    (:b  compressed-bases-high)}))
+
+(definline char->compressed-base-high
   "Convert from a char to BAM nybble representation of a base in high-order nybble."
   [base]
-  (condp #(some #{%2} %1) base
-    [\=]       (:eq compressed-bases-high)
-    [\a \A]    (:a  compressed-bases-high)
-    [\c \C]    (:c  compressed-bases-high)
-    [\g \G]    (:g  compressed-bases-high)
-    [\t \T]    (:t  compressed-bases-high)
-    [\n \N \.] (:n  compressed-bases-high)
-    [\m \M]    (:m  compressed-bases-high)
-    [\r \R]    (:r  compressed-bases-high)
-    [\s \S]    (:s  compressed-bases-high)
-    [\v \V]    (:v  compressed-bases-high)
-    [\w \W]    (:w  compressed-bases-high)
-    [\y \Y]    (:y  compressed-bases-high)
-    [\h \H]    (:h  compressed-bases-high)
-    [\k \K]    (:k  compressed-bases-high)
-    [\d \D]    (:d  compressed-bases-high)
-    [\b \B]    (:b  compressed-bases-high)
-    (throw (IllegalArgumentException. (str "Bad type: " base)))))
+  `(let [base# ~base]
+     (or
+       (_char->compressed-base-high base#)
+       (throw (IllegalArgumentException. (str "Bad type: " base#))))))
 
-(defn compressed-base->char-low
+(def ^:private _compressed-base->char-low
+  {(:eq compressed-bases-low) \=
+   (:a  compressed-bases-low) \A
+   (:c  compressed-bases-low) \C
+   (:g  compressed-bases-low) \G
+   (:t  compressed-bases-low) \T
+   (:n  compressed-bases-low) \N
+   (:m  compressed-bases-low) \M
+   (:r  compressed-bases-low) \R
+   (:s  compressed-bases-low) \S
+   (:v  compressed-bases-low) \V
+   (:w  compressed-bases-low) \W
+   (:y  compressed-bases-low) \Y
+   (:h  compressed-bases-low) \H
+   (:k  compressed-bases-low) \K
+   (:d  compressed-bases-low) \D
+   (:b  compressed-bases-low) \B})
+
+(definline compressed-base->char-low
   "Convert from BAM nybble representation of a base in low-order nybble to a char."
   [base]
-  (condp = (ubyte (bit-and base 0xf))
-    (:eq compressed-bases-low) \=
-    (:a  compressed-bases-low) \A
-    (:c  compressed-bases-low) \C
-    (:g  compressed-bases-low) \G
-    (:t  compressed-bases-low) \T
-    (:n  compressed-bases-low) \N
-    (:m  compressed-bases-low) \M
-    (:r  compressed-bases-low) \R
-    (:s  compressed-bases-low) \S
-    (:v  compressed-bases-low) \V
-    (:w  compressed-bases-low) \W
-    (:y  compressed-bases-low) \Y
-    (:h  compressed-bases-low) \H
-    (:k  compressed-bases-low) \K
-    (:d  compressed-bases-low) \D
-    (:b  compressed-bases-low) \B
-    (throw (IllegalArgumentException. (str "Bad type: " base)))))
+  `(let [base# ~base]
+     (or
+       (_compressed-base->char-low (ubyte (bit-and base# 0xf)))
+       (throw (IllegalArgumentException. (str "Bad type: " base#))))))
 
-(defn compressed-base->char-high
+(def ^:private _compressed-base->char-high
+  {(:eq compressed-bases-high) \=
+   (:a  compressed-bases-high) \A
+   (:c  compressed-bases-high) \C
+   (:g  compressed-bases-high) \G
+   (:t  compressed-bases-high) \T
+   (:n  compressed-bases-high) \N
+   (:m  compressed-bases-high) \M
+   (:r  compressed-bases-high) \R
+   (:s  compressed-bases-high) \S
+   (:v  compressed-bases-high) \V
+   (:w  compressed-bases-high) \W
+   (:y  compressed-bases-high) \Y
+   (:h  compressed-bases-high) \H
+   (:k  compressed-bases-high) \K
+   (:d  compressed-bases-high) \D
+   (:b  compressed-bases-high) \B})
+
+(definline compressed-base->char-high
   "Convert from BAM nybble representation of a base in high-order nybble to a char."
   [base]
-  (condp = (ubyte (bit-and base 0xf0))
-    (:eq compressed-bases-high) \=
-    (:a  compressed-bases-high) \A
-    (:c  compressed-bases-high) \C
-    (:g  compressed-bases-high) \G
-    (:t  compressed-bases-high) \T
-    (:n  compressed-bases-high) \N
-    (:m  compressed-bases-high) \M
-    (:r  compressed-bases-high) \R
-    (:s  compressed-bases-high) \S
-    (:v  compressed-bases-high) \V
-    (:w  compressed-bases-high) \W
-    (:y  compressed-bases-high) \Y
-    (:h  compressed-bases-high) \H
-    (:k  compressed-bases-high) \K
-    (:d  compressed-bases-high) \D
-    (:b  compressed-bases-high) \B
-    (throw (IllegalArgumentException. (str "Bad type: " base)))))
+  `(let [base# ~base]
+     (or
+       (_compressed-base->char-high (ubyte (bit-and base# 0xf0)))
+       (throw (IllegalArgumentException. (str "Bad type: " base#))))))
 
-(defn bytes->compressed-bases [read-bases]
-  (let [rlen (count read-bases)
-        bases (for [i (range 1 rlen) :when (odd? i)]
-                (byte (bit-or (char->compressed-base-high (char (nth read-bases (dec i))))
-                              (char->compressed-base-low (char (nth read-bases i))))))]
-   (if (odd? rlen)
-     (byte-array (conj (vec bases) (char->compressed-base-high (char (nth read-bases (dec rlen))))))
-     (byte-array bases))))
+(defn bytes->compressed-bases [^bytes read-bases]
+  (let [rlen (alength read-bases)
+        result-len (quot (inc rlen) 2)
+        result (byte-array result-len)]
+    (loop [i 0]
+      (if (<= result-len i)
+        result
+        (let [h-idx (* 2 i)
+              h (char->compressed-base-high (char (aget read-bases h-idx)))
+              l-idx (inc h-idx)
+              l (if (<= rlen l-idx)
+                  0
+                  (char->compressed-base-low (char (aget read-bases l-idx))))]
+          (aset-byte result i (byte (bit-or h l)))
+          (recur (inc i)))))))
 
 (defn compressed-bases->chars [length compressed-bases compressed-offset]
   (let [bases (apply concat
@@ -314,18 +342,17 @@
 
 ;;; fastq and phred
 
-(defmulti fastq->phred class)
+(definline fastq-char->phred-byte [ch]
+  `(let [ch# (int ~ch)]
+     (assert (<= 33 ch# 126))
+     (byte (- ch# 33))))
 
-(defmethod fastq->phred String
-  [^String fastq]
-  (let [length (count fastq)]
-    (byte-array (for [i (range length)]
-                  (fastq->phred (.charAt fastq i))))))
-
-(defmethod fastq->phred Character
-  [ch]
-  {:pre [(<= 33 (int ch) 126)]}
-  (byte (- (int ch) 33)))
+(defn fastq->phred [^String fastq]
+  (let [length (count fastq)
+        result (byte-array length)]
+    (dotimes [i length]
+      (aset-byte result i (fastq-char->phred-byte (.charAt fastq i))))
+    result))
 
 (defmulti phred->fastq class)
 

--- a/src/cljam/util/sam_util.clj
+++ b/src/cljam/util/sam_util.clj
@@ -220,13 +220,12 @@
                    [\d \D]    (:d  compressed-bases-low)
                    [\b \B]    (:b  compressed-bases-low)}))
 
-(definline char->compressed-base-low
+(defn char->compressed-base-low
   "Convert from a char to BAM nybble representation of a base in low-order nybble."
   [base]
-  `(let [base# ~base]
-     (or
-       (_char->compressed-base-low base#)
-       (throw (IllegalArgumentException. (str "Bad type: " base#))))))
+  (or
+   (_char->compressed-base-low base)
+   (throw (IllegalArgumentException. (str "Bad type: " base)))))
 
 (def ^:private _char->compressed-base-high
   (unfold-ksv-map {[\=]       (:eq compressed-bases-high)
@@ -246,13 +245,12 @@
                    [\d \D]    (:d  compressed-bases-high)
                    [\b \B]    (:b  compressed-bases-high)}))
 
-(definline char->compressed-base-high
+(defn char->compressed-base-high
   "Convert from a char to BAM nybble representation of a base in high-order nybble."
   [base]
-  `(let [base# ~base]
-     (or
-       (_char->compressed-base-high base#)
-       (throw (IllegalArgumentException. (str "Bad type: " base#))))))
+  (or
+   (_char->compressed-base-high base)
+   (throw (IllegalArgumentException. (str "Bad type: " base)))))
 
 (def ^:private _compressed-base->char-low
   {(:eq compressed-bases-low) \=
@@ -272,13 +270,12 @@
    (:d  compressed-bases-low) \D
    (:b  compressed-bases-low) \B})
 
-(definline compressed-base->char-low
+(defn compressed-base->char-low
   "Convert from BAM nybble representation of a base in low-order nybble to a char."
   [base]
-  `(let [base# ~base]
-     (or
-       (_compressed-base->char-low (ubyte (bit-and base# 0xf)))
-       (throw (IllegalArgumentException. (str "Bad type: " base#))))))
+  (or
+   (_compressed-base->char-low (ubyte (bit-and base 0xf)))
+   (throw (IllegalArgumentException. (str "Bad type: " base)))))
 
 (def ^:private _compressed-base->char-high
   {(:eq compressed-bases-high) \=
@@ -298,13 +295,12 @@
    (:d  compressed-bases-high) \D
    (:b  compressed-bases-high) \B})
 
-(definline compressed-base->char-high
+(defn compressed-base->char-high
   "Convert from BAM nybble representation of a base in high-order nybble to a char."
   [base]
-  `(let [base# ~base]
-     (or
-       (_compressed-base->char-high (ubyte (bit-and base# 0xf0)))
-       (throw (IllegalArgumentException. (str "Bad type: " base#))))))
+  (or
+   (_compressed-base->char-high (ubyte (bit-and base 0xf0)))
+   (throw (IllegalArgumentException. (str "Bad type: " base)))))
 
 (defn bytes->compressed-bases [^bytes read-bases]
   (let [rlen (alength read-bases)
@@ -342,10 +338,10 @@
 
 ;;; fastq and phred
 
-(definline fastq-char->phred-byte [ch]
-  `(let [ch# (int ~ch)]
-     (assert (<= 33 ch# 126))
-     (byte (- ch# 33))))
+(defn fastq-char->phred-byte [ch]
+  [ch]
+  {:pre [(<= 33 (int ch) 126)]}
+  (byte (- (int ch) 33)))
 
 (defn fastq->phred [^String fastq]
   (let [length (count fastq)


### PR DESCRIPTION
I have improved a performance of SAM/BAM convert function.

- Add encoder of BAM alignment which support parallel processing (See `cljam.bam.encoder`)
- Add SAM/BAM convert functions (See 'cljam.convert)
- Tweak a performance of some functions in `cljam.util.sam-util`
    - compressing/decompressing of base codes
    - phred score calculation
- Fix some minor issues