### PR TITLE
Activate cljam.fasta/slurp

### DIFF
--- a/src/cljam/fasta.clj
+++ b/src/cljam/fasta.clj
@@ -1,7 +1,7 @@
 (ns cljam.fasta
   "Alpha - subject to change.
   Reader of a FASTA format file."
-  (:refer-clojure :exclude [read])
+  (:refer-clojure :exclude [read slurp])
   (:require [cljam.fasta.core :as fa-core]
             [cljam.fasta.reader])
   (:import cljam.fasta.reader.FASTAReader))
@@ -44,6 +44,12 @@
 (defn reset
   [rdr]
   (fa-core/reset rdr))
+
+(defn slurp
+  [f]
+  "Opens a reader on a FASTA file and reads all its contents, returning
+  a sequence about the data."
+  (fa-core/slurp f))
 
 (defn sequential-read
   "Reads entire sequences sequentially on caller's thread,

--- a/src/cljam/fasta/core.clj
+++ b/src/cljam/fasta/core.clj
@@ -59,7 +59,7 @@
   "Opens a reader on a FASTA file and reads all its contents, returning
   a sequence about the data."
   [f]
-  (with-open [r (reader f)]
+  (with-open [r (reader f {})]
     (doall (reader/read r))))
 
 (defn sequential-read

--- a/test/cljam/t_fasta.clj
+++ b/test/cljam/t_fasta.clj
@@ -4,8 +4,23 @@
             [cljam.fasta :as fasta]
             [clojure.string :as str]))
 
-;; (deftest slurp-fasta
-;;   (is (= (fasta/slurp test-fa-file) test-fa)))
+(defn- slurp= [fa1 fa2]
+  (when (= (count fa1) (count fa2))
+    (loop [fa1 fa1
+           fa2 fa2]
+      (let [ff1 (first fa1)
+            ff2 (first fa2)]
+        (if (nil? ff1)
+          true
+          (when (and (= (:rname ff1) (:rname ff2))
+                     (= (:offset ff1) (:offset ff2))
+                     (= (:seq ff1) (:seq ff2))
+                     (= (or (:blen ff1) (:line-blen ff1))
+                        (or (:blen ff2) (:line-blen ff2))))
+            (recur (rest fa1) (rest fa2))))))))
+
+(deftest slurp-fasta
+  (is (slurp= (fasta/slurp test-fa-file) test-fa)))
 
 (deftest read-fasta-file
   (let [rdr (fasta/reader test-fa-file)]


### PR DESCRIPTION
`cljam.fasta.core/slurp` exists, but `cljam.fasta/slurp` don't exists.
Create it and add tests.

If should not to go public it, please don't merge this PR and close this.
(I cannot judge this)