### PR TITLE
Fix single-use reader for n-threads = 1

### DIFF
--- a/src/cljam/pileup/pileup.clj
+++ b/src/cljam/pileup/pileup.clj
@@ -36,7 +36,8 @@
         count-fn (fn [xs]
                    (if (= n-threads 1)
                      (map (fn [[start end]]
-                            (count-for-positions (read-fn rdr start end) start end)) xs)
+                            (with-open [r (bam/clone-reader rdr)]
+                              (count-for-positions (read-fn r start end) start end))) xs)
                      (cp/pmap (dec n-threads)
                               (fn [[start end]]
                                 (with-open [r (bam/clone-reader rdr)]

--- a/test/cljam/t_pileup.clj
+++ b/test/cljam/t_pileup.clj
@@ -42,26 +42,28 @@
   (is (= (with-open [r (bam/reader test-sorted-bam-file)]
            (plp/pileup r "ref" nil))
          test-bam-pileup-ref))
-  (is (= (with-open [r (bam/reader test-sorted-bam-file)]
-           (plp/pileup r "ref" {:step 2 :n-threads 4}))
-         test-bam-pileup-ref))
-  (is (= (with-open [r (bam/reader test-sorted-bam-file)]
-           (plp/pileup r "ref" {:step 3 :n-threads 4}))
-         test-bam-pileup-ref))
-  (is (= (with-open [r (bam/reader test-sorted-bam-file)]
-           (plp/pileup r "ref" {:step 5 :n-threads 4}))
-         test-bam-pileup-ref))
-  (is (= (with-open [r (bam/reader test-sorted-bam-file)]
-           (plp/pileup r "ref" {:step 7 :n-threads 4}))
-         test-bam-pileup-ref))
-  (is (= (with-open [r (bam/reader test-sorted-bam-file)]
-           (plp/pileup r "ref" {:step 11 :n-threads 4}))
-         test-bam-pileup-ref))
-  (is (= (with-open [r (bam/reader test-sorted-bam-file)]
-           (plp/pileup r "ref" {:step 13 :n-threads 4}))
-         test-bam-pileup-ref))
-  (is (= (with-open [r (bam/reader test-sorted-bam-file)]
-           (plp/pileup r "ref" {:n-threads 4}) test-bam-pileup-ref)))
+  (doseq [n-threads [4 1]]
+    (is (= (with-open [r (bam/reader test-sorted-bam-file)]
+             (plp/pileup r "ref" {:step 2 :n-threads n-threads}))
+           test-bam-pileup-ref))
+    (is (= (with-open [r (bam/reader test-sorted-bam-file)]
+             (plp/pileup r "ref" {:step 3 :n-threads n-threads}))
+           test-bam-pileup-ref))
+    (is (= (with-open [r (bam/reader test-sorted-bam-file)]
+             (plp/pileup r "ref" {:step 5 :n-threads n-threads}))
+           test-bam-pileup-ref))
+    (is (= (with-open [r (bam/reader test-sorted-bam-file)]
+             (plp/pileup r "ref" {:step 7 :n-threads n-threads}))
+           test-bam-pileup-ref))
+    (is (= (with-open [r (bam/reader test-sorted-bam-file)]
+             (plp/pileup r "ref" {:step 11 :n-threads n-threads}))
+           test-bam-pileup-ref))
+    (is (= (with-open [r (bam/reader test-sorted-bam-file)]
+             (plp/pileup r "ref" {:step 13 :n-threads n-threads}))
+           test-bam-pileup-ref))
+    (is (= (with-open [r (bam/reader test-sorted-bam-file)]
+             (plp/pileup r "ref" {:n-threads n-threads})
+             test-bam-pileup-ref))))
   (is (= (plp/pileup (bam/reader test-sorted-bam-file) "ref2" nil) test-bam-pileup-ref2)))
 
 (deftest about-first-pos


### PR DESCRIPTION
Need to clone to reader not only multi-thread but also single-thead.
This threw exception without cloning.

And add related tests.