### PR TITLE
Fix cider-refresh error

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -19,8 +19,7 @@
                    :plugins [[lein-bin "0.3.5"]
                              [lein-codox "0.10.3"]
                              [lein-marginalia "0.9.0"]]
-                   :main cljam.main
-                   :aot [cljam.main]
+                   :main ^:skip-aot cljam.main
                    :global-vars {*warn-on-reflection* true}}
              :1.7 {:dependencies [[org.clojure/clojure "1.7.0"]]}
              :1.8 {:dependencies [[org.clojure/clojure "1.8.0"]]}


### PR DESCRIPTION
`cider-refresh` fails because of AOT compilation. It's a limitation of tools.namespace (cf. [tools.namespace#warnings-and-potential-problems](https://github.com/clojure/tools.namespace#warnings-and-potential-problems)).

Disabling AOT compilation in dev profile fixes `cider-refresh` error.

This change resolves the error, but refresh takes too long time. `cider-refresh` reloads not only source but also test. midje automatically checks facts just after a namespace is loaded. `:slow :heavy` facts are also checked at this time unexpectedly. This seems to be a bug of midje. I've opened a issue https://github.com/marick/Midje/issues/380. Please ignore it in this PR.