### PR TITLE
Improve performance of pileup.

### DIFF
--- a/src/cljam/pileup.clj
+++ b/src/cljam/pileup.clj
@@ -20,7 +20,7 @@
   ([bam-reader rname start end option]
    (let [option* (merge default-pileup-option option)]
      (binding [*n-threads* (:n-threads option*)]
-       (plp/pileup bam-reader rname start end)))))
+       (apply plp/pileup bam-reader rname start end (apply concat option*))))))
 
 (def mpileup mplp/pileup)
 


### PR DESCRIPTION
Little modification to use vectors instead of lists.

For example, here're average time of ten profiles piling-up BAM file containing about 54000 alignments in chr1:1000000-4000000.

- list `14404.216 msecs`
- vector `3738.751 msecs`

It's about 3.8x faster.

(It is yet too slow compared to samtools, it needs much more optimization to achieve that good performance..)