### PR TITLE
Add :ignore-index option to cljam.fasta/reader

### DIFF
--- a/src/cljam/dict.clj
+++ b/src/cljam/dict.clj
@@ -9,7 +9,7 @@
   "Creates a FASTA sequence dictionary file (.dict) from the specified FASTA
   file. The unfinished file will be deleted when failing."
   [fasta out-dict]
-  (with-open [r (fasta/reader fasta)]
+  (with-open [r (fasta/reader fasta :ignore-index true)]
     (dict-core/create-dict out-dict
                            (fasta/read-headers r)
                            (fasta/read-sequences r)

--- a/src/cljam/fasta.clj
+++ b/src/cljam/fasta.clj
@@ -6,9 +6,12 @@
   (:import cljam.fasta.reader.FASTAReader))
 
 (defn ^FASTAReader reader
-  "Returns FASTA file reader of f."
-  [f]
-  (fa-core/reader f))
+  "Returns an open cljam.fasta.reader.FASTAReader of f with options.
+  The options:
+    :ignore-index - returns reader without index, default false.
+  Should be used inside with-open to ensure the Reader is properly closed."
+  [f & options]
+  (fa-core/reader f options))
 
 (defn read
   [rdr]

--- a/src/cljam/fasta/core.clj
+++ b/src/cljam/fasta/core.clj
@@ -11,11 +11,15 @@
 ;; -------
 
 (defn ^FASTAReader reader
-  [^String f]
+  [^String f {:keys [ignore-index]
+              :or {ignore-index false}}]
   (let [f (.getAbsolutePath (io/file f))
         index-f (str f ".fai")
-        index (when (.exists (io/file index-f))
-                (fasta-index/reader index-f))]
+        index (if-not ignore-index
+                (if (.exists (io/file index-f))
+                  (fasta-index/reader index-f)
+                  (throw (java.io.FileNotFoundException.
+                          (str index-f " (No such FASTA index)")))))]
     (FASTAReader. (RandomAccessFile. f "r")
                   f
                   index)))

--- a/src/cljam/fasta/reader.clj
+++ b/src/cljam/fasta/reader.clj
@@ -95,20 +95,22 @@
 
 (defn read-whole-sequence
   [^FASTAReader rdr name]
-  (when-let [fai (.index rdr)]
+  (if-let [fai (.index rdr)]
     (let [header (fasta-index/get-header fai name)
           [offset-start offset-end] (fasta-index/get-span fai name 0 (:len header))]
-      (read-sequence-with-offset rdr offset-start offset-end))))
+      (read-sequence-with-offset rdr offset-start offset-end))
+    (throw (Exception. "FASTA index not found"))))
 
 (defn read-sequence
   [^FASTAReader rdr name start end]
-  (when-let [fai (.index rdr)]
+  (if-let [fai (.index rdr)]
     (let [header (fasta-index/get-header fai name)]
       (when-let [[offset-start offset-end] (fasta-index/get-span fai name (dec start) end)]
         (->> (concat (repeat (max 0 (- 1 start)) \N)
                        (read-sequence-with-offset rdr offset-start offset-end)
                        (repeat (max 0 (- end (:len header))) \N))
-             (apply str))))))
+             (apply str))))
+    (throw (Exception. "FASTA index not found"))))
 
 (defn read
   "Reads FASTA sequence data, returning its information as a lazy sequence."


### PR DESCRIPTION
`cljam.fasta/reader` comes to receive `:ignore-index` option by this commit. (default: `false`)

Current `cljam.fasta/reader` sets `.index` `nil` when an index file is not found. Some functions using index, such as `cljam.fasta/read-sequence`, always returns `nil` if the index is `nil`. This behavior may cause bugs. New `cljam.fasta/reader` disallows nil index unless `:ignore-index true` is passed.