### PR TITLE
SAM FLAGs

### DIFF
--- a/src/cljam/util/sam_util.clj
+++ b/src/cljam/util/sam_util.clj
@@ -393,3 +393,38 @@
   "Returns the first reference which has the specified name."
   [refs name]
   (some #(if (= (:name %) name) %) refs))
+
+(def ^:const flags
+  {:multiple         1 ; template having multiple segments in sequencing
+   :properly-aligned 2 ; each segment properly aligned according to the aligner
+   :unmapped         4 ; segment unmapped
+   :next-unmapped    8 ; next segment in the template unmapped
+   :reversed        16 ; SEQ begin reverse complemented
+   :next-reversed   32 ; SEQ of the next segment in the template being reverse complemented
+   :first           64 ; the first segment in the template
+   :last           128 ; the last segment in the template
+   :secondary      256 ; secondary alignment
+   :filtered-out   512 ; not passing filters, such as platform/vendor quality controls
+   :duplicated    1024 ; PCR or optical duplicate
+   :supplementary 2048 ; supplementary alignment
+   })
+
+(def ^:const flag-keywords
+  (vec (map vector (map key (sort-by val flags)) (range))))
+
+(defn decode-flags
+  "Returns a set of keywords for a given flag integer."
+  [f]
+  (into #{} (for [[k i] flag-keywords :when (bit-test f i)] k)))
+
+(defn encode-flags
+  "Returns a flag integer encoding set of keywords."
+  [s]
+  (reduce + (map flags s)))
+
+(defn primary?
+  "Returns true when an alignment with given flag is a primary line."
+  [f]
+  (cond
+    (integer? f) (zero? (bit-and f 0x900))
+    (set? f) (nil? (or (:supplementary f) (:secondary f)))))

--- a/test/cljam/util/t_sam_util.clj
+++ b/test/cljam/util/t_sam_util.clj
@@ -130,3 +130,31 @@
  "ref"        {:name "ref", :len 45}
  "ref2"       {:name "ref2", :len 40}
  "notfound"   nil?)
+
+(tabular
+ (facts "about flags"
+   (sam-util/decode-flags ?flag) => ?set
+   (sam-util/encode-flags ?set) => ?flag
+   (sam-util/primary? ?flag) => ?primary
+   (sam-util/primary? ?set) => ?primary)
+ ?flag ?primary  ?set
+ 0     truthy    #{}
+ 1     truthy    #{:multiple}
+ 2     truthy    #{:properly-aligned}
+ 3     truthy    #{:multiple :properly-aligned}
+ 4     truthy    #{:unmapped}
+ 16    truthy    #{:reversed}
+ 83    truthy    #{:multiple :properly-aligned :reversed :first}
+ 163   truthy    #{:multiple :properly-aligned :next-reversed :last}
+ 99    truthy    #{:multiple :properly-aligned :next-reversed :first}
+ 147   truthy    #{:multiple :properly-aligned :reversed :last}
+ 121   truthy    #{:multiple :next-unmapped :reversed :next-reversed :first}
+ 181   truthy    #{:multiple :unmapped :reversed :next-reversed :last}
+ 77    truthy    #{:multiple :unmapped :next-unmapped :first}
+ 141   truthy    #{:multiple :unmapped :next-unmapped :last}
+ 256   falsey    #{:secondary}
+ 257   falsey    #{:multiple :secondary}
+ 2048  falsey    #{:supplementary}
+ 2049  falsey    #{:multiple :supplementary}
+ 2304  falsey    #{:secondary :supplementary}
+ 0x900 falsey    #{:secondary :supplementary})


### PR DESCRIPTION
Add util functions for handling FLAG field of SAM format.

Original FLAG is an integer interpreted as a bitset. 
New functions in `cljam.util.sam-util` convert bitset <=> set of keywords as below.

```clojure
(cljam.util.sam-util/encode-flags 83) => #{:multiple :properly-aligned :reversed :first}
(cljam.util.sam-util/decode-flags #{:multiple :properly-aligned :reversed :first}) => 83
```