### PR TITLE
Activate cljam.fasta/sequential-read-byte-array

### DIFF
--- a/src/cljam/fasta.clj
+++ b/src/cljam/fasta.clj
@@ -45,6 +45,15 @@
   [rdr]
   (fa-core/reset rdr))
 
+(defn sequential-read-byte-array
+  "Reads entire sequences sequentially on caller's thread,
+   blocking until entire file is loaded.
+   Supporting raw (.fa) and compressed FASTA (.fa.gz, .fa.bz2, etc.).
+   Returns list of maps containing sequence as byte-array.
+   Bases ACGTN are encoded as 1~5"
+  [^String f]
+  (fa-core/sequential-read-byte-array f))
+
 (defn sequential-read
   "Reads entire sequences sequentially on caller's thread,
    blocking until entire file is loaded.

--- a/src/cljam/fasta/core.clj
+++ b/src/cljam/fasta/core.clj
@@ -62,6 +62,11 @@
   (with-open [r (reader f)]
     (doall (reader/read r))))
 
+(defn sequential-read-byte-array
+  [f]
+  (with-open [stream (util/compressor-input-stream f)]
+    (reader/sequential-read-byte-array stream (* 1024 1024 10) 536870912)))
+
 (defn sequential-read
   [f]
   (with-open [stream (util/compressor-input-stream f)]

--- a/test/cljam/t_fasta.clj
+++ b/test/cljam/t_fasta.clj
@@ -37,4 +37,21 @@
     (is (= (map (comp count :sequence) fa) '(100000))))
   (let [fa (fasta/sequential-read medium-fa-gz-file)]
     (is (= (map :name fa) '("chr1")))
-    (is (= (map (comp count :sequence) fa) '(100000)))))
+    (is (= (map (comp count :sequence) fa) '(100000))))
+  (let [fsrba= (fn [ba-data fa-data]
+                 (when (= (count ba-data) (count fa-data))
+                   (loop [ba-data ba-data
+                          fa-data fa-data]
+                     (let [ba-line (first ba-data)
+                           fa-line (first fa-data)]
+                       (if-not ba-line
+                         true
+                         (when (and (= (keys ba-line) (keys fa-line))
+                                    (= (String. (:name ba-line))
+                                       (:name fa-line))
+                                    (= (map {1 \A, 2 \C, 3 \G, 4 \T, 5 \N}
+                                            (:sequence ba-line))
+                                       (seq (str/upper-case (:sequence fa-line)))))
+                           (recur (rest ba-data) (rest fa-data))))))))]
+    (is (fsrba= (fasta/sequential-read-byte-array test-fa-file)
+                test-fa-sequences))))


### PR DESCRIPTION
`cljam.fasta.reader/sequential-read-byte-array` exists, but don't used.
Add `cljam.fasta/sequential-read-byte-array` to call this, and add related tests.

If should not to go public it, please don't merge this PR and close this.
(I cannot judge this)