### PR TITLE
Fix for `cljam level` command

### DIFF
--- a/src/cljam/cli.clj
+++ b/src/cljam/cli.clj
@@ -354,7 +354,7 @@
       (not= (count arguments) 2) (exit 1 (level-usage summary))
       errors (exit 1 (error-msg errors)))
     (let [[in out] arguments]
-      (with-open [r (reader in)
+      (with-open [r (reader in :ignore-index false)
                   w (writer out)]
         (level/add-level r w))))
   nil)


### PR DESCRIPTION
`cljam level` command needs index from internal bam reader, but bam reader without option args means `:ignore-index true`.
Need exipit `:ignore-index false` option.