### PR TITLE
Add protocols for I/O APIs.

### DIFF
--- a/src/cljam/bam/core.clj
+++ b/src/cljam/bam/core.clj
@@ -1,8 +1,7 @@
 (ns cljam.bam.core
   "The core of BAM features."
-  (:require [clojure.java.io :refer [file]]
+  (:require [clojure.java.io :as cio]
             [me.raynes.fs :as fs]
-            [cljam.io]
             [cljam.lsb :as lsb]
             (cljam.bam [common :refer [bam-magic]]
                        [reader :as reader]
@@ -27,19 +26,19 @@
 
 (defn ^BAMReader reader [f {:keys [ignore-index]
                             :or {ignore-index false}}]
-  (let [rdr (BGZFInputStream. (file f))
+  (let [rdr (BGZFInputStream. (cio/file f))
         data-rdr (DataInputStream. rdr)]
     (when-not (Arrays/equals ^bytes (lsb/read-bytes data-rdr 4) (.getBytes ^String bam-magic))
       (throw (IOException. "Invalid BAM file")))
     (let [{:keys [header refs]} (reader/load-headers data-rdr)
           index-delay (delay (bam-index f :ignore ignore-index))]
-      (BAMReader. (.getAbsolutePath (file f))
+      (BAMReader. (.getAbsolutePath (cio/file f))
                   header refs rdr data-rdr index-delay (.getFilePointer rdr)))))
 
 (defn ^BAMReader clone-reader
   "Clones bam reader sharing persistent objects."
   [^BAMReader rdr]
-  (let [bgzf-rdr (BGZFInputStream. (file (.f rdr)))
+  (let [bgzf-rdr (BGZFInputStream. (cio/file (.f rdr)))
         data-rdr (DataInputStream. bgzf-rdr)]
     (.seek bgzf-rdr (.start-pos rdr))
     (BAMReader. (.f rdr) (.header rdr) (.refs rdr) bgzf-rdr data-rdr (.index-delay rdr) (.start-pos rdr))))
@@ -48,5 +47,5 @@
 ;; -------
 
 (defn ^BAMWriter writer [f]
-  (BAMWriter. (.getAbsolutePath (file f))
-              (DataOutputStream. (BGZFOutputStream. (file f)))))
+  (BAMWriter. (.getAbsolutePath (cio/file f))
+              (DataOutputStream. (BGZFOutputStream. (cio/file f)))))

--- a/src/cljam/bam/reader.clj
+++ b/src/cljam/bam/reader.clj
@@ -1,6 +1,6 @@
 (ns cljam.bam.reader
   (:require [cljam.lsb :as lsb]
-            [cljam.io]
+            [cljam.io :as io]
             [cljam.util.sam-util :refer [ref-id ref-name parse-header get-end]]
             [cljam.bam-index :refer [get-spans]]
             [cljam.bam-index.core :as bai]
@@ -22,33 +22,51 @@
   Closeable
   (close [this]
     (.close ^Closeable (.reader this)))
-  cljam.io/ISAMReader
+  io/IReader
   (reader-path [this]
     (.f this))
+  (read [this]
+    (io/read this {}))
+  (read [this option]
+    (io/read-alignments this {} option))
+  io/IAlignmentReader
   (read-header [this]
     (.header this))
   (read-refs [this]
     (.refs this))
   (read-alignments [this]
-    (read-alignments-sequentially* this :deep))
-  (read-alignments [this {:keys [chr start end depth]
-                          :or {chr nil
-                               start 1
-                               end Long/MAX_VALUE
-                               depth :deep}}]
+    (io/read-alignments this {} {}))
+  (read-alignments [this region]
+    (io/read-alignments this region {}))
+  (read-alignments [this
+                    {:keys [chr start end]
+                     :or {chr nil
+                          start 1
+                          end Long/MAX_VALUE}}
+                    {:keys [depth]
+                     :or {depth :deep}}]
     (if (nil? chr)
       (read-alignments-sequentially* this depth)
       (read-alignments* this chr start end depth)))
   (read-blocks [this]
-    (read-blocks-sequentially* this :normal))
-  (read-blocks [this {:keys [chr start end mode]
-                      :or {chr nil
-                           start 1
-                           end Long/MAX_VALUE
-                           mode :normal}}]
+    (io/read-blocks this {} {}))
+  (read-blocks [this region]
+    (io/read-blocks this region {}))
+  (read-blocks [this
+                {:keys [chr start end]
+                 :or {chr nil
+                      start 1
+                      end Long/MAX_VALUE}}
+                {:keys [mode]
+                 :or {mode :normal}}]
     (if (nil? chr)
       (read-blocks-sequentially* this mode)
-      (read-blocks* this chr start end))))
+      (read-blocks* this chr start end)))
+  io/IRegionReader
+  (read-in-region [this region]
+    (io/read-in-region this region {}))
+  (read-in-region [this region option]
+    (io/read-alignments this region option)))
 
 ;; Reading a single block
 ;; --------------------

--- a/src/cljam/bam/writer.clj
+++ b/src/cljam/bam/writer.clj
@@ -1,6 +1,6 @@
 (ns cljam.bam.writer
   (:require [clojure.string :refer [split]]
-            [cljam.io]
+            [cljam.io :as io]
             (cljam [cigar :as cgr]
                    [lsb :as lsb]
                    [util :refer [string->bytes ubyte]])
@@ -21,9 +21,10 @@
   Closeable
   (close [this]
     (.close ^Closeable (.writer this)))
-  cljam.io/ISAMWriter
+  io/IWriter
   (writer-path [this]
     (.f this))
+  io/IAlignmentWriter
   (write-header [this header]
     (write-header* this header))
   (write-refs [this header]

--- a/src/cljam/bam_index/core.clj
+++ b/src/cljam/bam_index/core.clj
@@ -1,6 +1,6 @@
 (ns cljam.bam-index.core
   "The core of BAM index features."
-  (:require [clojure.java.io :as io]
+  (:require [clojure.java.io :as cio]
             [clojure.tools.logging :as logging]
             [me.raynes.fs :as fs]
             (cljam.bam-index [common :refer :all]
@@ -77,9 +77,9 @@
 
 (defn ^BAIWriter writer
   [f refs]
-  (BAIWriter. (DataOutputStream. (FileOutputStream. (io/file f)))
+  (BAIWriter. (DataOutputStream. (FileOutputStream. (cio/file f)))
               refs
-              (.getAbsolutePath (io/file f))))
+              (.getAbsolutePath (cio/file f))))
 
 (defn create-index
   "Creates a BAM index file from the alignments and references data."

--- a/src/cljam/bam_index/reader.clj
+++ b/src/cljam/bam_index/reader.clj
@@ -1,5 +1,5 @@
 (ns cljam.bam-index.reader
-  (:require [clojure.java.io :as io]
+  (:require [clojure.java.io :as cio]
             [cljam.lsb :as lsb]
             [cljam.bam-index.common :refer [bai-magic]])
   (:import java.util.Arrays
@@ -113,7 +113,7 @@
      :lidx lidx}))
 
 (defn reader [f]
-  (let [r (DataInputStream. (FileInputStream. (io/file f)))]
+  (let [r (DataInputStream. (FileInputStream. (cio/file f)))]
     (when-not (Arrays/equals ^bytes (lsb/read-bytes r 4) (.getBytes ^String bai-magic))
       (throw (IOException. "Invalid BAI file")))
     (->BAIReader f r)))

--- a/src/cljam/bam_index/writer.clj
+++ b/src/cljam/bam_index/writer.clj
@@ -1,6 +1,5 @@
 (ns cljam.bam-index.writer
-  (:require [clojure.java.io :as io]
-            [com.climate.claypoole :as cp]
+  (:require [com.climate.claypoole :as cp]
             [cljam.common :refer [get-exec-n-threads]]
             [cljam.lsb :as lsb]
             [cljam.util.sam-util :as sam-util]

--- a/src/cljam/bam_indexer.clj
+++ b/src/cljam/bam_indexer.clj
@@ -11,5 +11,5 @@
   (with-open [r (bam/reader in-bam :ignore-index true)]
     (binding [*n-threads* n-threads]
       (bai-core/create-index out-bai
-                             (io/read-blocks r {:mode :pointer})
+                             (io/read-blocks r {} {:mode :pointer})
                              (io/read-refs r)))))

--- a/src/cljam/bcf.clj
+++ b/src/cljam/bcf.clj
@@ -18,11 +18,7 @@
 (defn meta-info
   "Returns meta-information of the BCF from rdr as a map."
   [^BCFReader rdr]
-  (-> (.meta-info rdr)
-      (update :contig (fn [xs] (map (fn [m] (dissoc m :idx)) xs)))
-      (update :filter (fn [xs] (keep (fn [m] (when-not (= (:id m) "PASS") (dissoc m :idx))) xs)))
-      (update :info (fn [xs] (map (fn [m] (dissoc m :idx)) xs)))
-      (update :format (fn [xs] (map (fn [m] (dissoc m :idx)) xs)))))
+  (bcf-reader/meta-info rdr))
 
 (defn header
   "Returns header of the BCF from rdr as a vector including header field strings."
@@ -39,8 +35,10 @@
      :bcf     BCF-style map. CHROM, FILTER, INFO and :genotype contains indices to meta-info.
      :shallow Only CHROM, POS and ref-length are parsed.
      :raw     Raw map of ByteBufers."
-  [rdr & {:keys [depth] :or {depth :deep}}]
-  (bcf-reader/read-variants rdr :depth depth))
+  ([rdr]
+   (read-variants rdr {}))
+  ([rdr {:keys [depth] :or {depth :deep}}]
+   (bcf-reader/read-variants rdr {:depth depth})))
 
 ;; Writing
 ;; -------

--- a/src/cljam/convert.clj
+++ b/src/cljam/convert.clj
@@ -4,7 +4,8 @@
             [cljam.io :as io]
             [cljam.bam.encoder :as encoder]
             [cljam.util.sam-util :as sam-util]
-            [com.climate.claypoole :as cp]))
+            [com.climate.claypoole :as cp])
+  (:import [cljam.bam.writer BAMWriter]))
 
 (def ^:private default-num-block 100000)
 (def ^:private default-num-write-block 10000)
@@ -15,7 +16,7 @@
 
 (defn- bam-write-alignments [rdr wtr hdr num-block num-write-block]
   (let [refs (sam-util/make-refs hdr)
-        w (.writer wtr)]
+        w (.writer ^BAMWriter wtr)]
     (cp/with-shutdown! [pool (cp/threadpool (cp/ncpus))]
       (doseq [alns (partition-all num-block (io/read-alignments rdr {}))]
         (let [blocks (doall (cp/pmap pool

--- a/src/cljam/core.clj
+++ b/src/cljam/core.clj
@@ -8,18 +8,19 @@
             [cljam.fastq :as fastq]
             [cljam.vcf :as vcf]
             [cljam.bcf :as bcf]
-            [cljam.bed :as bed])
+            [cljam.bed :as bed]
+            [cljam.pileup.mpileup :as mplp])
   (:import [java.io Closeable]))
 
 (defn alignment-reader?
-  "Checks if given object implements ISAMReader"
+  "Checks if given object implements protocol IAlignmentReader."
   [rdr]
-  (satisfies? io/ISAMReader rdr))
+  (satisfies? cljam.io/IAlignmentReader rdr))
 
 (defn alignment-writer?
-  "Checks if given object implements ISAMWriter"
+  "Checks if given object implements protocol IAlignmentWriter."
   [wtr]
-  (satisfies? io/ISAMWriter wtr))
+  (satisfies? cljam.io/IAlignmentWriter wtr))
 
 (defn sam-reader?
   "Checks if given object is an instance of SAMReader."
@@ -41,6 +42,16 @@
   [wtr]
   (instance? cljam.bam.writer.BAMWriter wtr))
 
+(defn variant-reader?
+  "Checks if given object implements protocol IVariantReader."
+  [rdr]
+  (satisfies? cljam.io/IVariantReader rdr))
+
+(defn variant-writer?
+  "Checks if given object implements protocol IVariantWriter."
+  [wtr]
+  (satisfies? cljam.io/IVariantWriter wtr))
+
 (defn vcf-reader?
   "Checks if given object is an instance of VCFReader."
   [rdr]
@@ -60,6 +71,11 @@
   "Checks if given object is an instance of BCFWriter."
   [wtr]
   (instance? cljam.bcf.writer.BCFWriter wtr))
+
+(defn sequence-reader?
+  "Checks if given object implements protocol ISequenceReader."
+  [rdr]
+  (satisfies? cljam.io/ISequenceReader rdr))
 
 (defn fasta-reader?
   "Checks if given object is an instance of FASTAReader."
@@ -139,4 +155,3 @@
     :bcf (apply bcf/writer f args)
     :bed (bed/writer f)
     :else (throw (IllegalArgumentException. "Invalid file type"))))
-

--- a/src/cljam/dict.clj
+++ b/src/cljam/dict.clj
@@ -1,7 +1,7 @@
 (ns cljam.dict
   "Alpha - subject to change.
   Generator of a FASTA sequence dictionary file."
-  (:require [clojure.java.io :as io]
+  (:require [clojure.java.io :as cio]
             [cljam.fasta :as fasta]
             [cljam.dict.core :as dict-core]))
 
@@ -13,4 +13,4 @@
     (dict-core/create-dict out-dict
                            (fasta/read-headers r)
                            (fasta/read-sequences r)
-                           (str (.. (io/file fasta) getCanonicalFile toURI)))))
+                           (str (.. (cio/file fasta) getCanonicalFile toURI)))))

--- a/src/cljam/dict/core.clj
+++ b/src/cljam/dict/core.clj
@@ -1,6 +1,6 @@
 (ns cljam.dict.core
   "The core of dictionary features."
-  (:require [clojure.java.io :as io]
+  (:require [clojure.java.io :as cio]
             [clojure.tools.logging :as logging]
             [me.raynes.fs :as fs]
             [cljam.dict.writer :as writer])
@@ -18,8 +18,8 @@
   "Opens f, returning a `cljam.dict.writer.DICTWriter`. Should be used inside
   `with-open` to ensure the writer is properly closed."
   [f]
-  (DICTWriter. (io/writer f)
-               (.getAbsolutePath (io/file f))))
+  (DICTWriter. (cio/writer f)
+               (.getAbsolutePath (cio/file f))))
 
 (defn create-dict
   "Creates a FASTA sequence dictionary file (.dict) from the specified FASTA

--- a/src/cljam/fasta.clj
+++ b/src/cljam/fasta.clj
@@ -2,9 +2,8 @@
   "Alpha - subject to change.
   Reader of a FASTA format file."
   (:refer-clojure :exclude [read])
-  (:require [cljam.fasta.core :as fa-core]
-            [cljam.fasta.reader])
-  (:import cljam.fasta.reader.FASTAReader))
+  (:require [cljam.fasta.core :as fa-core])
+  (:import [cljam.fasta.reader FASTAReader]))
 
 (defn ^FASTAReader reader
   "Returns an open cljam.fasta.reader.FASTAReader of f with options.

--- a/src/cljam/fasta_index/core.clj
+++ b/src/cljam/fasta_index/core.clj
@@ -1,6 +1,6 @@
 (ns cljam.fasta-index.core
   "The core of FASTA index features."
-  (:require [clojure.java.io :as io]
+  (:require [clojure.java.io :as cio]
             [clojure.tools.logging :as logging]
             [me.raynes.fs :as fs]
             [cljam.fasta-index.writer :as writer]
@@ -12,13 +12,13 @@
 (defn writer
   [f]
   (cljam.fasta_index.writer.FAIWriter.
-   (io/writer f)
-   (.getAbsolutePath (io/file f))))
+   (cio/writer f)
+   (.getAbsolutePath (cio/file f))))
 
 (defn create-index
   "Creates a FASTA index file from the sequences."
   [in-fa out-fai]
-  (with-open [r (io/reader (util/compressor-input-stream in-fa))
+  (with-open [r (cio/reader (util/compressor-input-stream in-fa))
               w ^cljam.fasta_index.writer.FAIWriter (writer out-fai)]
     (try
       (writer/write-index! r w)
@@ -32,9 +32,9 @@
 (defn reader
   [f]
   (cljam.fasta_index.reader.FAIReader.
-   (with-open [rdr (io/reader f)]
+   (with-open [rdr (cio/reader f)]
      (reader/parse-fai rdr))
-   (.getAbsolutePath (io/file f))))
+   (.getAbsolutePath (cio/file f))))
 
 (defn get-header
   [^cljam.fasta_index.reader.FAIReader fai name]

--- a/src/cljam/io.clj
+++ b/src/cljam/io.clj
@@ -1,25 +1,56 @@
 (ns cljam.io
-  "Protocols of SAM/BAM reader.")
+  "Protocols of reader/writer for various file formats."
+  (:refer-clojure :exclude [read]))
 
 (defrecord SAMAlignment
   [qname ^int flag rname ^int pos ^int end ^int mapq cigar rnext ^int pnext ^int tlen seq qual options])
 
-(defprotocol ISAMReader
-  (reader-path [this] "Returns the file's absolute path.")
-  (read-header [this] "Returns header of the SAM/BAM file.")
-  (read-refs [this] "Returns references of the SAM/BAM file.")
-  (read-alignments [this] [this option]
-    "Reads alignments of the SAM/BAM file, returning the alignments as a lazy
-    sequence.")
-  (read-blocks [this] [this option]
-    "Reads alignment blocks of the SAM/BAM file, returning the blocks as a lazy
-    sequence."))
+(defprotocol IReader
+  (reader-path [this]
+    "Returns the file's absolute path.")
+  (read [this] [this option]
+    "Sequentially reads contents of the file."))
 
-(defprotocol ISAMWriter
-  (writer-path [this] "Returns the file's absolute path.")
-  (write-header [this header] "Writes header to the SAM/BAM file.")
-  (write-refs [this header] "Writes references to the SAM/BAM file.")
+(defprotocol IWriter
+  (writer-path [this]
+    "Returns the file's absolute path."))
+
+(defprotocol IRegionReader
+  (read-in-region [this region] [this region option]
+    "Reads contents of the file in given region."))
+
+(defprotocol IAlignmentReader
+  (read-header [this]
+    "Returns header of the SAM/BAM file.")
+  (read-refs [this]
+    "Returns references of the SAM/BAM file.")
+  (read-alignments [this] [this region] [this region option]
+    "Reads alignments of the SAM/BAM file, returning the alignments as a lazy sequence.")
+  (read-blocks [this] [this region] [this region option]
+    "Reads alignment blocks of the SAM/BAM file, returning the blocks as a lazy sequence."))
+
+(defprotocol IAlignmentWriter
+  (write-header [this header]
+    "Writes header to the SAM/BAM file.")
+  (write-refs [this header]
+    "Writes references to the SAM/BAM file.")
   (write-alignments [this alignments header]
     "Writes alignments to the SAM/BAM file.")
   (write-blocks [this blocks]
     "Writes alignment blocks of the SAM/BAM file."))
+
+(defprotocol IVariantReader
+  (meta-info [this]
+    "Returns meta-info section of VCF/BCF file as a map.")
+  (header [this]
+    "Returns header of VCF/BCF file as a sequence of strings.")
+  (read-variants [this] [this option]
+    "Reads variants of the VCF/BCF file, returning them as a lazy sequence."))
+
+(defprotocol IVariantWriter
+  (write-variants [this variants]
+    "Writes variants to thee VCF/BCF file."))
+
+(defprotocol ISequenceReader
+  (read-sequence [this region] [this region option]
+    "Reads all sequences of FASTA/2BIT file."))

--- a/src/cljam/pileup.clj
+++ b/src/cljam/pileup.clj
@@ -1,8 +1,6 @@
 (ns cljam.pileup
-  (:require [clojure.java.io :refer [writer]]
-            [cljam.common :refer [*n-threads*]]
+  (:require [cljam.common :refer [*n-threads*]]
             [cljam.bam :as bam]
-            [cljam.io :as io]
             [cljam.pileup.common :as plpc]
             [cljam.pileup.pileup :as plp]
             [cljam.pileup.mpileup :as mplp]))
@@ -15,14 +13,12 @@
   {:n-threads 0})
 
 (defn pileup
-  ([bam-reader rname]
-   (pileup bam-reader rname {}))
-  ([bam-reader rname option]
-   (pileup bam-reader rname -1 -1 option))
-  ([bam-reader rname start end option]
+  ([reader region]
+   (pileup reader region {}))
+  ([bam-reader {:keys [chr start end] :or {start -1 end -1} :as region} option]
    (let [option* (merge default-pileup-option option)]
      (binding [*n-threads* (:n-threads option*)]
-       (apply plp/pileup bam-reader rname start end (apply concat option*))))))
+       (apply plp/pileup bam-reader region (apply concat option*))))))
 
 (def mpileup mplp/pileup)
 

--- a/src/cljam/sam.clj
+++ b/src/cljam/sam.clj
@@ -1,8 +1,6 @@
 (ns cljam.sam
   "Read/Write a SAM format file."
-  (:refer-clojure :exclude [slurp spit])
-  (:require [cljam.io :as io]
-            (cljam.sam [reader :as sam-reader]
+  (:require (cljam.sam [reader :as sam-reader]
                        [writer :as sam-writer]))
   (:import cljam.sam.reader.SAMReader
            cljam.sam.writer.SAMWriter))

--- a/src/cljam/sam/writer.clj
+++ b/src/cljam/sam/writer.clj
@@ -1,24 +1,25 @@
 (ns cljam.sam.writer
   "Provides writing features."
-  (:require [clojure.java.io :as io]
+  (:require [clojure.java.io :as cio]
             [clojure.tools.logging :as logging]
             [cljam.util.sam-util :refer [stringify-header
                                          stringify-alignment]]
-            [cljam.io])
-  (:import java.io.BufferedWriter))
+            [cljam.io :as io])
+  (:import [java.io BufferedWriter Closeable]))
 
 (declare write-header* write-alignments* write-blocks*)
 
 ;; SAMWriter
 ;; ---------
 
-(deftype SAMWriter [^java.io.BufferedWriter writer f]
-  java.io.Closeable
+(deftype SAMWriter [^BufferedWriter writer f]
+  Closeable
   (close [this]
     (.close writer))
-  cljam.io/ISAMWriter
+  io/IWriter
   (writer-path [this]
     (.f this))
+  io/IAlignmentWriter
   (write-header [this header]
     (write-header* this header))
   (write-refs [this refs]
@@ -56,5 +57,5 @@
 
 (defn ^SAMWriter writer
   [f]
-  (->SAMWriter (clojure.java.io/writer f)
-               (.getAbsolutePath (io/file f))))
+  (->SAMWriter (cio/writer f)
+               (.getAbsolutePath (cio/file f))))

--- a/src/cljam/sorter.clj
+++ b/src/cljam/sorter.clj
@@ -44,7 +44,7 @@
 
 (defn- sort-alignments-by-pos [rdr]
   (let [ref-map (make-ref-map (io/read-header rdr))]
-    (sort (partial compare-key-pos ref-map) (io/read-blocks rdr {:mode :coordinate}))))
+    (sort (partial compare-key-pos ref-map) (io/read-blocks rdr {} {:mode :coordinate}))))
 
 ;; Queryname sorter
 ;; ----------------
@@ -108,7 +108,7 @@
         ref-map (make-ref-map header)]
     (io/write-header wtr header)
     (io/write-refs wtr header)
-    (loop [blocks-list (map #(io/read-blocks % {:mode :coordinate}) rdrs)]
+    (loop [blocks-list (map #(io/read-blocks % {} {:mode :coordinate}) rdrs)]
       (let [candidates (map first blocks-list)]
         (when-not (every? nil? candidates)
           (let [[i b] (head candidates ref-map)]

--- a/src/cljam/tabix.clj
+++ b/src/cljam/tabix.clj
@@ -1,7 +1,7 @@
 (ns cljam.tabix
   "Alpha - subject to change.
   Reader of a TABIX format file."
-  (:require [clojure.java.io :as io]
+  (:require [clojure.java.io :as cio]
             [cljam.lsb :as lsb])
   (:import java.util.Arrays
            [java.io DataInputStream IOException]
@@ -70,5 +70,5 @@
 
 (defn read-index
   [f]
-  (with-open [r (DataInputStream. (BGZFInputStream. (io/file f)))]
+  (with-open [r (DataInputStream. (BGZFInputStream. (cio/file f)))]
     (read-index* r)))

--- a/src/cljam/twobit.clj
+++ b/src/cljam/twobit.clj
@@ -1,6 +1,7 @@
 (ns cljam.twobit
   (:require [clojure.string :as cstr]
-            [clojure.java.io :as io]
+            [clojure.java.io :as cio]
+            [cljam.io :as io]
             [cljam.lsb :as lsb]
             [cljam.util :as util])
   (:import [java.io Closeable DataInput RandomAccessFile]
@@ -94,34 +95,58 @@
 (defn ^String read-sequence
   "Reads sequence at the given region from reader.
    Pass {:mask? true} to enable masking of sequence."
-  [^TwoBitReader rdr {:keys [chr start end mask?] :or {mask? false}}]
-  (when-let [[n {:keys [offset]}]
-             (first (filter (fn [[i {:keys [name]}]] (= name chr)) (map vector (range) (.file-index rdr))))]
-    (let [{:keys [len ambs masks header-offset]} @(nth (.seq-index rdr) n) ;; Potential seek & read.
-          start' (or start 1)
-          end' (or end len)
-          start-offset (quot (dec (max 1 start')) 4)
-          end-offset (quot (dec (min len end')) 4)
-          ba (byte-array (- end-offset start-offset -1))
-          cb (CharBuffer/allocate (inc (- end' start')))]
-      (.seek ^RandomAccessFile (.reader rdr) (+ offset header-offset start-offset))
-      (.readFully ^RandomAccessFile (.reader rdr) ba)
-      (dotimes [out-pos (inc (- end' start'))]
-        (let [ref-pos (+ out-pos start')
-              ba-pos (- (quot (dec ref-pos) 4) start-offset)
-              bit-pos (mod (dec ref-pos) 4)]
-          (if (<= 1 ref-pos len)
-            (.put cb (.charAt ^String (twobit-to-str (+ (aget ba ba-pos) 128)) bit-pos))
-            (.put cb \N))))
-      (when mask? (mask! cb masks start' end'))
-      (replace-ambs! cb ambs start' end')
-      (.rewind cb)
-      (.toString cb))))
+  ([rdr region]
+   (read-sequence rdr region {}))
+  ([^TwoBitReader rdr {:keys [chr start end]} {:keys [mask?] :or {mask? false}}]
+   (when-let [[n {:keys [offset]}]
+              (first (filter (fn [[i {:keys [name]}]] (= name chr)) (map vector (range) (.file-index rdr))))]
+     (let [{:keys [len ambs masks header-offset]} @(nth (.seq-index rdr) n) ;; Potential seek & read.
+           start' (or start 1)
+           end' (or end len)
+           start-offset (quot (dec (max 1 start')) 4)
+           end-offset (quot (dec (min len end')) 4)
+           ba (byte-array (- end-offset start-offset -1))
+           cb (CharBuffer/allocate (inc (- end' start')))]
+       (.seek ^RandomAccessFile (.reader rdr) (+ offset header-offset start-offset))
+       (.readFully ^RandomAccessFile (.reader rdr) ba)
+       (dotimes [out-pos (inc (- end' start'))]
+         (let [ref-pos (+ out-pos start')
+               ba-pos (- (quot (dec ref-pos) 4) start-offset)
+               bit-pos (mod (dec ref-pos) 4)]
+           (if (<= 1 ref-pos len)
+             (.put cb (.charAt ^String (twobit-to-str (+ (aget ba ba-pos) 128)) bit-pos))
+             (.put cb \N))))
+       (when mask? (mask! cb masks start' end'))
+       (replace-ambs! cb ambs start' end')
+       (.rewind cb)
+       (.toString cb)))))
+
+(extend-type TwoBitReader
+  io/IReader
+  (reader-path [this] (.f this))
+  (read
+    ([this] (io/read this {}))
+    ([this option]
+     (for [{:keys [name offset]} (.file-index this)]
+       {:name name :sequence (read-sequence this {:chr name} option)})))
+  io/ISequenceReader
+  (read-sequence
+    (^String [this region]
+     (io/read-sequence this region {}))
+    (^String [this region option]
+     (read-sequence this region option)))
+  io/IRegionReader
+  (read-in-region
+    (^String [this region]
+     (io/read-in-region this region {}))
+    (^String [this {:keys [chr start end] :as region} option]
+     (read-sequence this region option))))
 
 (defn ^TwoBitReader reader
   "Returns .2bit file reader of f."
   [^String f]
-  (let [rdr (RandomAccessFile. f "r")
+  (let [abs-f (.getAbsolutePath (cio/file f))
+        rdr (RandomAccessFile. abs-f "r")
         [endian nseq] (read-file-header! rdr)]
     (when (and endian nseq)
       (let [indices (vec (repeatedly nseq #(read-index! rdr endian)))
@@ -130,4 +155,4 @@
                                  (.seek rdr offset)
                                  (read-sequence-header! rdr endian)))
                               indices)]
-        (TwoBitReader. rdr f endian indices seq-indices)))))
+        (TwoBitReader. rdr abs-f endian indices seq-indices)))))

--- a/src/cljam/util/chromosome.clj
+++ b/src/cljam/util/chromosome.clj
@@ -20,7 +20,7 @@
       s
       (let [[_ base leftover] m
             base  (if (re-find #"^\d+$" base)
-                    (str (Integer. base))
+                    (str (Integer. ^String base))
                     base)]
         (str "chr" (cstr/upper-case (str base leftover)))))))
 

--- a/src/cljam/vcf.clj
+++ b/src/cljam/vcf.clj
@@ -1,6 +1,6 @@
 (ns cljam.vcf
   "Functions to read and write the Variant Call Format (VCF)."
-  (:require [clojure.java.io :as io]
+  (:require [clojure.java.io :as cio]
             [cljam.util :as util]
             [cljam.vcf.reader :as vcf-reader]
             [cljam.vcf.writer :as vcf-writer])
@@ -14,12 +14,12 @@
   "Returns an open cljam.vcf.reader.VCFReader of f. Should be used inside
   with-open to ensure the Reader is properly closed."
   [f]
-  (let [meta-info (with-open [r (io/reader (util/compressor-input-stream f))]
+  (let [meta-info (with-open [r (cio/reader (util/compressor-input-stream f))]
                     (vcf-reader/load-meta-info r))
-        header (with-open [r (io/reader (util/compressor-input-stream f))]
+        header (with-open [r (cio/reader (util/compressor-input-stream f))]
                  (vcf-reader/load-header r))]
-    (VCFReader. (.getAbsolutePath (io/file f)) meta-info header
-                (io/reader (util/compressor-input-stream f)))))
+    (VCFReader. (.getAbsolutePath (cio/file f)) meta-info header
+                (cio/reader (util/compressor-input-stream f)))))
 
 (defn meta-info
   "Returns meta-information of the VCF from rdr as a map."
@@ -39,8 +39,10 @@
 
     :deep Fully parsed variant map. FORMAT, FILTER, INFO and samples columns are parsed.
     :vcf  VCF-style map. FORMAT, FILTER, INFO and samples columns are strings."
-  [rdr & {:keys [depth] :or {depth :deep}}]
-  (vcf-reader/read-variants rdr :depth depth))
+  ([rdr]
+   (read-variants rdr {}))
+  ([rdr {:keys [depth] :or {depth :deep}}]
+   (vcf-reader/read-variants rdr {:depth depth})))
 
 ;; Writing
 ;; -------
@@ -55,8 +57,8 @@
                             [\"CHROM\" \"POS\" \"ID\" \"REF\" \"ALT\" ...])]
       (WRITING-VCF))"
   [f meta-info header]
-  (doto (VCFWriter. (.getAbsolutePath (io/file f))
-                    (io/writer (util/compressor-output-stream f))
+  (doto (VCFWriter. (.getAbsolutePath (cio/file f))
+                    (cio/writer (util/compressor-output-stream f))
                     meta-info
                     header)
     (vcf-writer/write-meta-info meta-info)

--- a/src/cljam/vcf/writer.clj
+++ b/src/cljam/vcf/writer.clj
@@ -3,15 +3,24 @@
   https://samtools.github.io/hts-specs/ for the detail VCF specifications."
   (:require [clojure.string :as cstr]
             [camel-snake-kebab.core :refer [->camelCaseString]]
-            [cljam.util.vcf-util :as vcf-util]))
+            [cljam.io :as io]
+            [cljam.util.vcf-util :as vcf-util])
+  (:import [java.io Closeable BufferedWriter]))
+
+(declare write-variants)
 
 ;; VCFWriter
 ;; ---------
 
 (deftype VCFWriter [f writer meta-info header]
-  java.io.Closeable
+  Closeable
   (close [this]
-    (.close ^java.io.Closeable (.writer this))))
+    (.close ^Closeable (.writer this)))
+  io/IWriter
+  (writer-path [this] (.f this))
+  io/IVariantWriter
+  (write-variants [this variants]
+    (write-variants this variants)))
 
 ;; Vars and utilities
 ;; ------------------
@@ -26,7 +35,7 @@
   (if (nil? s) "." s))
 
 (defn- write-line
-  [^java.io.BufferedWriter bwtr ^String s]
+  [^BufferedWriter bwtr ^String s]
   (doto bwtr
     (.write s)
     (.newLine)))

--- a/test/cljam/t_bcf.clj
+++ b/test/cljam/t_bcf.clj
@@ -1,7 +1,7 @@
 (ns cljam.t-bcf
   (:require [clojure.test :refer :all]
             [cljam.t-common :refer :all]
-            [clojure.java.io :as io]
+            [clojure.java.io :as cio]
             [cljam.bcf :as bcf]
             [cljam.vcf :as vcf])
   (:import [java.io IOException]
@@ -39,19 +39,19 @@
 (deftest about-reading-bcf-variants-vcf
   (is
    (= (with-open [r (bcf/reader test-bcf-v4_3-file)]
-        (doall (bcf/read-variants r :depth :vcf)))
+        (doall (bcf/read-variants r {:depth :vcf})))
       test-vcf-v4_3-variants)))
 
 (deftest about-reading-bcf-variants-deep
   (with-open [r  (bcf/reader test-bcf-v4_3-file)]
-    (doseq [[v1 v2] (map vector (bcf/read-variants r :depth :deep) test-vcf-v4_3-variants-deep)]
+    (doseq [[v1 v2] (map vector (bcf/read-variants r {:depth :deep}) test-vcf-v4_3-variants-deep)]
       (is
        (= v1 v2)))))
 
 (deftest about-reading-bcf-variants-shallow
   (with-open [r (bcf/reader test-bcf-v4_3-file)]
     (doseq [[v1 v2] (map vector
-                         (map (juxt :chr :pos :rlen) (bcf/read-variants r :depth :shallow))
+                         (map (juxt :chr :pos :rlen) (bcf/read-variants r {:depth :shallow}))
                          (map (fn [v] [(:chr v) (:pos v) (count (:ref v))]) test-vcf-v4_3-variants))]
       (is
        (= v1 v2)))))
@@ -59,7 +59,7 @@
 (deftest about-reading-bcf-variants-bcf
   (with-open [r (bcf/reader test-bcf-v4_3-file)]
     (doseq [[v1 v2] (map vector
-                         (map (juxt :chr :pos :id :ref :alt) (bcf/read-variants r :depth :bcf))
+                         (map (juxt :chr :pos :id :ref :alt) (bcf/read-variants r {:depth :bcf}))
                          (map (fn [v] [0 (:pos v) (:id v) (:ref v) (:alt v)]) test-vcf-v4_3-variants-deep))]
       (is
        (= v1 v2)))))
@@ -67,7 +67,7 @@
 (deftest about-read-write-bcf
   (with-before-after {:before (prepare-cache!)
                       :after (clean-cache!)}
-    (let [temp-file (.getAbsolutePath (io/file temp-dir "test_v4_3.bcf"))]
+    (let [temp-file (.getAbsolutePath (cio/file temp-dir "test_v4_3.bcf"))]
       (with-open [r (bcf/reader test-bcf-v4_3-file)
                   w (bcf/writer temp-file (bcf/meta-info r) (bcf/header r))]
         (bcf/write-variants w (bcf/read-variants r)))
@@ -84,7 +84,7 @@
 (deftest about-vcf->bcf-conversion
   (with-before-after {:before (prepare-cache!)
                       :after (clean-cache!)}
-    (let [temp-file (.getAbsolutePath (io/file temp-dir "test_v4_3.bcf"))]
+    (let [temp-file (.getAbsolutePath (cio/file temp-dir "test_v4_3.bcf"))]
       (with-open [r (vcf/reader test-vcf-v4_3-file)
                   w (bcf/writer temp-file (vcf/meta-info r) (vcf/header r))]
         (bcf/write-variants w (vcf/read-variants r)))
@@ -101,7 +101,7 @@
 (deftest about-bcf->vcf-conversion
   (with-before-after {:before (prepare-cache!)
                       :after (clean-cache!)}
-    (let [temp-file (.getAbsolutePath (io/file temp-dir "test_v4_3.vcf"))]
+    (let [temp-file (.getAbsolutePath (cio/file temp-dir "test_v4_3.vcf"))]
       (with-open [r (bcf/reader test-bcf-v4_3-file)
                   w (vcf/writer temp-file (bcf/meta-info r) (bcf/header r))]
         (vcf/write-variants w (bcf/read-variants r)))

--- a/test/cljam/t_bed.clj
+++ b/test/cljam/t_bed.clj
@@ -1,10 +1,9 @@
 (ns cljam.t-bed
   (:require [clojure.test :refer :all]
             [cljam.t-common :refer :all]
-            [clojure.java.io :as io]
             [cljam.bed :as bed]
             [cljam.fasta :as fa]
-            [cljam.io :as cio]
+            [cljam.io :as io]
             [cljam.bam :as bam]
             [cljam.util.sam-util :as sam-util])
   (:import [java.io BufferedReader InputStreamReader ByteArrayInputStream
@@ -171,7 +170,7 @@
 (deftest bed-reader-and-bam-reader
   (with-open [bam (bam/reader test-sorted-bam-file)]
     (letfn [(ref-pos-end [m] {:rname (:rname m) :pos (:pos m) :end (sam-util/get-end m)})
-            (read-region [s] (->> (str->bed s) (mapcat #(cio/read-alignments bam %)) (map ref-pos-end)))]
+            (read-region [s] (->> (str->bed s) (mapcat #(io/read-alignments bam %)) (map ref-pos-end)))]
       (are [?region-str ?result] (= (read-region ?region-str) ?result)
         "ref 0 6" []
         "ref 6 7" [{:rname "ref" :pos 7 :end 22}]

--- a/test/cljam/t_cli.clj
+++ b/test/cljam/t_cli.clj
@@ -1,20 +1,20 @@
 (ns cljam.t-cli
   (:require [clojure.test :refer :all]
             [cljam.t-common :refer :all]
-            [clojure.java.io :as io]
+            [clojure.java.io :as cio]
             [cljam.cli :as cli]
-            [cljam.io :as cio]
+            [cljam.io :as io]
             [cljam.bam :as bam])
   (:import [java.io PrintStream]))
 
 (defmacro with-out-file
   [f & body]
-  `(let [os# (io/output-stream ~f)
+  `(let [os# (cio/output-stream ~f)
          old-ps# System/out
          ps# (PrintStream. os#)]
      (try
        (System/setOut ps#)
-       (binding [*out* (io/writer os#)]
+       (binding [*out* (cio/writer os#)]
          ~@body)
        (finally
          (.flush ps#)
@@ -80,11 +80,11 @@
 
 (deftest about-index
   (with-before-after {:before (do (prepare-cache!)
-                                  (io/copy (io/file test-sorted-bam-file)
-                                           (io/file temp-bam)))
+                                  (cio/copy (cio/file test-sorted-bam-file)
+                                            (cio/file temp-bam)))
                       :after (clean-cache!)}
     (is (not-throw? (with-out-file temp-out (cli/index [temp-bam]))))
-    (is (.exists (io/file (str temp-bam ".bai"))))
+    (is (.exists (cio/file (str temp-bam ".bai"))))
     (is (not-throw? (with-out-file temp-out (cli/index ["-t" "1" temp-bam]))))
     (is (not-throw? (with-out-file temp-out (cli/index ["-t" "4" temp-bam]))))))
 
@@ -114,18 +114,18 @@
 
 (deftest about-faidx
   (with-before-after {:before (do (prepare-cache!)
-                                  (io/copy (io/file test-fa-file)
-                                           (io/file temp-out)))
+                                  (cio/copy (cio/file test-fa-file)
+                                            (cio/file temp-out)))
                       :after (clean-cache!)}
     (is (not-throw? (with-out-file temp-out (cli/faidx [temp-out]))))
-    (is (.exists (io/file (str temp-out ".fai"))))))
+    (is (.exists (cio/file (str temp-out ".fai"))))))
 
 (deftest about-dict
   (with-before-after {:before (prepare-cache!)
                       :after (clean-cache!)}
     (let [temp-dict (str temp-dir "/out.dict")]
       (is (not-throw? (with-out-file temp-out (cli/dict [test-fa-file temp-dict]))))
-      (is (.exists (io/file temp-dict))))))
+      (is (.exists (cio/file temp-dict))))))
 
 (deftest about-level
   (with-before-after {:before (prepare-cache!)
@@ -136,7 +136,7 @@
                                                         temp-bam]))))
     (with-open [rdr (bam/reader temp-bam :ignore-index true)]
       (is (= (map #(first (keep :LV (:options %)))
-                  (cio/read-alignments rdr))
+                  (io/read-alignments rdr))
              test-sorted-bam-levels)))))
 
 (deftest about-run

--- a/test/cljam/t_core.clj
+++ b/test/cljam/t_core.clj
@@ -1,6 +1,7 @@
 (ns cljam.t-core
   (:require [clojure.test :refer :all]
-            [clojure.java.io :as io]
+            [clojure.java.io :as cio]
+            [cljam.core :as core]
             [cljam.core :as core]
             [cljam.util :as util]
             [cljam.util.sam-util :as sam-util]
@@ -66,8 +67,10 @@
       core/alignment-reader? true
       core/sam-reader? true
       core/bam-reader? false
+      core/variant-reader? false
       core/vcf-reader? false
       core/bcf-reader? false
+      core/sequence-reader? false
       core/fasta-reader? false
       core/twobit-reader? false
       core/fastq-reader? false
@@ -79,8 +82,10 @@
       core/alignment-reader? true
       core/sam-reader? false
       core/bam-reader? true
+      core/variant-reader? false
       core/vcf-reader? false
       core/bcf-reader? false
+      core/sequence-reader? false
       core/fasta-reader? false
       core/twobit-reader? false
       core/fastq-reader? false
@@ -92,8 +97,10 @@
       core/alignment-reader? false
       core/sam-reader? false
       core/bam-reader? false
+      core/variant-reader? true
       core/vcf-reader? true
       core/bcf-reader? false
+      core/sequence-reader? false
       core/fasta-reader? false
       core/twobit-reader? false
       core/fastq-reader? false
@@ -105,8 +112,10 @@
       core/alignment-reader? false
       core/sam-reader? false
       core/bam-reader? false
+      core/variant-reader? true
       core/vcf-reader? false
       core/bcf-reader? true
+      core/sequence-reader? false
       core/fasta-reader? false
       core/twobit-reader? false
       core/fastq-reader? false
@@ -118,8 +127,10 @@
       core/alignment-reader? false
       core/sam-reader? false
       core/bam-reader? false
+      core/variant-reader? false
       core/vcf-reader? false
       core/bcf-reader? false
+      core/sequence-reader? true
       core/fasta-reader? true
       core/twobit-reader? false
       core/fastq-reader? false
@@ -131,8 +142,10 @@
       core/alignment-reader? false
       core/sam-reader? false
       core/bam-reader? false
+      core/variant-reader? false
       core/vcf-reader? false
       core/bcf-reader? false
+      core/sequence-reader? true
       core/fasta-reader? false
       core/twobit-reader? true
       core/fastq-reader? false
@@ -144,9 +157,11 @@
       core/alignment-reader? false
       core/sam-reader? false
       core/bam-reader? false
+      core/variant-reader? false
       core/vcf-reader? false
       core/bcf-reader? false
       core/fasta-reader? false
+      core/sequence-reader? false
       core/twobit-reader? false
       core/fastq-reader? true
       core/bed-reader? false))
@@ -157,8 +172,10 @@
       core/alignment-reader? false
       core/sam-reader? false
       core/bam-reader? false
+      core/variant-reader? false
       core/vcf-reader? false
       core/bcf-reader? false
+      core/sequence-reader? false
       core/fasta-reader? false
       core/twobit-reader? false
       core/fastq-reader? false
@@ -176,71 +193,77 @@
   (is (thrown? Exception (core/reader "./test-resources/bam/foo.baam"))))
 
 (deftest about-writers
-  (with-open [r (core/writer (.getAbsolutePath (io/file util/temp-dir "temp.sam")))]
+  (with-open [r (core/writer (.getAbsolutePath (cio/file util/temp-dir "temp.sam")))]
     (are [?pred ?expected]
         (= (?pred r) ?expected)
       core/alignment-writer? true
       core/sam-writer? true
       core/bam-writer? false
+      core/variant-writer? false
       core/vcf-writer? false
       core/bcf-writer? false
       core/fastq-writer? false
       core/bed-writer? false))
 
-  (with-open [r (core/writer (.getAbsolutePath (io/file util/temp-dir "temp.bam")))]
+  (with-open [r (core/writer (.getAbsolutePath (cio/file util/temp-dir "temp.bam")))]
     (are [?pred ?expected]
         (= (?pred r) ?expected)
       core/alignment-writer? true
       core/sam-writer? false
       core/bam-writer? true
+      core/variant-writer? false
       core/vcf-writer? false
       core/bcf-writer? false
       core/fastq-writer? false
       core/bed-writer? false))
 
-  (with-open [r (core/writer (.getAbsolutePath (io/file util/temp-dir "temp.vcf")) {} [])]
+  (with-open [r (core/writer (.getAbsolutePath (cio/file util/temp-dir "temp.vcf")) {} [])]
     (are [?pred ?expected]
         (= (?pred r) ?expected)
       core/alignment-writer? false
       core/sam-writer? false
       core/bam-writer? false
+      core/variant-writer?  true
       core/vcf-writer? true
       core/bcf-writer? false
       core/fastq-writer? false
       core/bed-writer? false))
 
-  (with-open [r (core/writer (.getAbsolutePath (io/file util/temp-dir "temp.bcf")) {} [])]
+  (with-open [r (core/writer (.getAbsolutePath (cio/file util/temp-dir "temp.bcf")) {} [])]
     (are [?pred ?expected]
         (= (?pred r) ?expected)
       core/alignment-writer? false
       core/sam-writer? false
       core/bam-writer? false
+      core/variant-writer?  true
       core/vcf-writer? false
       core/bcf-writer? true
       core/fastq-writer? false
       core/bed-writer? false))
 
-  (with-open [r (core/writer (.getAbsolutePath (io/file util/temp-dir "temp.fq")))]
+  (with-open [r (core/writer (.getAbsolutePath (cio/file util/temp-dir "temp.fq")))]
     (are [?pred ?expected]
         (= (?pred r) ?expected)
       core/alignment-writer? false
       core/sam-writer? false
       core/bam-writer? false
+      core/variant-writer?  false
       core/vcf-writer? false
       core/bcf-writer? false
       core/fastq-writer? true
       core/bed-writer? false))
 
-  (with-open [r (core/writer (.getAbsolutePath (io/file util/temp-dir "temp.bed")))]
+  (with-open [r (core/writer (.getAbsolutePath (cio/file util/temp-dir "temp.bed")))]
     (are [?pred ?expected]
         (= (?pred r) ?expected)
       core/alignment-writer? false
       core/sam-writer? false
       core/bam-writer? false
+      core/variant-writer?  false
       core/vcf-writer? false
       core/bcf-writer? false
       core/fastq-writer? false
       core/bed-writer? true))
 
-  (is (thrown? Exception (core/writer (.getAbsolutePath (io/file util/temp-dir "temp.baam")))))
-  (is (thrown? Exception (core/writer (.getAbsolutePath (io/file util/temp-dir "temp.bai"))))))
+  (is (thrown? Exception (core/writer (.getAbsolutePath (cio/file util/temp-dir "temp.baam")))))
+  (is (thrown? Exception (core/writer (.getAbsolutePath (cio/file util/temp-dir "temp.bai"))))))

--- a/test/cljam/t_dedupe.clj
+++ b/test/cljam/t_dedupe.clj
@@ -1,7 +1,6 @@
 (ns cljam.t-dedupe
   (:require [clojure.test :refer :all]
             [cljam.t-common :refer :all]
-            [cljam.io :as cio]
             [cljam.bam :as bam]
             [cljam.dedupe :as dedupe]))
 

--- a/test/cljam/t_dict.clj
+++ b/test/cljam/t_dict.clj
@@ -3,13 +3,13 @@
   (:require [clojure.test :refer :all]
             [clojure.string :as string]
             [me.raynes.fs :as fs]
-            [clojure.java.io :as io]
+            [clojure.java.io :as cio]
             [cljam.t-common :refer :all]
             [cljam.dict :as dict]))
 
 (defn same-dict-file? [f1 f2]
-  (with-open [r1 (io/reader f1)
-              r2 (io/reader f2)]
+  (with-open [r1 (cio/reader f1)
+              r2 (cio/reader f2)]
     (let [dict1 (line-seq r1)
           dict2 (line-seq r2)
           ;; NB: `UR` is calculated by local file path, ignore it,

--- a/test/cljam/t_fasta_indexer.clj
+++ b/test/cljam/t_fasta_indexer.clj
@@ -1,7 +1,6 @@
 (ns cljam.t-fasta-indexer
   "Tests for cljam.fasta-indexer."
   (:require [clojure.test :refer :all]
-            [clojure.java.io :as io]
             [me.raynes.fs :as fs]
             [cljam.t-common :refer :all]
             [cljam.fasta-indexer :as fai]))

--- a/test/cljam/t_fastq.clj
+++ b/test/cljam/t_fastq.clj
@@ -1,77 +1,76 @@
 (ns cljam.t-fastq
   (:require [clojure.test :refer :all]
             [cljam.t-common :refer :all]
-            [clojure.java.io :as io]
+            [clojure.java.io :as cio]
             [cljam.fastq :as fq]))
 
 (deftest fastq-file-input
   (is (= (with-open [r (fq/reader test-fq-file)]
-           (doall (map (partial into {}) (fq/read-sequence r))))
+           (doall (map (partial into {}) (fq/read-sequences r))))
          test-fq-sequences))
   (is (= (with-open [r (fq/reader test-fq-file)]
            (doall (map (partial into {})
-                       (fq/read-sequence r :decode-quality :phred33))))
+                       (fq/read-sequences r {:decode-quality :phred33}))))
          test-fq-sequences))
   (is (= (with-open [r (fq/reader test-fq-file)]
            (doall (map (partial into {})
-                       (fq/read-sequence r :decode-quality nil))))
+                       (fq/read-sequences r {:decode-quality nil}))))
          test-fq-sequences-raw))
   (is (thrown? AssertionError
                (with-open [r (fq/reader test-fq-file)]
                  (doall (map (partial into {})
-                             (fq/read-sequence r :decode-quality :phred64))))))
+                             (fq/read-sequences r {:decode-quality :phred64}))))))
   (is (= (with-open [r (fq/reader test-fq-gz-file)]
-           (doall (map (partial into {}) (fq/read-sequence r))))
+           (doall (map (partial into {}) (fq/read-sequences r))))
          test-fq-sequences))
   (is (= (with-open [r (fq/reader test-fq-bz2-file)]
-           (doall (map (partial into {}) (fq/read-sequence r))))
+           (doall (map (partial into {}) (fq/read-sequences r))))
          test-fq-sequences)))
 
 (deftest fastq-file-output
   (with-before-after {:before (do (clean-cache!)
                                   (prepare-cache!))
                       :after (clean-cache!)}
-    (is (= (let [path (.getAbsolutePath (io/file temp-dir "test.fq"))]
+    (is (= (let [path (.getAbsolutePath (cio/file temp-dir "test.fq"))]
              (with-open [w (fq/writer path)]
-               (fq/write-sequence w test-fq-sequences))
+               (fq/write-sequences w test-fq-sequences))
              (with-open [r (fq/reader path)]
-               (doall (map (partial into {}) (fq/read-sequence r)))))
+               (doall (map (partial into {}) (fq/read-sequences r)))))
            test-fq-sequences))
 
-    (is (= (let [path (.getAbsolutePath (io/file temp-dir "test-33.fq"))]
+    (is (= (let [path (.getAbsolutePath (cio/file temp-dir "test-33.fq"))]
              (with-open [w (fq/writer path)]
-               (fq/write-sequence w test-fq-sequences :encode-quality :phred33))
+               (fq/write-sequences w test-fq-sequences {:encode-quality :phred33}))
              (with-open [r (fq/reader path)]
-               (doall (map (partial into {}) (fq/read-sequence r)))))
+               (doall (map (partial into {}) (fq/read-sequences r)))))
            test-fq-sequences))
 
-    (is (= (let [path (.getAbsolutePath (io/file temp-dir "test-raw.fq"))]
+    (is (= (let [path (.getAbsolutePath (cio/file temp-dir "test-raw.fq"))]
              (with-open [w (fq/writer path)]
-               (fq/write-sequence w test-fq-sequences-raw :encode-quality nil))
+               (fq/write-sequences w test-fq-sequences-raw {:encode-quality nil}))
              (with-open [r (fq/reader path)]
-               (doall (map (partial into {}) (fq/read-sequence r)))))
+               (doall (map (partial into {}) (fq/read-sequences r)))))
            test-fq-sequences))
 
     (is (thrown? AssertionError
-                 (let [path (.getAbsolutePath (io/file temp-dir "test-64.fq"))]
+                 (let [path (.getAbsolutePath (cio/file temp-dir "test-64.fq"))]
                    (with-open [w (fq/writer path)]
-                     (fq/write-sequence w test-fq-sequences
-                                        :encode-quality :phred64))
+                     (fq/write-sequences w test-fq-sequences {:encode-quality :phred64}))
                    (with-open [r (fq/reader path)]
-                     (doall (map (partial into {}) (fq/read-sequence r)))))))
+                     (doall (map (partial into {}) (fq/read-sequences r)))))))
 
-    (is (= (let [path (.getAbsolutePath (io/file temp-dir "test.fq.gz"))]
+    (is (= (let [path (.getAbsolutePath (cio/file temp-dir "test.fq.gz"))]
              (with-open [w (fq/writer path)]
-               (fq/write-sequence w test-fq-sequences))
+               (fq/write-sequences w test-fq-sequences))
              (with-open [r (fq/reader path)]
-               (doall (map (partial into {}) (fq/read-sequence r)))))
+               (doall (map (partial into {}) (fq/read-sequences r)))))
            test-fq-sequences))
 
-    (is (= (let [path (.getAbsolutePath (io/file temp-dir "test.fq.bz2"))]
+    (is (= (let [path (.getAbsolutePath (cio/file temp-dir "test.fq.bz2"))]
              (with-open [w (fq/writer path)]
-               (fq/write-sequence w test-fq-sequences))
+               (fq/write-sequences w test-fq-sequences))
              (with-open [r (fq/reader path)]
-               (doall (map (partial into {}) (fq/read-sequence r)))))
+               (doall (map (partial into {}) (fq/read-sequences r)))))
            test-fq-sequences))))
 
 (def sample-1_8 {:instrument "EAS139"

--- a/test/cljam/t_io.clj
+++ b/test/cljam/t_io.clj
@@ -1,0 +1,189 @@
+(ns cljam.t-io
+  (:require [clojure.test :refer :all]
+            [clojure.java.io :as cio]
+            [cljam.core :as core]
+            [cljam.io :as io]
+            [cljam.t-common :as common]))
+
+(deftest readers
+  (are [?file]
+      (with-open [r (core/reader ?file)]
+        (= (io/reader-path r) (.getAbsolutePath (cio/file ?file))))
+    common/test-sam-file
+    common/small-bam-file
+    common/test-fa-file
+    common/test-twobit-file
+    common/test-vcf-v4_3-file
+    common/test-bcf-v4_3-file
+    common/test-fq-file
+    common/test-bed-file1))
+
+(deftest writers
+  (common/with-before-after {:before (common/prepare-cache!)
+                             :after (common/clean-cache!)}
+    (are [?ext]
+        (let [f (.getPath (cio/file common/temp-dir (str "test." ?ext)))]
+          (with-open [r (core/writer f)]
+            (= (io/writer-path r) (.getAbsolutePath (cio/file f)))))
+      "sam"
+      "bam"
+      "fastq"
+      "bed")
+
+    (are [?ext]
+        (let [f (.getPath (cio/file common/temp-dir (str "test." ?ext)))]
+          (with-open [r (core/writer f {} [])]
+            (= (io/writer-path r) (.getAbsolutePath (cio/file f)))))
+      "vcf"
+      "bcf")))
+
+(deftest bam-io
+  (is (= (with-open [r (core/reader common/medium-bam-file)]
+           (into [] (comp (map :pos) (take 10)) (io/read r)))
+         [546609 547480 662438 714873 907683 1026525 1058055 1102230 1105259 1120976]))
+
+  (is (= (with-open [r (core/reader common/medium-bam-file)]
+           (into [] (comp (map :pos) (take 10)) (io/read r {:depth :deep})))
+         [546609 547480 662438 714873 907683 1026525 1058055 1102230 1105259 1120976]))
+
+  (is (= (with-open [r (core/reader common/medium-bam-file)]
+           (into [] (comp (map :pos) (take 10)) (io/read-in-region r {})))
+         [546609 547480 662438 714873 907683 1026525 1058055 1102230 1105259 1120976]))
+
+  (is (= (with-open [r (core/reader common/medium-bam-file)]
+           (into [] (comp (map :pos) (take 10)) (io/read-in-region r {:chr "chr2"})))
+         [67302 388030 393457 552907 650982 777266 845153 875507 905898 906758]))
+
+  (is (= (with-open [r (core/reader common/medium-bam-file)]
+           (into [] (comp (map :pos) (take 10)) (io/read-in-region r {:chr "chr2" :start 70000})))
+         [388030 393457 552907 650982 777266 845153 875507 905898 906758 1232621]))
+
+  (is (= (with-open [r (core/reader common/medium-bam-file)]
+           (into [] (comp (map :pos) (take 10)) (io/read-in-region r {:chr "chr2" :start 70000 :end 500000})))
+         [388030 393457])))
+
+(deftest sam-io
+  (is (= (with-open [r (core/reader common/test-sam-file)]
+           (into [] (comp (map :pos) (take 10)) (io/read r)))
+         [29 7 9 9 6 16 37 1 2 10]))
+
+  (is (= (with-open [r (core/reader common/test-sam-file)]
+           (into [] (comp (map :pos) (take 10)) (io/read r {})))
+         [29 7 9 9 6 16 37 1 2 10]))
+
+  (is (= (with-open [r (core/reader common/test-sam-file)]
+           (into [] (comp (map :pos) (take 10)) (io/read-in-region r {})))
+         [29 7 9 9 6 16 37 1 2 10]))
+
+  (is (= (with-open [r (core/reader common/test-sam-file)]
+           (into [] (comp (map :pos) (take 10)) (io/read-in-region r {:chr "ref2"})))
+         [6 1 2 10 14 12]))
+
+  (is (= (with-open [r (core/reader common/test-sam-file)]
+           (into [] (comp (map :pos) (take 10)) (io/read-in-region r {:chr "ref2" :start 10})))
+         [6 1 2 10 14 12]))
+
+  (is (= (with-open [r (core/reader common/test-sam-file)]
+           (into [] (comp (map :pos) (take 10)) (io/read-in-region r {:chr "ref2" :start 10 :end 11})))
+         [6 1 2 10])))
+
+(deftest fasta-io
+  (is
+   (= (with-open [r (core/reader common/test-fa-file)]
+        (doall (io/read r)))
+      [{:name "ref", :sequence "AGCATGTTAGATAAGATAGCTGTGCTAGTAGGCAGTCAGCGCCAT"}
+       {:name "ref2", :sequence "AGGTTTTATAAAACAATTAAGTCTACAGAGCAACTACGCG"}]))
+
+  (is
+   (= (with-open [r (core/reader common/test-fa-file)]
+        (doall (io/read r {})))
+      [{:name "ref", :sequence "AGCATGTTAGATAAGATAGCTGTGCTAGTAGGCAGTCAGCGCCAT"}
+       {:name "ref2", :sequence "AGGTTTTATAAAACAATTAAGTCTACAGAGCAACTACGCG"}]))
+
+  (is
+   (= (with-open [r (core/reader common/test-fa-file)]
+        (io/read-in-region r {:chr "ref" :start 1 :end 10}))
+      "AGCATGTTAG"))
+
+  (is
+   (= (with-open [r (core/reader common/test-fa-file)]
+        (io/read-sequence r {:chr "ref" :start 1 :end 10}))
+      "AGCATGTTAG")))
+
+(deftest twobit-io
+  (is
+   (= (with-open [r (core/reader common/test-twobit-file)]
+        (doall (io/read r)))
+      [{:name "ref", :sequence "AGCATGTTAGATAAGATAGCTGTGCTAGTAGGCAGTCAGCGCCAT"}
+       {:name "ref2", :sequence "AGGTTTTATAAAACAATTAAGTCTACAGAGCAACTACGCG"}]))
+
+  (is
+   (= (with-open [r (core/reader common/test-twobit-file)]
+        (doall (io/read r {:mask? true})))
+      [{:name "ref", :sequence "AGCATGTTAGATAAGATAGCTGTGCTAGTAGGCAGTCAGCGCCAT"}
+       {:name "ref2", :sequence "aggttttataaaacaattaagtctacagagcaactacgcg"}]))
+
+  (is
+   (= (with-open [r (core/reader common/test-twobit-file)]
+        (io/read-in-region r {:chr "ref" :start 1 :end 10}))
+      "AGCATGTTAG"))
+
+  (is
+   (= (with-open [r (core/reader common/test-twobit-file)]
+        (io/read-sequence r {:chr "ref" :start 1 :end 10}))
+      "AGCATGTTAG")))
+
+(deftest fastq-io
+  (is
+   (= (with-open [r (core/reader common/test-fq-file)]
+        (->> (io/read r) (map #(into {} %)) doall))
+      common/test-fq-sequences))
+
+  (is
+   (= (with-open [r (core/reader common/test-fq-file)]
+        (->> (io/read r {:decode-quality nil})
+             (map #(into {} %))
+             doall))
+      common/test-fq-sequences-raw)))
+
+(deftest vcf-io
+  (is
+   (= (with-open [r (core/reader common/test-vcf-v4_3-file)]
+        (doall (io/read r)))
+      common/test-vcf-v4_3-variants-deep))
+
+  (is
+   (= (with-open [r (core/reader common/test-vcf-v4_3-file)]
+        (doall (io/read-in-region r {:chr "20"})))
+      common/test-vcf-v4_3-variants-deep))
+
+  (is
+   (= (with-open [r (core/reader common/test-vcf-v4_3-file)]
+        (doall (io/read-in-region r {:chr "20" :start 1 :end 20000})))
+      (take 2 common/test-vcf-v4_3-variants-deep))))
+
+(deftest bcf-io
+  (is
+   (= (with-open [r (core/reader common/test-bcf-v4_3-file)]
+        (doall (io/read r)))
+      common/test-vcf-v4_3-variants-deep))
+
+  (is
+   (= (with-open [r (core/reader common/test-bcf-v4_3-file)]
+        (doall (io/read-in-region r {:chr "20"})))
+      common/test-vcf-v4_3-variants-deep))
+
+  (is
+   (= (with-open [r (core/reader common/test-bcf-v4_3-file)]
+        (doall (io/read-in-region r {:chr "20" :start 1 :end 20000})))
+      (take 2 common/test-vcf-v4_3-variants-deep))))
+
+(deftest bed-io
+  (is
+   (= (with-open [r (core/reader common/test-bed-file1)]
+        (doall (io/read r)))
+      [{:chr "chr22" :start 1001 :end 5000 :name "cloneA" :score 960 :strand :plus :thick-start 1001
+        :thick-end 5000 :item-rgb "0" :block-count 2 :block-sizes [567 488] :block-starts [0 3512]}
+       {:chr "chr22" :start 2001 :end 6000 :name "cloneB" :score 900 :strand :minus :thick-start 2001
+        :thick-end 6000 :item-rgb "0" :block-count 2 :block-sizes [433 399] :block-starts [0 3601]}])))
+

--- a/test/cljam/t_lsb.clj
+++ b/test/cljam/t_lsb.clj
@@ -1,6 +1,6 @@
 (ns cljam.t-lsb
   (:require [clojure.test :refer :all]
-            [clojure.java.io :as io]
+            [clojure.java.io :as cio]
             [cljam.t-common :as common]
             [cljam.lsb :as lsb])
   (:import [java.nio ByteBuffer ByteOrder]
@@ -248,7 +248,7 @@
   (common/with-before-after {:before (common/prepare-cache!)
                              :after (common/clean-cache!)}
     (let [filename (str common/temp-dir "raf.bin.gz")]
-      (with-open [bgzfos (BGZFOutputStream. (io/file filename))]
+      (with-open [bgzfos (BGZFOutputStream. (cio/file filename))]
         (let [bb (lsb/gen-byte-buffer 24)]
           (.putLong bb 0x789ABCDEF0123456)
           (doseq [c "ABCDEFGH"]
@@ -256,7 +256,7 @@
           (doseq [c [\I \J \K \L 0 \M \N \O]]
             (.put bb (byte c)))
           (.write bgzfos (.array bb))))
-      (with-open [bgzfis (BGZFInputStream. (io/file filename))]
+      (with-open [bgzfis (BGZFInputStream. (cio/file filename))]
         (.seek bgzfis 0)
         (is (= (lsb/read-byte bgzfis) 0x56))
         (is (= (lsb/read-byte bgzfis) 0x34))

--- a/test/cljam/t_sorter.clj
+++ b/test/cljam/t_sorter.clj
@@ -3,7 +3,8 @@
             [cljam.t-common :refer :all]
             [cljam.sam :as sam]
             [cljam.bam :as bam]
-            [cljam.sorter :as sorter]))
+            [cljam.sorter :as sorter])
+  (:import [java.io Closeable]))
 
 (def tmp-coordinate-sorted-sam-file (str temp-dir "/" "tmp.coordinate.sorted.sam"))
 (def tmp-coordinate-sorted-bam-file (str temp-dir "/" "tmp.coordinate.sorted.bam"))
@@ -41,9 +42,9 @@
                                  (str "invalid file suffix " dst-file))))
                   nil)]
     (if-not (nil? dst-wtr)
-      (with-open [src src-rdr
-                  dst dst-wtr] (target-fn src dst))
-      (with-open [src src-rdr] (target-fn src)))))
+      (with-open [src ^Closeable src-rdr
+                  dst ^Closeable dst-wtr] (target-fn src dst))
+      (with-open [src ^Closeable src-rdr] (target-fn src)))))
 
 (deftest about-sorting-a-sam-by-chromosomal-positions
   (with-before-after {:before (do (prepare-cache!)

--- a/test/cljam/t_twobit.clj
+++ b/test/cljam/t_twobit.clj
@@ -5,17 +5,17 @@
 
 (deftest twobit-reference
   (with-open [r (tb/reader test-twobit-file)]
-    (are [?arg ?result] (= (tb/read-sequence r ?arg) ?result)
-      {:chr "ref"} "AGCATGTTAGATAAGATAGCTGTGCTAGTAGGCAGTCAGCGCCAT"
-      {:chr "ref2"} "AGGTTTTATAAAACAATTAAGTCTACAGAGCAACTACGCG"
-      {:chr "ref2" :mask? true} "aggttttataaaacaattaagtctacagagcaactacgcg"
-      {:chr "ref" :start 1 :end 4} "AGCA"
-      {:chr "ref" :start 0 :end 4} "NAGCA"
-      {:chr "ref" :start 41 :end 50} "GCCATNNNNN"
-      {:chr "ref" :start 1 :end 45} "AGCATGTTAGATAAGATAGCTGTGCTAGTAGGCAGTCAGCGCCAT"
-      {:chr "ref2" :start 1 :end 40} "AGGTTTTATAAAACAATTAAGTCTACAGAGCAACTACGCG"
-      {:chr "ref2" :start 1 :end 40 :mask? true} "aggttttataaaacaattaagtctacagagcaactacgcg"
-      {:chr "chr1" :start 1 :end 40} nil)
+    (are [?region ?opt ?result] (= (tb/read-sequence r ?region ?opt) ?result)
+      {:chr "ref"} {} "AGCATGTTAGATAAGATAGCTGTGCTAGTAGGCAGTCAGCGCCAT"
+      {:chr "ref2"} {} "AGGTTTTATAAAACAATTAAGTCTACAGAGCAACTACGCG"
+      {:chr "ref2"} {:mask? true} "aggttttataaaacaattaagtctacagagcaactacgcg"
+      {:chr "ref" :start 1 :end 4} {} "AGCA"
+      {:chr "ref" :start 0 :end 4} {} "NAGCA"
+      {:chr "ref" :start 41 :end 50} {} "GCCATNNNNN"
+      {:chr "ref" :start 1 :end 45} {} "AGCATGTTAGATAAGATAGCTGTGCTAGTAGGCAGTCAGCGCCAT"
+      {:chr "ref2" :start 1 :end 40} {} "AGGTTTTATAAAACAATTAAGTCTACAGAGCAACTACGCG"
+      {:chr "ref2" :start 1 :end 40} {:mask? true} "aggttttataaaacaattaagtctacagagcaactacgcg"
+      {:chr "chr1" :start 1 :end 40} {} nil)
     (is (= (for [i (range 1 45) j (range i 46)]
              (tb/read-sequence r {:chr "ref" :start i :end j}))
            (for [i (range 1 45) j (range i 46)]
@@ -23,17 +23,17 @@
 
 (deftest twobit-reference-with-n
   (with-open [r (tb/reader test-twobit-n-file)]
-    (are [?arg ?result] (= (tb/read-sequence r ?arg) ?result)
-      {:chr "ref"} "NNNNNGTTAGATAAGATAGCNNTGCTAGTAGGCAGTCNNNNCCAT"
-      {:chr "ref2"} "AGNNNTTATAAAACAATTANNNCTACAGAGCAACTANNNN"
-      {:chr "ref2" :mask? true} "agNNNttataaaacaattaNNNctacagagcaactaNNNN"
-      {:chr "ref" :start 1 :end 4} "NNNN"
-      {:chr "ref" :start 0 :end 4} "NNNNN"
-      {:chr "ref" :start 41 :end 50} "NCCATNNNNN"
-      {:chr "ref" :start 1 :end 45} "NNNNNGTTAGATAAGATAGCNNTGCTAGTAGGCAGTCNNNNCCAT"
-      {:chr "ref2" :start 1 :end 40} "AGNNNTTATAAAACAATTANNNCTACAGAGCAACTANNNN"
-      {:chr "ref2" :start 1 :end 40 :mask? true} "agNNNttataaaacaattaNNNctacagagcaactaNNNN"
-      {:chr "chr1" :start 1 :end 40} nil)
+    (are [?region ?opt ?result] (= (tb/read-sequence r ?region ?opt) ?result)
+      {:chr "ref"} {} "NNNNNGTTAGATAAGATAGCNNTGCTAGTAGGCAGTCNNNNCCAT"
+      {:chr "ref2"} {} "AGNNNTTATAAAACAATTANNNCTACAGAGCAACTANNNN"
+      {:chr "ref2"} {:mask? true} "agNNNttataaaacaattaNNNctacagagcaactaNNNN"
+      {:chr "ref" :start 1 :end 4} {} "NNNN"
+      {:chr "ref" :start 0 :end 4} {} "NNNNN"
+      {:chr "ref" :start 41 :end 50} {} "NCCATNNNNN"
+      {:chr "ref" :start 1 :end 45} {} "NNNNNGTTAGATAAGATAGCNNTGCTAGTAGGCAGTCNNNNCCAT"
+      {:chr "ref2" :start 1 :end 40} {} "AGNNNTTATAAAACAATTANNNCTACAGAGCAACTANNNN"
+      {:chr "ref2" :start 1 :end 40} {:mask? true} "agNNNttataaaacaattaNNNctacagagcaactaNNNN"
+      {:chr "chr1" :start 1 :end 40} {} nil)
     (is (= (for [i (range 1 45) j (range i 46)]
              (tb/read-sequence r {:chr "ref" :start i :end j}))
            (for [i (range 1 45) j (range i 46)]

--- a/test/cljam/t_util.clj
+++ b/test/cljam/t_util.clj
@@ -24,3 +24,32 @@
   (is (instance? Integer (util/str->int "123")))
   (is (instance? Long (util/str->int "12345678901")))
   (is (= (util/str->int "12345678901") 12345678901)))
+
+(deftest divide-region
+  (are [?start ?end ?step ?expected]
+      (= (util/divide-region ?start ?end ?step) ?expected)
+    1 10 1 [[1 1] [2 2] [3 3] [4 4] [5 5] [6 6] [7 7] [8 8] [9 9] [10 10]]
+    1 10 2 [[1 2] [3 4] [5 6] [7 8] [9 10]]
+    1 10 3 [[1 3] [4 6] [7 9] [10 10]]
+    1 10 4 [[1 4] [5 8] [9 10]]
+    1 10 5 [[1 5] [6 10]]
+    1 10 6 [[1 6] [7 10]]
+    1 10 7 [[1 7] [8 10]]
+    1 10 8 [[1 8] [9 10]]
+    1 10 9 [[1 9] [10 10]]
+    1 10 10 [[1 10]]
+    1 10 11 [[1 10]]))
+
+(deftest divide-refs
+  (are [?refs ?step ?expected]
+      (= (util/divide-refs ?refs ?step) ?expected)
+    [{:name "chr1" :len 10}] 4 [{:chr "chr1" :start 1 :end 4}
+                                {:chr "chr1" :start 5 :end 8}
+                                {:chr "chr1" :start 9 :end 10}]
+    [{:name "chr1" :len 10}] 5 [{:chr "chr1" :start 1 :end 5}
+                                {:chr "chr1" :start 6 :end 10}]
+    [{:name "chr1" :len 10}] 10 [{:chr "chr1" :start 1 :end 10}]
+    [{:name "chr1" :len 10}
+     {:name "chr2" :len 5}] 6 [{:chr "chr1" :start 1 :end 6}
+                               {:chr "chr1" :start 7 :end 10}
+                               {:chr "chr2" :start 1 :end 5}]))

--- a/test/cljam/t_vcf.clj
+++ b/test/cljam/t_vcf.clj
@@ -10,7 +10,7 @@
   (with-open [rdr (vcf/reader f)]
     {:meta-info (vcf/meta-info rdr)
      :header (vcf/header rdr)
-     :variants (doall (vcf/read-variants rdr :depth (or depth :deep)))}))
+     :variants (doall (vcf/read-variants rdr {:depth (or depth :deep)}))}))
 
 (defn- spit-vcf-for-test
   [f meta-info header variants]


### PR DESCRIPTION
**This PR includes breaking changes**

#### Summary
This PR adds new protocols for I/O classes for the sake of
- Abstraction of concrete implementation of file formats
- Improving consistency of APIs
- Convenience for REPL use

#### Changes
- Add protocols to `cljam.io`
- Modify readers/writers to conform to the protocols
- Modify arguments to take region map like `{:chr "chr1", :start 1, :end 3}` and option as another map if required.
- Add util function for manipulating region map.
- Use unique aliases: `cio` for `clojure.java.io` and `io` for `cljam.io`
- Replace vararg `[& {:keys [...]}]` with map `[{:keys [...]}]`
- Arity overloadings default to call same fn with larger arity

#### Problems
`read-in-region` reads contents in certain region.
In current implementation, readers without index (SAM, VCF...) are still supporting the function by `filter`.
Even though they will warn about performance, I'm still thinking if we should disable this.