### PR TITLE
Read unplaced reads in BAM

### DIFF
--- a/src/cljam/bam/decoder.clj
+++ b/src/cljam/bam/decoder.clj
@@ -74,7 +74,7 @@
      l-seq))
 
 (defn decode-qual [^bytes b]
-  (if (Arrays/equals b (byte-array (count b) (ubyte 0xff)))
+  (if (Arrays/equals b (byte-array (alength b) (ubyte 0xff)))
     "*"
     (phred->fastq b)))
 

--- a/src/cljam/bam_index/core.clj
+++ b/src/cljam/bam_index/core.clj
@@ -61,6 +61,18 @@
     (->> (chunk/optimize-chunks chunks min-offset)
          (map vals))))
 
+(defn get-unplaced-spans
+  [^BAMIndex bai]
+  (if-let [begin (some->>
+                  (for [[ref-id bins] (.bidx bai)
+                        [bin chunks] bins
+                        {:keys [beg end]} chunks]
+                    end)
+                  seq
+                  (reduce max))]
+    [[begin Long/MAX_VALUE]]
+    []))
+
 ;; ## Writing
 
 (defn ^BAIWriter writer

--- a/src/cljam/lsb.clj
+++ b/src/cljam/lsb.clj
@@ -142,7 +142,7 @@
 
 (defn write-bytes
   [^DataOutputStream w ^bytes b]
-  (.write w b 0 (count b))
+  (.write w b 0 (alength b))
   nil)
 
 (defn write-ubyte
@@ -190,5 +190,5 @@
 (defn write-string
   [^DataOutputStream w s]
   (let [data-bytes (string->bytes s)]
-   (.write w data-bytes 0 (count data-bytes))
+   (.write w data-bytes 0 (alength data-bytes))
    nil))

--- a/src/cljam/util.clj
+++ b/src/cljam/util.clj
@@ -35,11 +35,11 @@
 
 (defn ^"[B" string->bytes [^String s]
   (let [buf (byte-array (count s))]
-    (.getBytes s 0 (count buf) buf 0)
+    (.getBytes s 0 (alength buf) buf 0)
     buf))
 
 (defn ^String bytes->string [^bytes b]
-  (String. b 0 (count b)))
+  (String. b 0 (alength b)))
 
 (defn from-hex-digit [^Character c]
   (let [d (Character/digit c 16)]


### PR DESCRIPTION
This PR extends `cljam.io/read-alignments` for BAM to support random reading of unplaced reads in BAM file.

Currently, we can't directly access to unplaced reads.
But sequential read is slow because unplaced reads are stored in the last part of BAM file.
I modified the function to read from the end of the last chunk in the last bin if "*" is specified for chr.

This enables a use case like following.
```clojure
(with-open [r (cljam.bam/reader "path/to/bam")]
  (cljam.io/read-alignments r {:chr "*" :depth :deep}))
=> ({:rname "*" :pos 0 ...} , ...)
```

