### PR TITLE
Add functions for deduplicating paired-end BAM.

### DIFF
--- a/src/cljam/dedupe.clj
+++ b/src/cljam/dedupe.clj
@@ -1,0 +1,70 @@
+(ns cljam.dedupe
+  (:refer-clojure :exclude [dedupe])
+  (:require [com.climate.claypoole :as cp]
+            [cljam.io :as io]
+            [cljam.bam :as bam]
+            [cljam.util.sam-util :as sam-util]))
+
+(defn- refs->regions [refs]
+  (for [{:keys [name len]} refs]
+    {:chr name :start 1 :end len}))
+
+(defn- sum-quals [a]
+  (when-let [q ^String (:qual a)]
+    (when-not (and (= (.length q) 1) (= \* (.charAt q 0)))
+      (reduce (fn [r x] (+ r (- (int x) 33))) 0 q))))
+
+(defn- paired? [{:keys [flag]}]
+  (pos? (bit-and flag (sam-util/flags :multiple))))
+
+(defn- mapped? [{:keys [flag]}]
+  (zero? (bit-and flag (bit-or (sam-util/flags :unmapped) (sam-util/flags :next-unmapped)))))
+
+(defn dedupe-xform
+  "Returns a transducer which removes PCR duplications."
+  [& {:keys [remove-dups] :or {remove-dups true}}]
+  (let [removed (atom #{})
+        cp (juxt sum-quals :mapq)]
+    (comp
+     (partition-by (juxt :rname :pos))
+     (mapcat
+      (fn [alns]
+        (loop [[{:keys [pos tlen qname] :as x} :as xs] alns heads {} tails [] dups []]
+          (if x
+            (cond
+              (not (and (paired? x) (mapped? x) (= (:rnext x) "="))) (recur (next xs) heads (conj tails x) dups)
+              (pos? tlen) (let [k [pos tlen]]
+                            (if-let [v (get heads k)]
+                              (let [[good bad] (if (pos? (compare (cp v) (cp x))) [v x] [x v])]
+                                (swap! removed conj (:qname bad))
+                                (recur (next xs) (assoc heads k good) tails (conj dups bad)))
+                              (recur (next xs) (assoc heads k x) tails dups)))
+              (@removed qname) (do (swap! removed disj qname) (recur (next xs) heads tails (conj dups x)))
+              :else (recur (next xs) heads (conj tails x) dups))
+            (concat
+             (vals heads)
+             tails
+             (when-not remove-dups
+               (map (fn [a] (update a :flag #(bit-or % 1024))) dups))))))))))
+
+(defn dedupe
+  "Remove PCR duplications from paired-end alignments."
+  [in out & {:keys [remove-dups] :or {remove-dups true}}]
+  (cp/with-shutdown! [pool (cp/ncpus)]
+    (let [[header refs] (with-open [r (bam/reader in)] [(io/read-header r) (io/read-refs r)])]
+      (with-open [w (bam/writer out)]
+        (io/write-header w header)
+        (io/write-refs w header)
+        (io/write-alignments
+         w
+         (->> refs
+              refs->regions
+              (cp/pmap
+               pool
+               (fn [{:keys [start end] :as region}]
+                 (with-open [r (bam/reader in)]
+                   (->> (io/read-alignments r region)
+                        (sequence (dedupe-xform :remove-dups remove-dups))
+                        doall))))
+              (sequence cat))
+         header)))))

--- a/test/cljam/t_dedupe.clj
+++ b/test/cljam/t_dedupe.clj
@@ -1,0 +1,58 @@
+(ns cljam.t-dedupe
+  (:use [midje.sweet])
+  (:require [cljam.io :as cio]
+            [cljam.bam :as bam]
+            [cljam.dedupe :as dedupe]))
+
+
+(fact
+ "Simple PE dedupe"
+ (into #{}
+  (dedupe/dedupe-xform)
+  [{:qname "r1" :flag 99 :rname "ref" :pos 1 :mapq 60 :rnext "=" :pnext 10 :tlen 5 :qual "IIIII"}
+   {:qname "r2" :flag 99 :rname "ref" :pos 1 :mapq 60 :rnext "=" :pnext 10 :tlen 5 :qual "IIIIH"}
+   {:qname "r1" :flag 147 :rname "ref" :pos 10 :mapq 60 :rnext "=" :pnext 1 :tlen -5 :qual "IIIII"}])
+ => #{{:qname "r1" :flag 99 :rname "ref" :pos 1 :mapq 60 :rnext "=" :pnext 10 :tlen 5 :qual "IIIII"}
+      {:qname "r1" :flag 147 :rname "ref" :pos 10 :mapq 60 :rnext "=" :pnext 1 :tlen -5 :qual "IIIII"}}
+
+ (into #{}
+  (dedupe/dedupe-xform)
+  [{:qname "r1" :flag 99 :rname "ref" :pos 1 :mapq 60 :rnext "=" :pnext 10 :tlen 5 :qual "IIIIH"}
+   {:qname "r2" :flag 99 :rname "ref" :pos 1 :mapq 60 :rnext "=" :pnext 10 :tlen 5 :qual "IIIII"}
+   {:qname "r1" :flag 147 :rname "ref" :pos 10 :mapq 60 :rnext "=" :pnext 1 :tlen -5 :qual "IIIII"}])
+ => #{{:qname "r2" :flag 99 :rname "ref" :pos 1 :mapq 60 :rnext "=" :pnext 10 :tlen 5 :qual "IIIII"}}
+
+ (into #{}
+  (dedupe/dedupe-xform)
+  [{:qname "r1" :flag 99 :rname "ref" :pos 1 :mapq 60 :rnext "=" :pnext 10 :tlen 5 :qual "IIIII"}
+   {:qname "r2" :flag 99 :rname "ref" :pos 1 :mapq 60 :rnext "=" :pnext 11 :tlen 6 :qual "IIIIH"}
+   {:qname "r1" :flag 147 :rname "ref" :pos 10 :mapq 60 :rnext "=" :pnext 1 :tlen -5 :qual "IIIII"}
+   {:qname "r2" :flag 147 :rname "ref" :pos 11 :mapq 60 :rnext "=" :pnext 1 :tlen -6 :qual "IIIII"}])
+  => #{{:qname "r1" :flag 99 :rname "ref" :pos 1 :mapq 60 :rnext "=" :pnext 10 :tlen 5 :qual "IIIII"}
+       {:qname "r2" :flag 99 :rname "ref" :pos 1 :mapq 60 :rnext "=" :pnext 11 :tlen 6 :qual "IIIIH"}
+       {:qname "r1" :flag 147 :rname "ref" :pos 10 :mapq 60 :rnext "=" :pnext 1 :tlen -5 :qual "IIIII"}
+       {:qname "r2" :flag 147 :rname "ref" :pos 11 :mapq 60 :rnext "=" :pnext 1 :tlen -6 :qual "IIIII"}}
+
+  (into #{}
+   (dedupe/dedupe-xform)
+   [{:qname "r1" :flag 99 :rname "ref" :pos 1 :mapq 60 :rnext "=" :pnext 10 :tlen 5 :qual "IIIII"}
+    {:qname "r2" :flag 99 :rname "ref" :pos 1 :mapq 60 :rnext "=" :pnext 10 :tlen 5 :qual "IIIIH"}
+    {:qname "r4" :flag 4 :rname "ref" :pos 1 :mapq 0 :rnext "*" :pnext 0 :tlen 0 :qual "IIIII"}
+    {:qname "r1" :flag 147 :rname "ref" :pos 10 :mapq 60 :rnext "=" :pnext 1 :tlen -5 :qual "IIIII"}
+    {:qname "r2" :flag 147 :rname "ref" :pos 10 :mapq 60 :rnext "=" :pnext 1 :tlen -5 :qual "IIIII"}
+    {:qname "r3" :flag 99 :rname "ref" :pos 10 :mapq 60 :rnext "ref2" :pnext 1 :tlen 0 :qual "IIIII"}
+    {:qname "r3" :flag 147 :rname "ref2" :pos 1 :mapq 60 :rnext "ref" :pnext 10 :tlen 0 :qual "IIIII"}])
+  => #{{:qname "r4" :flag 4 :rname "ref" :pos 1 :mapq 0 :rnext "*" :pnext 0 :tlen 0 :qual "IIIII"}
+       {:qname "r1" :flag 99 :rname "ref" :pos 1 :mapq 60 :rnext "=" :pnext 10 :tlen 5 :qual "IIIII"}
+       {:qname "r3" :flag 99 :rname "ref" :pos 10 :mapq 60 :rnext "ref2" :pnext 1 :tlen 0 :qual "IIIII"}
+       {:qname "r1" :flag 147 :rname "ref" :pos 10 :mapq 60 :rnext "=" :pnext 1 :tlen -5 :qual "IIIII"}
+       {:qname "r3" :flag 147 :rname "ref2" :pos 1 :mapq 60 :rnext "ref" :pnext 10 :tlen 0 :qual "IIIII"}}
+
+  (into #{}
+   (dedupe/dedupe-xform :remove-dups false)
+   [{:qname "r1" :flag 99 :rname "ref" :pos 1 :mapq 60 :rnext "=" :pnext 10 :tlen 5 :qual "IIIII"}
+    {:qname "r2" :flag 99 :rname "ref" :pos 1 :mapq 60 :rnext "=" :pnext 10 :tlen 5 :qual "IIIIH"}
+    {:qname "r1" :flag 147 :rname "ref" :pos 10 :mapq 60 :rnext "=" :pnext 1 :tlen -5 :qual "IIIII"}])
+  => #{{:qname "r1" :flag 99 :rname "ref" :pos 1 :mapq 60 :rnext "=" :pnext 10 :tlen 5 :qual "IIIII"}
+       {:qname "r2" :flag (+ 99 1024) :rname "ref" :pos 1 :mapq 60 :rnext "=" :pnext 10 :tlen 5 :qual "IIIIH"}
+       {:qname "r1" :flag 147 :rname "ref" :pos 10 :mapq 60 :rnext "=" :pnext 1 :tlen -5 :qual "IIIII"}})


### PR DESCRIPTION
This PR adds a function `cljam.dedup/dedup` and a transducer `cljam.dedup/dedup-xform` for removing PCR duplications in paired-end BAM files.

```clojure
(sequence
  (dedup/dedup-xform)
  [{:qname "r1" :flag 99 :rname "ref" :pos 1 :mapq 60 :rnext "=" :pnext 10 :tlen 5 :qual "IIIII"}
   {:qname "r2" :flag 99 :rname "ref" :pos 1 :mapq 60 :rnext "=" :pnext 10 :tlen 5 :qual "IIIIH"}
   {:qname "r1" :flag 147 :rname "ref" :pos 10 :mapq 60 :rnext "=" :pnext 1 :tlen -5 :qual "IIIII"}])
 => [{:qname "r1" :flag 99 :rname "ref" :pos 1 :mapq 60 :rnext "=" :pnext 10 :tlen 5 :qual "IIIII"}
     {:qname "r1" :flag 147 :rname "ref" :pos 10 :mapq 60 :rnext "=" :pnext 1 :tlen -5 :qual "IIIII"}]
```

Its algorithm is similar to `rmdup` command of samtools.
As mentioned in #2, `MarkDuplicates` command of Picard implements more complex processes such as 2-pass filtering and file-backed indexing to remove not only PCR duplications but also optical duplications.