### PR TITLE
Improve performance of FASTA indexing

### DIFF
--- a/src/cljam/fasta_index/core.clj
+++ b/src/cljam/fasta_index/core.clj
@@ -4,7 +4,8 @@
             [clojure.tools.logging :as logging]
             [me.raynes.fs :as fs]
             [cljam.fasta-index.writer :as writer]
-            [cljam.fasta-index.reader :as reader]))
+            [cljam.fasta-index.reader :as reader]
+            [cljam.util :as util]))
 
 ;;;; Writing
 
@@ -16,10 +17,11 @@
 
 (defn create-index
   "Creates a FASTA index file from the sequences."
-  [rdr f]
-  (with-open [w ^cljam.fasta_index.writer.FAIWriter (writer f)]
+  [in-fa out-fai]
+  (with-open [r (io/reader (util/compressor-input-stream in-fa))
+              w ^cljam.fasta_index.writer.FAIWriter (writer out-fai)]
     (try
-      (writer/write-index! rdr w)
+      (writer/write-index! r w)
       (catch Exception e (do
                            (fs/delete (.f w))
                            (logging/error "Failed to create FASTA index")

--- a/src/cljam/fasta_index/writer.clj
+++ b/src/cljam/fasta_index/writer.clj
@@ -1,9 +1,8 @@
 (ns cljam.fasta-index.writer
   "Writing features for a FASTA index file."
   (:require [clojure.string :as cstr]
-            [cljam.util :refer [graph?]]
             [cljam.util.fasta :refer [header-line? parse-header-line]])
-  (:import [java.io BufferedWriter RandomAccessFile]))
+  (:import [java.io BufferedWriter]))
 
 ;;;; FAIWriter
 
@@ -15,11 +14,9 @@
 ;;;; Writing
 
 (defn make-indices
-  [rdr]
-  (let [r ^RandomAccessFile (.reader rdr)
-        indices (atom [])
+  [^java.io.BufferedReader r]
+  (let [indices (atom [])
         current-index (atom nil)]
-    (.seek r 0)
     (loop [l (.readLine r)
            pos 0]
       (when-not (nil? l)

--- a/src/cljam/fasta_indexer.clj
+++ b/src/cljam/fasta_indexer.clj
@@ -1,11 +1,9 @@
 (ns cljam.fasta-indexer
   "Alpha - subject to change.
   Indexer of FASTA."
-  (:require [cljam.fasta :as fasta]
-            [cljam.fasta-index.core :as fai-core]))
+  (:require [cljam.fasta-index.core :as fai-core]))
 
 (defn create-index
   "Create a FASTA index file from the FASTA file."
   [in-fa out-fai]
-  (with-open [r (fasta/reader in-fa)]
-    (fai-core/create-index r out-fai)))
+  (fai-core/create-index in-fa out-fai))


### PR DESCRIPTION
Current FASTA indexer is critically slow because it uses `java.io.RandomAccessFile` to read a source FASTA. This commit improves the performance by using `java.io.BufferedReader`.

The following showd results of indexing 101MB FASTA.

```clojure
;; before:
(time (fai/create-index "/tmp/refMrna.fa" "/tmp/refMrna.fa.fai"))
"Elapsed time: 73621.207302 msecs"

;; after:
(time (fai/create-index "/tmp/refMrna.fa" "/tmp/refMrna.fa.fai"))
"Elapsed time: 2986.332916 msecs"

```