### PR TITLE
Add a function to clone bam reader.

### DIFF
--- a/src/cljam/bam.clj
+++ b/src/cljam/bam.clj
@@ -9,6 +9,11 @@
   [f & option]
   (bam-core/reader f option))
 
+(defn ^BAMReader clone-reader
+  "Clones bam reader sharing persistent objects."
+  [r]
+  (bam-core/clone-reader r))
+
 (defn ^BAMWriter writer
   "Returns BAM file writer of f."
   [f]

--- a/src/cljam/bam/reader.clj
+++ b/src/cljam/bam/reader.clj
@@ -12,7 +12,7 @@
 ;; BAMReader
 ;; ---------
 
-(deftype BAMReader [f header refs reader data-reader index-delay]
+(deftype BAMReader [f header refs reader data-reader index-delay start-pos]
   Closeable
   (close [this]
     (.close ^Closeable (.reader this))))


### PR DESCRIPTION
Reading BAM header and BAI will be time-consuming when BAM has a lot of refs.
Usually we create one reader per ref when process alignments in parallel and reading same BAM header and BAI repeatedly caused degradation of performance.

This PR adds `clone-reader` function to clone BAMReader reconstructing stateful reader objects of Java.