### PR TITLE
Add to support lein cloverage

### DIFF
--- a/README.md
+++ b/README.md
@@ -138,6 +138,14 @@ To run heavy tests which uses remote large-size files,
 $ lein midje :filter heavy
 ```
 
+To get coverage, (but it is a half-day job)
+
+```console
+$ lein cloverage
+```
+
+And open `target/coverage/index.html`.
+
 ### Generating document
 
 cljam uses [Codox](https://github.com/weavejester/codox) for API reference and

--- a/project.clj
+++ b/project.clj
@@ -18,7 +18,8 @@
                                   [cavia "0.3.1"]]
                    :plugins [[lein-bin "0.3.5"]
                              [lein-codox "0.10.3"]
-                             [lein-marginalia "0.9.0"]]
+                             [lein-marginalia "0.9.0" :exclusions [org.clojure/clojure]]
+                             [lein-cloverage "1.0.9" :exclusions [org.clojure/clojure]]]
                    :main ^:skip-aot cljam.main
                    :global-vars {*warn-on-reflection* true}}
              :1.7 {:dependencies [[org.clojure/clojure "1.7.0"]]}

--- a/src/cljam/bam.clj
+++ b/src/cljam/bam.clj
@@ -1,6 +1,8 @@
 (ns cljam.bam
   "Read/Write a BAM format file."
-  (:require [cljam.bam.core :as bam-core])
+  (:require [cljam.bam.core :as bam-core]
+            [cljam.bam.reader]
+            [cljam.bam.writer])
   (:import cljam.bam.reader.BAMReader
            cljam.bam.writer.BAMWriter))
 

--- a/src/cljam/bam/core.clj
+++ b/src/cljam/bam/core.clj
@@ -36,51 +36,9 @@
       (BAMReader. (.getAbsolutePath (file f))
                   header refs rdr data-rdr index-delay))))
 
-(extend-type BAMReader
-  cljam.io/ISAMReader
-  (reader-path [this]
-    (.f this))
-  (read-header [this]
-    (.header this))
-  (read-refs [this]
-    (.refs this))
-  (read-alignments
-    ([this]
-       (reader/read-alignments-sequentially* this :deep))
-    ([this {:keys [chr start end depth]
-            :or {chr nil
-                 start -1 end -1
-                 depth :deep}}]
-       (if (nil? chr)
-         (reader/read-alignments-sequentially* this depth)
-         (reader/read-alignments* this chr start end depth))))
-  (read-blocks
-    ([this]
-       (reader/read-blocks-sequentially* this :normal))
-    ([this {:keys [chr start end mode]
-            :or {chr nil
-                 start -1 end -1
-                 mode :normal}}]
-     (if (nil? chr)
-       (reader/read-blocks-sequentially* this mode)
-       (reader/read-blocks* this chr start end)))))
-
 ;; Writing
 ;; -------
 
 (defn ^BAMWriter writer [f]
   (BAMWriter. (.getAbsolutePath (file f))
               (DataOutputStream. (BGZFOutputStream. (file f)))))
-
-(extend-type BAMWriter
-  cljam.io/ISAMWriter
-  (writer-path [this]
-    (.f this))
-  (write-header [this header]
-    (writer/write-header* this header))
-  (write-refs [this header]
-    (writer/write-refs* this header))
-  (write-alignments [this alignments header]
-    (writer/write-alignments* this alignments header))
-  (write-blocks [this blocks]
-    (writer/write-blocks* this blocks)))

--- a/src/cljam/bam/writer.clj
+++ b/src/cljam/bam/writer.clj
@@ -1,5 +1,6 @@
 (ns cljam.bam.writer
   (:require [clojure.string :refer [split]]
+            [cljam.io]
             (cljam [cigar :as cgr]
                    [lsb :as lsb]
                    [util :refer [string->bytes ubyte]])
@@ -18,6 +19,21 @@
   Closeable
   (close [this]
     (.close ^Closeable (.writer this))))
+
+(declare write-header* write-refs* write-alignments* write-blocks*)
+
+(extend-type BAMWriter
+  cljam.io/ISAMWriter
+  (writer-path [this]
+    (.f this))
+  (write-header [this header]
+    (write-header* this header))
+  (write-refs [this header]
+    (write-refs* this header))
+  (write-alignments [this alignments header]
+    (write-alignments* this alignments header))
+  (write-blocks [this blocks]
+    (write-blocks* this blocks)))
 
 ;;
 ;; write

--- a/src/cljam/core.clj
+++ b/src/cljam/core.clj
@@ -2,12 +2,7 @@
   "Core features of cljam."
   (:require [cljam.sam :as sam]
             [cljam.bam :as bam]
-            [cljam.fasta :as fasta])
-  (:import cljam.sam.reader.SAMReader
-           cljam.sam.writer.SAMWriter
-           cljam.bam.reader.BAMReader
-           cljam.bam.writer.BAMWriter
-           cljam.fasta.reader.FASTAReader))
+            [cljam.fasta :as fasta]))
 
 (defn reader
   "Selects suitable reader from f's extension, returning the reader. This
@@ -30,20 +25,20 @@
 
 (defn sam-reader?
   [rdr]
-  (= (type rdr) cljam.sam.reader.SAMReader))
+  (= (str (type rdr)) "class cljam.sam.reader.SAMReader"))
 
 (defn sam-writer?
   [wtr]
-  (= (type wtr) cljam.sam.writer.SAMWriter))
+  (= (str (type wtr)) "class cljam.sam.writer.SAMWriter"))
 
 (defn bam-reader?
   [rdr]
-  (= (type rdr) cljam.bam.reader.BAMReader))
+  (= (str (type rdr)) "class cljam.bam.reader.BAMReader"))
 
 (defn bam-writer?
   [wtr]
-  (= (type wtr) cljam.bam.writer.BAMWriter))
+  (= (str (type wtr)) "class cljam.bam.writer.BAMWriter"))
 
 (defn fasta-reader?
   [rdr]
-  (= (type rdr) cljam.fasta.reader.FASTAReader))
+  (= (str (type rdr)) "class cljam.fasta.reader.FASTAReader"))

--- a/src/cljam/fasta.clj
+++ b/src/cljam/fasta.clj
@@ -2,7 +2,8 @@
   "Alpha - subject to change.
   Reader of a FASTA format file."
   (:refer-clojure :exclude [read])
-  (:require [cljam.fasta.core :as fa-core])
+  (:require [cljam.fasta.core :as fa-core]
+            [cljam.fasta.reader])
   (:import cljam.fasta.reader.FASTAReader))
 
 (defn ^FASTAReader reader

--- a/src/cljam/pileup/pileup.clj
+++ b/src/cljam/pileup/pileup.clj
@@ -4,9 +4,7 @@
             [cljam.common :refer [get-exec-n-threads]]
             [cljam.util.sam-util :as sam-util]
             [cljam.io :as io]
-            [cljam.pileup.common :refer [window-width step center]]
-            cljam.bam.reader)
-  (:import cljam.bam.reader.BAMReader))
+            [cljam.pileup.common :refer [window-width step center]]))
 
 (defn- update-pile
   "Updates the pile vector from the alignment, returning the updated pile


### PR DESCRIPTION
Add `lein cloverage`.

This patch includes two fixes for `lein cloverage`.

- importing `deftype`d classes should need `require` in combination.

- `extend-type` (and `extend`) do `alter-var-root` internally. So `extend-type` should be just below `deftype`.