### PR TITLE
Enable decompressUntilEOF of CompressorStreamFactory

### DIFF
--- a/src/cljam/util.clj
+++ b/src/cljam/util.clj
@@ -132,7 +132,7 @@
   [f]
   (let [is (io/input-stream f)]
     (try
-      (-> (CompressorStreamFactory.)
+      (-> (CompressorStreamFactory. true)
           (.createCompressorInputStream is))
       (catch CompressorException _
         is))))


### PR DESCRIPTION
Current compressor reader cannot read some compressed files until the end.

```clojure
(with-open [rdr (vcf/reader "/tmp/ALL.chrY.phase3_integrated_v2a.20130502.genotypes.vcf.gz")]
  (count (vcf/read-variants rdr)))
;; => 19
```

This PR fixes this problem by setting `decompressUntilEOF` option of `CompressorStreamFactory` to `true`.

```clojure
(with-open [rdr (vcf/reader "/tmp/ALL.chrY.phase3_integrated_v2a.20130502.genotypes.vcf.gz")]
  (count (vcf/read-variants rdr)))
;; => 62042
```

The above `ALL.chrY.phase3_integrated_v2a.20130502.genotypes.vcf.gz` is available on ftp://ftp.1000genomes.ebi.ac.uk/vol1/ftp/release/20130502/