### PR TITLE
Separate :slow and :heavy test-selectors

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,17 +128,11 @@ $ cljam view --header path/to/file.sam
 
 ### Test
 
-To run all basic tests,
+To run tests,
 
-```console
-$ lein test
-```
-
-To run heavy tests which uses remote large-size files,
-
-```console
-$ lein test :all
-```
+- `lein test` for basic tests,
+- `lein test :slow` for slow tests with local resources,
+- `lein test :remote` for tests with remote resources.
 
 To get coverage
 

--- a/project.clj
+++ b/project.clj
@@ -18,9 +18,9 @@
                              [lein-codox "0.10.3"]
                              [lein-marginalia "0.9.0" :exclusions [org.clojure/clojure]]
                              [lein-cloverage "1.0.9" :exclusions [org.clojure/clojure]]]
-                   :test-selectors {:default #(not-any? % [:slow :heavy])
+                   :test-selectors {:default #(not-any? % [:slow :remote])
                                     :slow :slow   ; Slow tests with local resources
-                                    :heavy :heavy ; Tests with remote resources
+                                    :remote :remote ; Tests with remote resources
                                     :all (constantly true)}
                    :main ^:skip-aot cljam.main
                    :global-vars {*warn-on-reflection* true}}

--- a/project.clj
+++ b/project.clj
@@ -19,8 +19,8 @@
                              [lein-marginalia "0.9.0" :exclusions [org.clojure/clojure]]
                              [lein-cloverage "1.0.9" :exclusions [org.clojure/clojure]]]
                    :test-selectors {:default #(not-any? % [:slow :heavy])
-                                    :slow :slow
-                                    :heavy #(every? % [:slow :heavy])
+                                    :slow :slow   ; Slow tests with local resources
+                                    :heavy :heavy ; Tests with remote resources
                                     :all (constantly true)}
                    :main ^:skip-aot cljam.main
                    :global-vars {*warn-on-reflection* true}}

--- a/test/cljam/t_bam.clj
+++ b/test/cljam/t_bam.clj
@@ -114,7 +114,7 @@
           (is (not-throw? (io/write-alignments w alns header)))
           (same-file? medium-bam-file temp-file))))))
 
-(deftest-slow-heavy bamreader-large-file
+(deftest-heavy bamreader-large-file
   (with-before-after {:before (do (prepare-cache!)
                                   (prepare-cavia!))
                       :after (clean-cache!)}

--- a/test/cljam/t_bam.clj
+++ b/test/cljam/t_bam.clj
@@ -114,7 +114,7 @@
           (is (not-throw? (io/write-alignments w alns header)))
           (same-file? medium-bam-file temp-file))))))
 
-(deftest-heavy bamreader-large-file
+(deftest-remote bamreader-large-file
   (with-before-after {:before (do (prepare-cache!)
                                   (prepare-cavia!))
                       :after (clean-cache!)}

--- a/test/cljam/t_bam_index.clj
+++ b/test/cljam/t_bam_index.clj
@@ -48,9 +48,9 @@
 
 ;;; Tests for a large-size file.
 
-(deftest-heavy bin-index-is-done-without-errors-with-a-large-file
+(deftest-remote bin-index-is-done-without-errors-with-a-large-file
   (with-before-after {:before (prepare-cavia!)}
     (is (not-throw? (bai/bin-index test-large-bai-file 0)))))
-(deftest-heavy linear-index-is-done-without-errors-with-a-large-file
+(deftest-remote linear-index-is-done-without-errors-with-a-large-file
   (with-before-after {:before (prepare-cavia!)}
     (is (not-throw? (bai/linear-index test-large-bai-file 0)))))

--- a/test/cljam/t_bam_index.clj
+++ b/test/cljam/t_bam_index.clj
@@ -48,9 +48,9 @@
 
 ;;; Tests for a large-size file.
 
-(deftest-slow-heavy bin-index-is-done-without-errors-with-a-large-file
+(deftest-heavy bin-index-is-done-without-errors-with-a-large-file
   (with-before-after {:before (prepare-cavia!)}
     (is (not-throw? (bai/bin-index test-large-bai-file 0)))))
-(deftest-slow-heavy linear-index-is-done-without-errors-with-a-large-file
+(deftest-heavy linear-index-is-done-without-errors-with-a-large-file
   (with-before-after {:before (prepare-cavia!)}
     (is (not-throw? (bai/linear-index test-large-bai-file 0)))))

--- a/test/cljam/t_bam_indexer.clj
+++ b/test/cljam/t_bam_indexer.clj
@@ -93,7 +93,7 @@
                   (io/read-alignments r {:chr "*"}))))
     (is (fs/exists? (str temp-file-sorted ".bai")))))
 
-(deftest-heavy about-bam-indexer-large-file
+(deftest-remote about-bam-indexer-large-file
   (with-before-after {:before (do (prepare-cavia!)
                                   (prepare-cache!)
                                   (fs/copy large-bam-file temp-file-sorted))

--- a/test/cljam/t_bam_indexer.clj
+++ b/test/cljam/t_bam_indexer.clj
@@ -93,7 +93,7 @@
                   (io/read-alignments r {:chr "*"}))))
     (is (fs/exists? (str temp-file-sorted ".bai")))))
 
-(deftest-slow-heavy about-bam-indexer-large-file
+(deftest-heavy about-bam-indexer-large-file
   (with-before-after {:before (do (prepare-cavia!)
                                   (prepare-cache!)
                                   (fs/copy large-bam-file temp-file-sorted))

--- a/test/cljam/t_common.clj
+++ b/test/cljam/t_common.clj
@@ -25,9 +25,6 @@
 (defmacro deftest-heavy [sym args & body]
   (expand-deftest (with-meta sym {:heavy true}) args body))
 
-(defmacro deftest-slow-heavy [sym args & body]
-  (expand-deftest (with-meta sym {:slow true :heavy true}) args body))
-
 (defprofile mycavia
   {:resources [{:id "large.bam"
                 :url "https://test.chrov.is/data/GSM721144_H3K36me3.nodup.bam"

--- a/test/cljam/t_common.clj
+++ b/test/cljam/t_common.clj
@@ -22,8 +22,8 @@
 (defmacro deftest-slow [sym args & body]
   (expand-deftest (with-meta sym {:slow true}) args body))
 
-(defmacro deftest-heavy [sym args & body]
-  (expand-deftest (with-meta sym {:heavy true}) args body))
+(defmacro deftest-remote [sym args & body]
+  (expand-deftest (with-meta sym {:remote true}) args body))
 
 (defprofile mycavia
   {:resources [{:id "large.bam"

--- a/test/cljam/t_sorter.clj
+++ b/test/cljam/t_sorter.clj
@@ -85,7 +85,7 @@
     ;; (is (with-reader sorter/sorted-by? tmp-queryname-sorted-bam-file-2)) ; TODO: future
     (is (get #{:queryname :coordinate :unsorted :unknown}
              (with-reader sorter/sort-order tmp-shuffled-sam-file)))
-    (is (get #{:queryname :coordinate :unsorted :unknown} 
+    (is (get #{:queryname :coordinate :unsorted :unknown}
              (with-reader sorter/sort-order tmp-shuffled-bam-file)))
     (is (= (with-reader sorter/sort-order tmp-coordinate-sorted-sam-file-2)
            sorter/order-unknown))
@@ -139,7 +139,7 @@
     (is (not-throw? (check-sort-order (slurp-sam-for-test tmp-coordinate-sorted-sam-file))))
     (is (not-throw? (check-sort-order (slurp-bam-for-test tmp-coordinate-sorted-bam-file))))))
 
-(deftest-slow-heavy about-sorting-large-file
+(deftest-heavy about-sorting-large-file
   (with-before-after {:before (do (prepare-cavia!)
                                   (prepare-cache!))
                       :after (clean-cache!)}

--- a/test/cljam/t_sorter.clj
+++ b/test/cljam/t_sorter.clj
@@ -139,7 +139,7 @@
     (is (not-throw? (check-sort-order (slurp-sam-for-test tmp-coordinate-sorted-sam-file))))
     (is (not-throw? (check-sort-order (slurp-bam-for-test tmp-coordinate-sorted-bam-file))))))
 
-(deftest-heavy about-sorting-large-file
+(deftest-remote about-sorting-large-file
   (with-before-after {:before (do (prepare-cavia!)
                                   (prepare-cache!))
                       :after (clean-cache!)}

--- a/test/cljam/t_tabix.clj
+++ b/test/cljam/t_tabix.clj
@@ -22,6 +22,6 @@
                   :linear-index vector?}
                  (tbi/read-index test-tabix-file))))
 
-(deftest-heavy large-file
+(deftest-remote large-file
   (with-before-after {:before (prepare-cavia!)}
     (is (not-throw? (tbi/read-index test-large-tabix-file)))))

--- a/test/cljam/t_tabix.clj
+++ b/test/cljam/t_tabix.clj
@@ -22,6 +22,6 @@
                   :linear-index vector?}
                  (tbi/read-index test-tabix-file))))
 
-(deftest-slow-heavy large-file
+(deftest-heavy large-file
   (with-before-after {:before (prepare-cavia!)}
     (is (not-throw? (tbi/read-index test-large-tabix-file)))))


### PR DESCRIPTION
`:slow` and `:heavy` tests are substantially same on current test-selectors because all `:heavy` tests also have `:slow` tag. It is difficult to run only slow tests with local resources.

`:slow` and `:heavy` tests are clearly separated by this PR.

* `lein test :slow` to run slow tests with local resources.
* `lein test :heavy` to run tests with remote resources.
* `lein test :slow :heavy` to run slow tests with local and remote resources.