### PR TITLE
Use lein-binplus instead of lein-bin

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -30,7 +30,8 @@
              :uberjar {:main cljam.main
                        :aot :all}}
   :aliases {"docs" ["do" "codox" ["marg" "-d" "target/literate" "-m"]]}
-  :bin {:name "cljam"}
+  :bin {:name "cljam"
+        :bootclasspath true}
   :codox {:namespaces [#"^cljam\.(?!cli)(?!lsb)(?!main)(?!util)[^\.]+$"]
           :output-path "target/docs"
           :source-uri "https://github.com/chrovis/cljam/blob/{version}/{filepath}#L{line}"}

--- a/project.clj
+++ b/project.clj
@@ -14,7 +14,7 @@
                  [camel-snake-kebab "0.4.0"]]
   :profiles {:dev {:dependencies [[org.clojure/clojure "1.8.0"]
                                   [cavia "0.4.0"]]
-                   :plugins [[lein-bin "0.3.5"]
+                   :plugins [[lein-binplus "0.6.2"]
                              [lein-codox "0.10.3"]
                              [lein-marginalia "0.9.0" :exclusions [org.clojure/clojure]]
                              [lein-cloverage "1.0.9" :exclusions [org.clojure/clojure]]]

--- a/src/cljam/cli.clj
+++ b/src/cljam/cli.clj
@@ -359,23 +359,33 @@
         (level/add-level r w))))
   nil)
 
+;; ### version command
+
+(defn version [args]
+  (let [ver (with-open [r (-> "META-INF/maven/cljam/cljam/pom.properties"
+                              (clojure.java.io/resource)
+                              (clojure.java.io/reader))]
+              (.getProperty (doto (java.util.Properties.) (.load r)) "version"))]
+    (exit 0 ver)))
+
 ;; Main command
 ;; ------------
 
 (defn run [args]
   (let [[opts cmd args help cands]
         (sub-command args
-                     "Usage: cljam {view,convert,sort,index,pileup,faidx,dict} ..."
+                     "Usage: cljam {view,convert,normalize,sort,index,pileup,faidx,dict,level,version} ..."
                      :options  [["-h" "--help" "Show help" :default false :flag true]]
                      :commands [["view"    "Extract/print all or sub alignments in SAM or BAM format."]
                                 ["convert" "Convert SAM to BAM or BAM to SAM."]
-                                ["normalize" "Normalize references of alignments"]
+                                ["normalize" "Normalize references of alignments."]
                                 ["sort"    "Sort alignments by leftmost coordinates."]
                                 ["index"   "Index sorted alignment for fast random access."]
                                 ["pileup"  "Generate pileup for the BAM file."]
                                 ["faidx"   "Index reference sequence in the FASTA format."]
                                 ["dict"    "Create a FASTA sequence dictionary file."]
-                                ["level"   "Add level of alignments."]])]
+                                ["level"   "Add level of alignments."]
+                                ["version" "Print version number."]])]
     (when (:help opts)
       (exit 0 help))
     (case cmd
@@ -388,6 +398,7 @@
       :faidx   (faidx args)
       :dict    (dict args)
       :level   (level args)
+      :version (version args)
       (do (println "Invalid command. See 'cljam --help'.")
           (when (seq cands)
             (newline)


### PR DESCRIPTION
[lein-bin](https://github.com/Raynes/lein-bin) plugin is not been maintained anymore. [lein-binplus](https://github.com/BrunoBonacci/lein-binplus) is active fork of lein-bin.

Additionally,

* `:bin {:bootclasspath true}` for launch performance
* `version` sub-command for printing version

were added.