### PR TITLE
Change default start/end of bam reader.

### DIFF
--- a/src/cljam/bam/reader.clj
+++ b/src/cljam/bam/reader.clj
@@ -33,7 +33,8 @@
     (read-alignments-sequentially* this :deep))
   (read-alignments [this {:keys [chr start end depth]
                           :or {chr nil
-                               start -1 end -1
+                               start 1
+                               end Long/MAX_VALUE
                                depth :deep}}]
     (if (nil? chr)
       (read-alignments-sequentially* this depth)
@@ -42,7 +43,8 @@
     (read-blocks-sequentially* this :normal))
   (read-blocks [this {:keys [chr start end mode]
                       :or {chr nil
-                           start -1 end -1
+                           start 1
+                           end Long/MAX_VALUE
                            mode :normal}}]
     (if (nil? chr)
       (read-blocks-sequentially* this mode)
@@ -218,8 +220,7 @@
         window (fn [^clojure.lang.PersistentHashMap a]
                  (let [^Long left (:pos a)]
                    (and (= chr (:rname a))
-                        (<= start left)
-                        (>= end left))))
+                        (<= start left end))))
         candidates (flatten (map (fn [[^Long begin ^Long finish]]
                                    (read-to-finish rdr begin finish read-coordinate-alignment-block)) spans))]
     (filter window candidates)))

--- a/test/cljam/t_bam.clj
+++ b/test/cljam/t_bam.clj
@@ -85,13 +85,32 @@
   (with-before-after {:before (prepare-cache!)
                       :after (clean-cache!)}
     (with-open [rdr (bam/reader test-sorted-bam-file :ignore-index false)]
-      ;; TODO: Does not works?
-      (is (= (io/read-alignments rdr {:chr "ref2"}) [])))
+      (is (= (io/read-alignments rdr {:chr "ref2"})
+             (drop 6 (:alignments test-sam-sorted-by-pos)))))
     (with-open [rdr (bam/reader test-sorted-bam-file :ignore-index false)]
-      (is (= (data->clj (io/read-blocks rdr)) test-sorted-bam-data)))
+      (is (= (io/read-alignments rdr {:chr "ref2" :start 21})
+             (drop 7 (:alignments test-sam-sorted-by-pos)))))
     (with-open [rdr (bam/reader test-sorted-bam-file :ignore-index false)]
-      ;; TODO: Does not works?
-      (is (= (data->clj (io/read-blocks rdr {:chr "ref2"})) [])))))
+      (is (= (io/read-alignments rdr {:chr "ref2" :end 9})
+             (take 3 (drop 6 (:alignments test-sam-sorted-by-pos))))))
+    (with-open [rdr (bam/reader test-sorted-bam-file :ignore-index false)]
+      (is (= (io/read-alignments rdr {:chr "ref2" :start 10 :end 12})
+             (take 5 (drop 6 (:alignments test-sam-sorted-by-pos))))))
+    (with-open [rdr (bam/reader test-sorted-bam-file :ignore-index false)]
+      (is (= (data->clj (io/read-blocks rdr))
+             test-sorted-bam-data)))
+    (with-open [rdr (bam/reader test-sorted-bam-file :ignore-index false)]
+      (is (= (map #(dissoc % :pos :qname :rname) (data->clj (io/read-blocks rdr {:chr "ref2"})))
+             (drop 6 test-sorted-bam-data))))
+    (with-open [rdr (bam/reader test-sorted-bam-file :ignore-index false)]
+      (is (= (map #(dissoc % :pos :qname :rname) (data->clj (io/read-blocks rdr {:chr "ref2" :start 2})))
+             (drop 7 test-sorted-bam-data))))
+    (with-open [rdr (bam/reader test-sorted-bam-file :ignore-index false)]
+      (is (= (map #(dissoc % :pos :qname :rname) (data->clj (io/read-blocks rdr {:chr "ref2" :end 2})))
+             (take 2 (drop 6 test-sorted-bam-data)))))
+    (with-open [rdr (bam/reader test-sorted-bam-file :ignore-index false)]
+      (is (= (map #(dissoc % :pos :qname :rname) (data->clj (io/read-blocks rdr {:chr "ref2" :start 4 :end 12})))
+             (take 3 (drop 8 test-sorted-bam-data)))))))
 
 (deftest bamreader-invalid-files
   (with-before-after {:before (prepare-cache!)


### PR DESCRIPTION
Related to #62

Currently, we get no alignments when giving only chromosome name like `{:chr "chr1"}`.
This is because the default value of start/end is -1/-1.

This PR replaces them with 1 and Long/MAX_VALUE so that `{:chr "chr1"}` will represent whole region of chromosome 1.