### PR TITLE
Improves performance of pileup

### DIFF
--- a/src/cljam/pileup.clj
+++ b/src/cljam/pileup.clj
@@ -20,7 +20,7 @@
   ([bam-reader rname start end option]
    (let [option* (merge default-pileup-option option)]
      (binding [*n-threads* (:n-threads option*)]
-       (plp/pileup bam-reader rname start end)))))
+       (apply plp/pileup bam-reader rname start end (apply concat option*))))))
 
 (def mpileup mplp/pileup)
 

--- a/src/cljam/pileup/mpileup.clj
+++ b/src/cljam/pileup/mpileup.clj
@@ -8,8 +8,7 @@
             [cljam.io :as io]
             [cljam.fasta :as fa]
             [cljam.cigar :as cig]
-            [cljam.pileup.common :refer [window-width step center]]
-            [cljam.pileup.pileup :refer [rpositions]]))
+            [cljam.pileup.common :refer [window-width step center]]))
 
 (defn to-mpileup
   "Stringify mpileup sequence."

--- a/test/cljam/t_pileup.clj
+++ b/test/cljam/t_pileup.clj
@@ -40,7 +40,22 @@
   (type (plp/pileup (bam/reader test-sorted-bam-file) "ref2" nil)) => clojure.lang.LazySeq)
 
 (fact "about pileup"
-  (plp/pileup (bam/reader test-sorted-bam-file) "ref" nil) => test-bam-pileup-ref)
+  (with-open [r (bam/reader test-sorted-bam-file)]
+    (plp/pileup r "ref" nil) => test-bam-pileup-ref)
+  (with-open [r (bam/reader test-sorted-bam-file)]
+    (plp/pileup r "ref" {:step 2 :n-threads 4}) => test-bam-pileup-ref)
+  (with-open [r (bam/reader test-sorted-bam-file)]
+    (plp/pileup r "ref" {:step 3 :n-threads 4}) => test-bam-pileup-ref)
+  (with-open [r (bam/reader test-sorted-bam-file)]
+    (plp/pileup r "ref" {:step 5 :n-threads 4}) => test-bam-pileup-ref)
+  (with-open [r (bam/reader test-sorted-bam-file)]
+    (plp/pileup r "ref" {:step 7 :n-threads 4}) => test-bam-pileup-ref)
+  (with-open [r (bam/reader test-sorted-bam-file)]
+    (plp/pileup r "ref" {:step 11 :n-threads 4}) => test-bam-pileup-ref)
+  (with-open [r (bam/reader test-sorted-bam-file)]
+    (plp/pileup r "ref" {:step 13 :n-threads 4}) => test-bam-pileup-ref)
+  (with-open [r (bam/reader test-sorted-bam-file)]
+    (plp/pileup r "ref" {:n-threads 4}) => test-bam-pileup-ref))
 
 (fact "about pileup"
   (plp/pileup (bam/reader test-sorted-bam-file) "ref2" nil) => test-bam-pileup-ref2)


### PR DESCRIPTION
This PR improves performance of pileup. (revised version of #40, this uses feature of #39)

There're two main points.
- use primitive arrays
- make step configurable

Average time of ten profiles piling-up BAM file containing about 65000 alignments in chr1:1-4000000.

[serial]
- before `20918 msecs`
- after `801 msecs`

about 26x faster

[parallel]
- before `8631 msecs`
- after `617 msecs`

about 14x faster