### PR TITLE
Integration with Codecov

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,8 @@
 language: clojure
 lein: lein
+cache:
+  directories:
+    - $HOME/.m2
 jdk:
   - oraclejdk8
   - oraclejdk7

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,3 +10,6 @@ env:
     - VERSION='1.8'
     - VERSION='1.9'
 script: lein with-profile dev,$VERSION test
+after_success:
+  - CLOVERAGE_VERSION=1.0.9 lein cloverage --codecov
+  - bash <(curl -s https://codecov.io/bash) -f target/coverage/codecov.json

--- a/README.md
+++ b/README.md
@@ -6,6 +6,8 @@ A DNA Sequence Alignment/Map (SAM) library for Clojure. [[API Reference]][api-re
 
 [![Build Status](https://travis-ci.org/chrovis/cljam.svg?branch=master)](https://travis-ci.org/chrovis/cljam)
 
+[![codecov](https://codecov.io/gh/chrovis/cljam/branch/master/graph/badge.svg)](https://codecov.io/gh/chrovis/cljam)
+
 [![Dependency Status](https://www.versioneye.com/user/projects/55dc18598d9c4b0021000759/badge.svg?style=flat)](https://www.versioneye.com/user/projects/55dc18598d9c4b0021000759)
 
 ## Installation


### PR DESCRIPTION
[Codecov](https://codecov.io/) configuration was added.

https://codecov.io/gh/chrovis/cljam

Additionally, caching on Travis CI was set up.