### PR TITLE
For reduce worktime of `lein cloverage`

### DIFF
--- a/test/cljam/t_bam.clj
+++ b/test/cljam/t_bam.clj
@@ -100,7 +100,7 @@
     (is (thrown? IOException (bam/reader invalid-file-2 :ignore-index true)))
     (is (thrown? IOException (bam/reader not-found-file :ignore-index true)))))
 
-(deftest bamreader-medium-file
+(deftest-slow bamreader-medium-file
   (with-before-after {:before (prepare-cache!)
                       :after (clean-cache!)}
     (with-open [rdr (bam/reader medium-bam-file :ignore-index true)]

--- a/test/cljam/t_bam_indexer.clj
+++ b/test/cljam/t_bam_indexer.clj
@@ -71,10 +71,11 @@
       (with-open [r (bam/reader temp-file-sorted)]
         ;; Random read with different number of spans.
         (are [?param ?counts] (= (count (io/read-alignments r ?param)) ?counts)
-          {:chr "chr1" :start 23000000 :end 25000000 :depth :deep} 14858
-          {:chr "chr1" :start 23000000 :end 24500000 :depth :deep} 11424
-          {:chr "chr1" :start 23000000 :end 24000000 :depth :deep} 10010
-          {:chr "chr1" :start 23000000 :end 23500000 :depth :deep} 3806
+          {:chr "chr1" :start 23000000 :end 23001000 :depth :deep} 46 ;; 1 span
+          {:chr "chr1" :start 24900000 :end 24902000 :depth :deep} 3  ;; 2 spans
+          {:chr "chr1" :start 24000000 :end 24001000 :depth :deep} 6  ;; 3 spans
+          {:chr "chr1" :start 23260000 :end 23268650 :depth :deep} 58 ;; 4 spans
+          {:chr "chr1" :start 23430000 :end 23470000 :depth :deep} 55 ;; 5 spans
           {:chr "*"} 0)))))
 
 (deftest-slow about-bam-indexer-medium-file

--- a/test/cljam/t_bam_indexer.clj
+++ b/test/cljam/t_bam_indexer.clj
@@ -71,12 +71,10 @@
       (with-open [r (bam/reader temp-file-sorted)]
         ;; Random read with different number of spans.
         (are [?param ?counts] (= (count (io/read-alignments r ?param)) ?counts)
-          {:chr "chr1" :start 23000000 :end 23010000 :depth :shallow} 175
-          {:chr "chr1" :start 23000000 :end 23010000 :depth :pointer} 175
-          {:chr "chr1" :start 23000000 :end 23010000 :depth :deep} 175
-          {:chr "chr1" :start 23000000 :end 23020000 :depth :deep} 292
-          {:chr "chr1" :start 23000000 :end 23050000 :depth :deep} 621
+          {:chr "chr1" :start 23000000 :end 25000000 :depth :deep} 14858
+          {:chr "chr1" :start 23000000 :end 24500000 :depth :deep} 11424
           {:chr "chr1" :start 23000000 :end 24000000 :depth :deep} 10010
+          {:chr "chr1" :start 23000000 :end 23500000 :depth :deep} 3806
           {:chr "*"} 0)))))
 
 (deftest-slow about-bam-indexer-medium-file

--- a/test/cljam/t_pileup.clj
+++ b/test/cljam/t_pileup.clj
@@ -84,8 +84,8 @@
               (mplp/pileup-seq 101 120 (map #(hash-map :pos (inc %) :cigar "10M") (range))))
          [10 10 10 10 10 10 10 10 10 10 10 10 10 10 10 10 10 10 10 10]))
   (is (= (map :pos
-              (last (mplp/pileup-seq 1 1000000 (map #(hash-map :pos (inc %) :cigar "10M") (range)))))
-         [999991 999992 999993 999994 999995 999996 999997 999998 999999 1000000]))
+              (last (mplp/pileup-seq 1 100000 (map #(hash-map :pos (inc %) :cigar "10M") (range)))))
+         [99991 99992 99993 99994 99995 99996 99997 99998 99999 100000]))
 
   ;;     -----
   ;;    ----


### PR DESCRIPTION
- Reduce too many number of span in pileup test
- Mark `bamreader-medium-file` test as `deftest-slow` (It may causes decreasing of coverage a bit)
- Refine `about-bam-indexer-small-file test`