### PR TITLE
Move main and aot settings to dev and uberjar profiles

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,7 +88,7 @@ cljam provides a command-line tool to use the features easily.
 Run `lein-bin` plugin and it creates standalone console executable into `target` directory.
 
 ```console
-$ lein with-profile 1.8 bin
+$ lein with-profile +1.8 bin
 Created /path/to/cljam/target/cljam-0.1.5.jar
 Created /path/to/cljam/target/cljam-0.1.5-standalone.jar
 Creating standalone executable: /path/to/cljam/target/cljam

--- a/project.clj
+++ b/project.clj
@@ -19,13 +19,14 @@
                    :plugins [[lein-bin "0.3.5"]
                              [lein-codox "0.9.5"]
                              [lein-marginalia "0.9.0"]]
+                   :main cljam.main
+                   :aot [cljam.main]
                    :global-vars {*warn-on-reflection* true}}
              :1.7 {:dependencies [[org.clojure/clojure "1.7.0"]]}
              :1.8 {:dependencies [[org.clojure/clojure "1.8.0"]]}
-             :uberjar {:aot :all}}
-  :main cljam.main
+             :uberjar {:main cljam.main
+                       :aot :all}}
   :aliases {"docs" ["do" "codox" ["marg" "-d" "target/literate" "-m"]]}
-  :aot [cljam.main]
   :bin {:name "cljam"}
   :codox {:namespaces [#"^cljam\.(?!cli)(?!lsb)(?!main)(?!util)[^\.]+$"]
           :output-path "target/docs"


### PR DESCRIPTION
This PR avoids compiled dependencies are included in cljam jar.

Current project settings will pack classes of dependencies in the jar:

```console
$ jar -tf cljam-0.1.5.jar
META-INF/MANIFEST.MF
META-INF/maven/cljam/cljam/pom.xml
META-INF/leiningen/cljam/cljam/project.clj
project.clj
META-INF/leiningen/cljam/cljam/README.md
META-INF/leiningen/cljam/cljam/LICENSE
clj_sub_command/
clj_sub_command/core$apply_options.class
clj_sub_command/core$banner_for.class
clj_sub_command/core$banner_for_commands$fn__100.class
clj_sub_command/core$banner_for_commands$fn__98.class
...
```

This will inclease jar size and cause bugs of multiple dependency versions. `main` and `aot` settings are only required in development and binary generation environments.