### PR TITLE
Add FASTAWriter and TwoBitWriter.

### DIFF
--- a/src/cljam/core.clj
+++ b/src/cljam/core.clj
@@ -77,15 +77,30 @@
   [rdr]
   (satisfies? cljam.io/ISequenceReader rdr))
 
+(defn sequence-writer?
+  "Checks if given object implements protocol ISequenceWriter."
+  [wtr]
+  (satisfies? cljam.io/ISequenceWriter wtr))
+
 (defn fasta-reader?
   "Checks if given object is an instance of FASTAReader."
   [rdr]
   (instance? cljam.fasta.reader.FASTAReader rdr))
 
+(defn fasta-writer?
+  "Checks if given object is an instance of FASTAWriter."
+  [wtr]
+  (instance? cljam.fasta.writer.FASTAWriter wtr))
+
 (defn twobit-reader?
   "Checks if given object is an instance of TwoBitReader."
   [rdr]
-  (instance? cljam.twobit.TwoBitReader rdr))
+  (instance? cljam.twobit.reader.TwoBitReader rdr))
+
+(defn twobit-writer?
+  "Checks if given object is an instance of TwoBitWriter."
+  [wtr]
+  (instance? cljam.twobit.writer.TwoBitWriter wtr))
 
 (defn fastq-reader?
   "Checks if given object is an instance of FASTQReader."
@@ -145,11 +160,13 @@
 
 (defn ^Closeable writer
   "Selects suitable writer from f's extension, returning the writer.
-  This function supports SAM,BAM,FASTQ,VCF,BCF and BED format."
+  This function supports SAM,BAM,FASTA,2BIT,FASTQ,VCF,BCF and BED format."
   [f & args]
   (case (file-type f)
     :sam (sam/writer f)
     :bam (bam/writer f)
+    :fasta (apply fasta/writer f args)
+    :2bit (twobit/writer f)
     :fastq (fastq/writer f)
     :vcf (apply vcf/writer f args)
     :bcf (apply bcf/writer f args)

--- a/src/cljam/fasta.clj
+++ b/src/cljam/fasta.clj
@@ -2,8 +2,13 @@
   "Alpha - subject to change.
   Reader of a FASTA format file."
   (:refer-clojure :exclude [read])
-  (:require [cljam.fasta.core :as fa-core])
-  (:import [cljam.fasta.reader FASTAReader]))
+  (:require [cljam.fasta.core :as fa-core]
+            [cljam.fasta.writer :as fa-writer])
+  (:import [cljam.fasta.reader FASTAReader]
+           [cljam.fasta.writer FASTAWriter]))
+
+;; Reading
+;; -------
 
 (defn ^FASTAReader reader
   "Returns an open cljam.fasta.reader.FASTAReader of f with options.
@@ -50,3 +55,23 @@
    Supporting raw (.fa) and compressed FASTA (.fa.gz, .fa.bz2, etc.)."
   [^String f]
   (fa-core/sequential-read f))
+
+;; Writing
+;; -------
+
+(defn ^FASTAWriter writer
+  "Returns an open cljam.fasta.FASTAWriter of f.
+  The options:
+    :cols - Maximum number of characters written in one row.
+    :create-index? - If true, .fai will be created simultaneously.
+  Should be used inside with-open to ensure the Writer is properly closed."
+  ([f]
+   (writer f {}))
+  ([f option]
+   (fa-writer/writer f option)))
+
+(defn write-sequences
+  "Write sequences to wtr. seqs must be a sequence of map containing (and (or :name :rname) (or :seq :sequence)).
+  :sequence can be a String or a sequential collection of characters."
+  [wtr seqs]
+  (fa-writer/write-sequences wtr seqs))

--- a/src/cljam/fasta/core.clj
+++ b/src/cljam/fasta/core.clj
@@ -65,8 +65,8 @@
   io/IReader
   (reader-path [this] (.f this))
   (read
-    ([this] (sequential-read (.f this)))
-    ([this option] (sequential-read (.f this))))
+    ([this] (io/read this {}))
+    ([this option] (io/read-all-sequences this option)))
   io/IRegionReader
   (read-in-region
     ([this region]
@@ -74,6 +74,10 @@
     ([this region option]
      (io/read-sequence this region option)))
   io/ISequenceReader
+  (read-all-sequences
+    ([this] (io/read-all-sequences this {}))
+    ([this option]
+     (sequential-read (.f this))))
   (read-sequence
     ([this region]
      (io/read-sequence this region {}))

--- a/src/cljam/fasta/writer.clj
+++ b/src/cljam/fasta/writer.clj
@@ -1,0 +1,80 @@
+(ns cljam.fasta.writer
+  (:require [clojure.java.io :as cio]
+            [clojure.string :as cstr]
+            [cljam.util :as util]
+            [cljam.io :as io])
+  (:import [java.io Closeable BufferedWriter]))
+
+(declare write-sequences)
+
+(deftype FASTAWriter [f ^int cols writer index-writer curr-offset]
+  Closeable
+  (close [this]
+    (.close ^Closeable (.writer this))
+    (when-let [iw (.index-writer this)]
+      (.close ^Closeable iw)))
+  io/IWriter
+  (writer-path [this]
+    (.f this))
+  io/ISequenceWriter
+  (write-sequences [this seqs]
+    (write-sequences this seqs)))
+
+(defn writer [f {:keys [cols create-index?]
+                 :or {cols 80 create-index? true}}]
+  (let [abs-f (.getAbsolutePath (cio/file f))
+        writer (cio/writer (util/compressor-output-stream abs-f))
+        index-writer (when create-index? (cio/writer (str abs-f ".fai")))]
+    (FASTAWriter. abs-f cols writer index-writer (volatile! 0))))
+
+(defn- write-name
+  [^FASTAWriter w ^String n]
+  (let [wtr ^BufferedWriter (.writer w)]
+    (.write wtr (int \>))
+    (.write wtr n)
+    (.newLine wtr)
+    (+ 1 (.length n) (.length (System/lineSeparator)))))
+
+(defn- write-seq-str
+  [^FASTAWriter w ^String s]
+  (let [wtr ^BufferedWriter (.writer w)
+        l ^int (.length s)
+        c (.cols w)
+        n (quot (dec (+ l c)) c)]
+    (dotimes [i n]
+      (.write wtr s (int (* i c)) (int (if (= i (dec n)) (- l (* c i)) c)))
+      (.newLine wtr))
+    [l (+ l (* n (.length (System/lineSeparator))))]))
+
+(defn- write-seq
+  [^FASTAWriter w col]
+  (let [wtr ^BufferedWriter (.writer w)
+        nl-size (.length (System/lineSeparator))]
+    (loop [seq-len 0 written 0 xs (partition-all (.cols w) col)]
+      (if-let [x (first xs)]
+        (do (.write wtr (cstr/join x))
+            (.newLine wtr)
+            (recur (+ seq-len (count x)) (+ written nl-size (count x)) (next xs)))
+        [seq-len written]))))
+
+(defn- write-sequence
+  [^FASTAWriter w {:keys [name rname seq sequence]}]
+  (let [chr-name (or name rname)
+        seq-data (or seq sequence)
+        name-bytes (write-name w chr-name)
+        [seq-len seq-bytes] (if (string? seq-data)
+                              (write-seq-str w seq-data)
+                              (write-seq w seq-data))]
+    (when-let [iwtr ^BufferedWriter (.index-writer w)]
+      (let [c (Math/min (.cols w) (int seq-len))
+            offset (+ @(.curr-offset w) name-bytes)]
+        (->> [chr-name seq-len offset c (+ c (.length (System/lineSeparator)))]
+             (cstr/join \tab)
+             (.write iwtr))
+        (.newLine iwtr)
+        (vswap! (.curr-offset w) + name-bytes seq-bytes)))))
+
+(defn write-sequences
+  [w xs]
+  (doseq [x xs]
+    (write-sequence w x)))

--- a/src/cljam/io.clj
+++ b/src/cljam/io.clj
@@ -52,5 +52,11 @@
     "Writes variants to thee VCF/BCF file."))
 
 (defprotocol ISequenceReader
+  (read-all-sequences [this] [this option]
+    "Reads all sequences of FASTA/2BIT file.")
   (read-sequence [this region] [this region option]
-    "Reads all sequences of FASTA/2BIT file."))
+    "Reads sequence in region of FASTA/2BIT file."))
+
+(defprotocol ISequenceWriter
+  (write-sequences [this seqs]
+    "Writes all sequences to FASTA/2BIT file."))

--- a/src/cljam/twobit.clj
+++ b/src/cljam/twobit.clj
@@ -1,158 +1,45 @@
 (ns cljam.twobit
-  (:require [clojure.string :as cstr]
-            [clojure.java.io :as cio]
-            [cljam.io :as io]
-            [cljam.lsb :as lsb]
-            [cljam.util :as util])
-  (:import [java.io Closeable DataInput RandomAccessFile]
-           [java.nio CharBuffer]))
+  (:require [cljam.twobit.reader :as tb-reader]
+            [cljam.twobit.writer :as tb-writer])
+  (:import [cljam.twobit.reader TwoBitReader]
+           [cljam.twobit.writer TwoBitWriter]))
 
-(defrecord TwoBitReader [^RandomAccessFile reader ^String f endian file-index seq-index]
-  Closeable
-  (close [this]
-    (.close ^Closeable (.reader this))))
+;; Reading
+;; -------
 
-(defn- read-file-header!
-  [^DataInput rdr]
-  (let [sig (.readInt rdr)
-        endian (case sig
-                 0x1A412743 :big
-                 0x4327411A :little
-                 :else nil)]
-    (when endian
-      (let [read-fn (case endian :big #(.readInt ^DataInput %) :little lsb/read-int)
-            ver (read-fn rdr)
-            nseq (read-fn rdr)
-            zero (read-fn rdr)]
-        (when (and (zero? ver) (zero? zero))
-          [endian nseq])))))
-
-(defn- read-index!
-  [^DataInput rdr endian]
-  (let [name-size (case endian
-                    :little (lsb/read-ubyte rdr)
-                    :big (.readUnsignedByte rdr))
-        name-str (case endian
-                   :little (lsb/read-string rdr name-size)
-                   :big (let [ba (byte-array name-size)]
-                          (.readFully rdr ba)
-                          (String. ba)))
-        offset (case endian
-                 :little (lsb/read-int rdr)
-                 :big (.readInt rdr))]
-    {:name name-str
-     :offset offset}))
-
-(defn- read-sequence-header!
-  [^DataInput rdr endian]
-  (let [read-fn (case endian :little lsb/read-int :big #(.readInt ^DataInput %))
-        dna-size (read-fn rdr)
-        n-block-count (read-fn rdr)
-        n-block-starts (doall (repeatedly n-block-count #(inc (read-fn rdr))))
-        n-block-sizes (doall (repeatedly n-block-count #(read-fn rdr)))
-        mask-block-count (read-fn rdr)
-        mask-block-starts (doall (repeatedly mask-block-count #(inc (read-fn rdr))))
-        mask-block-sizes (doall (repeatedly mask-block-count #(read-fn rdr)))
-        zero (read-fn rdr)]
-    {:len dna-size
-     :ambs (mapv vector n-block-starts n-block-sizes)
-     :masks (mapv vector mask-block-starts mask-block-sizes)
-     :header-offset (+ 16 (* n-block-count 4 2) (* mask-block-count 4 2))}))
-
-(def ^:const twobit-to-str
-  (let [table "TCAG"]
-    (mapv
-     (fn [j] (let [i (byte (- j 128))
-                   n4 (bit-and i 2r11)
-                   n3 (bit-and (unsigned-bit-shift-right i 2) 2r11)
-                   n2 (bit-and (unsigned-bit-shift-right i 4) 2r11)
-                   n1 (bit-and (unsigned-bit-shift-right i 6) 2r11)]
-               (str (.charAt table n1) (.charAt table n2) (.charAt table n3) (.charAt table n4))))
-     (range 256))))
-
-(defn replace-ambs!
-  "Replace regions of charbuffer with Ns."
-  [^CharBuffer cb ambs ^long start ^long end]
-  (doseq [[^long n-start ^long n-size] ambs]
-    (when-not (or (< end n-start) (< (+ n-start n-size -1) start))
-      (.position cb (max 0 (- n-start start)))
-      (dotimes [_ (- (min end (+ n-start n-size -1)) (max start n-start) -1)]
-        (.put cb \N)))))
-
-(defn mask!
-  "Mask regions of given charbuffer."
-  [^CharBuffer cb masks ^long start ^long end]
-  (doseq [[^long m-start ^long m-size] masks]
-    (when-not (or (< end m-start) (< (+ m-start m-size -1) start))
-      (.position cb (max 0 (- m-start start)))
-      (.mark cb)
-      (let [ca (char-array (- (min end (+ m-start m-size -1)) (max start m-start) -1))]
-        (.get cb ca)
-        (.reset cb)
-        (dotimes [i (alength ca)]
-          (.put cb (char (+ (int (aget ca i)) 32)))))))) ;; lower case character
+(defn ^TwoBitReader reader
+  "Returns an open cljam.twobit.reader.TwoBitReader of f.
+  Should be used inside with-open to ensure the Reader is properly closed."
+  [f]
+  (tb-reader/reader f))
 
 (defn ^String read-sequence
   "Reads sequence at the given region from reader.
    Pass {:mask? true} to enable masking of sequence."
   ([rdr region]
    (read-sequence rdr region {}))
-  ([^TwoBitReader rdr {:keys [chr start end]} {:keys [mask?] :or {mask? false}}]
-   (when-let [[n {:keys [offset]}]
-              (first (filter (fn [[i {:keys [name]}]] (= name chr)) (map vector (range) (.file-index rdr))))]
-     (let [{:keys [len ambs masks header-offset]} @(nth (.seq-index rdr) n) ;; Potential seek & read.
-           start' (or start 1)
-           end' (or end len)
-           start-offset (quot (dec (max 1 start')) 4)
-           end-offset (quot (dec (min len end')) 4)
-           ba (byte-array (- end-offset start-offset -1))
-           cb (CharBuffer/allocate (inc (- end' start')))]
-       (.seek ^RandomAccessFile (.reader rdr) (+ offset header-offset start-offset))
-       (.readFully ^RandomAccessFile (.reader rdr) ba)
-       (dotimes [out-pos (inc (- end' start'))]
-         (let [ref-pos (+ out-pos start')
-               ba-pos (- (quot (dec ref-pos) 4) start-offset)
-               bit-pos (mod (dec ref-pos) 4)]
-           (if (<= 1 ref-pos len)
-             (.put cb (.charAt ^String (twobit-to-str (+ (aget ba ba-pos) 128)) bit-pos))
-             (.put cb \N))))
-       (when mask? (mask! cb masks start' end'))
-       (replace-ambs! cb ambs start' end')
-       (.rewind cb)
-       (.toString cb)))))
+  ([rdr region option]
+   (tb-reader/read-sequence rdr region option)))
 
-(extend-type TwoBitReader
-  io/IReader
-  (reader-path [this] (.f this))
-  (read
-    ([this] (io/read this {}))
-    ([this option]
-     (for [{:keys [name offset]} (.file-index this)]
-       {:name name :sequence (read-sequence this {:chr name} option)})))
-  io/ISequenceReader
-  (read-sequence
-    (^String [this region]
-     (io/read-sequence this region {}))
-    (^String [this region option]
-     (read-sequence this region option)))
-  io/IRegionReader
-  (read-in-region
-    (^String [this region]
-     (io/read-in-region this region {}))
-    (^String [this {:keys [chr start end] :as region} option]
-     (read-sequence this region option))))
+(defn read-all-sequences
+  "Reads all sequences in file and returns as a sequence of maps.
+   Pass {:mask? true} to enable masking of sequence."
+  ([rdr]
+   (read-all-sequences rdr {}))
+  ([rdr option]
+   (tb-reader/read-all-sequences rdr option)))
 
-(defn ^TwoBitReader reader
-  "Returns .2bit file reader of f."
-  [^String f]
-  (let [abs-f (.getAbsolutePath (cio/file f))
-        rdr (RandomAccessFile. abs-f "r")
-        [endian nseq] (read-file-header! rdr)]
-    (when (and endian nseq)
-      (let [indices (vec (repeatedly nseq #(read-index! rdr endian)))
-            seq-indices (mapv (fn [{:keys [offset] :as m}]
-                                (delay
-                                 (.seek rdr offset)
-                                 (read-sequence-header! rdr endian)))
-                              indices)]
-        (TwoBitReader. rdr abs-f endian indices seq-indices)))))
+;; Writing
+;; -------
+
+(defn ^TwoBitWriter writer
+  "Returns an open cljam.twobit.writer.TwoBitWriter of f.
+  Should be used inside with-open to ensure the Writer is properly closed."
+  [f]
+  (tb-writer/writer f))
+
+(defn write-sequences
+  "Write sequences to writer.
+  Input seqs must be a sequence of maps containing {:name , :sequence}."
+  [wtr seqs]
+  (tb-writer/write-sequences wtr seqs))

--- a/src/cljam/twobit/reader.clj
+++ b/src/cljam/twobit/reader.clj
@@ -1,0 +1,166 @@
+(ns cljam.twobit.reader
+  (:require [clojure.java.io :as cio]
+            [cljam.io :as io]
+            [cljam.lsb :as lsb])
+  (:import [java.io Closeable DataInput RandomAccessFile]
+           [java.nio CharBuffer]))
+
+(defrecord TwoBitReader [^RandomAccessFile reader ^String f endian file-index seq-index]
+  Closeable
+  (close [this]
+    (.close ^Closeable (.reader this))))
+
+(defn- read-file-header!
+  [^DataInput rdr]
+  (let [sig (.readInt rdr)
+        endian (case sig
+                 0x1A412743 :big
+                 0x4327411A :little
+                 :else nil)]
+    (when endian
+      (let [read-fn (case endian :big #(.readInt ^DataInput %) :little lsb/read-int)
+            ver (read-fn rdr)
+            nseq (read-fn rdr)
+            zero (read-fn rdr)]
+        (when (and (zero? ver) (zero? zero))
+          [endian nseq])))))
+
+(defn- read-index!
+  [^DataInput rdr endian]
+  (let [name-size (case endian
+                    :little (lsb/read-ubyte rdr)
+                    :big (.readUnsignedByte rdr))
+        name-str (case endian
+                   :little (lsb/read-string rdr name-size)
+                   :big (let [ba (byte-array name-size)]
+                          (.readFully rdr ba)
+                          (String. ba)))
+        offset (case endian
+                 :little (lsb/read-int rdr)
+                 :big (.readInt rdr))]
+    {:name name-str
+     :offset offset}))
+
+(defn- read-sequence-header!
+  [^DataInput rdr endian]
+  (let [read-fn (case endian :little lsb/read-int :big #(.readInt ^DataInput %))
+        dna-size (read-fn rdr)
+        n-block-count (read-fn rdr)
+        n-block-starts (doall (repeatedly n-block-count #(inc (read-fn rdr))))
+        n-block-sizes (doall (repeatedly n-block-count #(read-fn rdr)))
+        mask-block-count (read-fn rdr)
+        mask-block-starts (doall (repeatedly mask-block-count #(inc (read-fn rdr))))
+        mask-block-sizes (doall (repeatedly mask-block-count #(read-fn rdr)))
+        zero (read-fn rdr)]
+    {:len dna-size
+     :ambs (mapv vector n-block-starts n-block-sizes)
+     :masks (mapv vector mask-block-starts mask-block-sizes)
+     :header-offset (+ 16 (* n-block-count 4 2) (* mask-block-count 4 2))}))
+
+(def ^:const twobit-to-str
+  (let [table "TCAG"]
+    (mapv
+     (fn [j] (let [i (byte (- j 128))
+                   n4 (bit-and i 2r11)
+                   n3 (bit-and (unsigned-bit-shift-right i 2) 2r11)
+                   n2 (bit-and (unsigned-bit-shift-right i 4) 2r11)
+                   n1 (bit-and (unsigned-bit-shift-right i 6) 2r11)]
+               (str (.charAt table n1) (.charAt table n2) (.charAt table n3) (.charAt table n4))))
+     (range 256))))
+
+(defn replace-ambs!
+  "Replace regions of charbuffer with Ns."
+  [^CharBuffer cb ambs ^long start ^long end]
+  (doseq [[^long n-start ^long n-size] ambs]
+    (when-not (or (< end n-start) (< (+ n-start n-size -1) start))
+      (.position cb (max 0 (- n-start start)))
+      (dotimes [_ (- (min end (+ n-start n-size -1)) (max start n-start) -1)]
+        (.put cb \N)))))
+
+(defn mask!
+  "Mask regions of given charbuffer."
+  [^CharBuffer cb masks ^long start ^long end]
+  (doseq [[^long m-start ^long m-size] masks]
+    (when-not (or (< end m-start) (< (+ m-start m-size -1) start))
+      (.position cb (max 0 (- m-start start)))
+      (.mark cb)
+      (let [ca (char-array (- (min end (+ m-start m-size -1)) (max start m-start) -1))]
+        (.get cb ca)
+        (.reset cb)
+        (dotimes [i (alength ca)]
+          (.put cb (char (+ (int (aget ca i)) 32)))))))) ;; lower case character
+
+(defn ^String read-sequence
+  "Reads sequence at the given region from reader.
+   Pass {:mask? true} to enable masking of sequence."
+  ([rdr region]
+   (read-sequence rdr region {}))
+  ([^TwoBitReader rdr {:keys [chr start end]} {:keys [mask?] :or {mask? false}}]
+   (when-let [[n {:keys [offset]}]
+              (first (filter (fn [[i {:keys [name]}]] (= name chr)) (map vector (range) (.file-index rdr))))]
+     (let [{:keys [len ambs masks header-offset]} @(nth (.seq-index rdr) n) ;; Potential seek & read.
+           start' (or start 1)
+           end' (or end len)
+           start-offset (quot (dec (max 1 start')) 4)
+           end-offset (quot (dec (min len end')) 4)
+           ba (byte-array (- end-offset start-offset -1))
+           cb (CharBuffer/allocate (inc (- end' start')))]
+       (.seek ^RandomAccessFile (.reader rdr) (+ offset header-offset start-offset))
+       (.readFully ^RandomAccessFile (.reader rdr) ba)
+       (dotimes [out-pos (inc (- end' start'))]
+         (let [ref-pos (+ out-pos start')
+               ba-pos (- (quot (dec ref-pos) 4) start-offset)
+               bit-pos (mod (dec ref-pos) 4)]
+           (if (<= 1 ref-pos len)
+             (.put cb (.charAt ^String (twobit-to-str (+ (aget ba ba-pos) 128)) bit-pos))
+             (.put cb \N))))
+       (when mask? (mask! cb masks start' end'))
+       (replace-ambs! cb ambs start' end')
+       (.rewind cb)
+       (.toString cb)))))
+
+(defn read-all-sequences
+  "Reads all sequences in file."
+  ([rdr]
+   (read-all-sequences rdr {}))
+  ([^TwoBitReader rdr option]
+   (for [{:keys [name offset]} (.file-index rdr)]
+     {:name name :sequence (read-sequence rdr {:chr name} option)})))
+
+(extend-type TwoBitReader
+  io/IReader
+  (reader-path [this] (.f this))
+  (read
+    ([this] (io/read this {}))
+    ([this option] (io/read-all-sequences this option)))
+  io/ISequenceReader
+  (read-all-sequences
+    ([this] (io/read-all-sequences this {}))
+    ([this option]
+     (read-all-sequences this option)))
+  (read-sequence
+    (^String [this region]
+     (io/read-sequence this region {}))
+    (^String [this region option]
+     (read-sequence this region option)))
+  io/IRegionReader
+  (read-in-region
+    (^String [this region]
+     (io/read-in-region this region {}))
+    (^String [this {:keys [chr start end] :as region} option]
+     (read-sequence this region option))))
+
+(defn ^TwoBitReader reader
+  "Returns .2bit file reader of f."
+  [^String f]
+  (let [abs-f (.getAbsolutePath (cio/file f))
+        rdr (RandomAccessFile. abs-f "r")
+        [endian nseq] (read-file-header! rdr)]
+    (when (and endian nseq)
+      (let [indices (vec (repeatedly nseq #(read-index! rdr endian)))
+            seq-indices (mapv (fn [{:keys [offset] :as m}]
+                                (delay
+                                 (.seek rdr offset)
+                                 (read-sequence-header! rdr endian)))
+                              indices)]
+        (TwoBitReader. rdr abs-f endian indices seq-indices)))))

--- a/src/cljam/twobit/writer.clj
+++ b/src/cljam/twobit/writer.clj
@@ -1,0 +1,161 @@
+(ns cljam.twobit.writer
+  (:require [clojure.java.io :as cio]
+            [cljam.io :as io]
+            [cljam.lsb :as lsb])
+  (:import [java.io Closeable OutputStream DataOutputStream BufferedOutputStream FileOutputStream]
+           [java.nio ByteBuffer]))
+
+(declare write-sequences)
+
+(deftype TwoBitWriter [f writer]
+  Closeable
+  (close [this]
+    (.close ^Closeable (.writer this)))
+  io/IWriter
+  (writer-path [this]
+    (.f this))
+  io/ISequenceWriter
+  (write-sequences [this seqs]
+    (write-sequences this seqs)))
+
+(defn writer
+  "Returns a 2bit writer of f."
+  [f]
+  (let [abs-f (.getAbsolutePath (cio/file f))
+        fos (FileOutputStream. abs-f)
+        bos (BufferedOutputStream. fos)
+        dos (DataOutputStream. bos)]
+    (TwoBitWriter. abs-f dos)))
+
+(defn- write-file-header!
+  "Writes a 2bit file header. Supports little-endian only."
+  [w nseq]
+  (lsb/write-int w 0x1A412743)
+  (lsb/write-int w 0)
+  (lsb/write-int w nseq)
+  (lsb/write-int w 0))
+
+(defn- mask-regions
+  "Returns a sequence of [start length] of masked regions."
+  [^String s]
+  (let [len (.length s)]
+    (loop [r (transient [])
+           p nil
+           l nil
+           i 0]
+      (if (= i len)
+        (if p
+          (persistent! (conj! r [p l]))
+          (persistent! r))
+        (if (<= (int \a) (int (.charAt s (int i))))
+          (if p
+            (recur r p (inc l) (inc i))
+            (recur r i 1 (inc i)))
+          (if p
+            (recur (conj! r [p l]) nil nil (inc i))
+            (recur r nil nil (inc i))))))))
+
+(defn- amb-regions
+  "Returns a sequence of [start length] of N regions."
+  [^String s]
+  (let [len (.length s)]
+    (loop [r (transient [])
+           p nil
+           l nil
+           i 0]
+      (if (= i len)
+        (if p
+          (persistent! (conj! r [p l]))
+          (persistent! r))
+        (if (= \N (.charAt s (int i)))
+          (if p
+            (recur r p (inc l) (inc i))
+            (recur r i 1 (inc i)))
+          (if p
+            (recur (conj! r [p l]) nil nil (inc i))
+            (recur r nil nil (inc i))))))))
+
+(defn- index-size
+  "Number of bytes required for index."
+  [seqs]
+  (-> (fn [{:keys [name]}]
+        (+ 1 (count name) 4))
+      map
+      (transduce + 0 seqs)))
+
+(defn- write-index!
+  "Writes index section to writer."
+  [w seqs]
+  (loop [offset (+ (* 4 4) (index-size seqs)) xs seqs]
+    (when-let [{:keys [name sequence masks ambs]} (first xs)]
+      (let [header-size (+ 4 4 (* 2 4 (count ambs)) 4 (* 2 4 (count masks)) 4)
+            seq-size (quot (dec (+ (count sequence) 4)) 4)]
+        (lsb/write-ubyte w (count name))
+        (lsb/write-string w name)
+        (lsb/write-int w offset)
+        (recur (+ offset header-size seq-size) (next xs))))))
+
+(def ^:private
+  char->twobit
+  (doto (byte-array 128)
+    (aset-byte (int \C) 1)
+    (aset-byte (int \c) 1)
+    (aset-byte (int \A) 2)
+    (aset-byte (int \a) 2)
+    (aset-byte (int \G) 3)
+    (aset-byte (int \g) 3)))
+
+(defn write-twobit!
+  "Encodes a sequence into twobit format."
+  [^OutputStream o ^String s]
+  (let [len (.length s)
+        bb (ByteBuffer/wrap (.getBytes s))
+        table ^bytes char->twobit]
+    (dotimes [_ (quot len 4)]
+      (->> (bit-or
+            (bit-shift-left (aget table (.get bb)) 6)
+            (bit-shift-left (aget table (.get bb)) 4)
+            (bit-shift-left (aget table (.get bb)) 2)
+            (aget table (.get bb)))
+           unchecked-int
+           (.write o)))
+    (when (pos? (mod len 4))
+      (loop [b 0 i (mod len 4)]
+        (if (pos? i)
+          (recur (bit-or b (bit-shift-left (aget table (.get bb)) (* 2 (- 4 i)))) (dec i))
+          (.write o (unchecked-int b)))))))
+
+(defn- write-sequence!
+  "Writes a single sequence entry to writer."
+  [w {:keys [sequence masks ambs]}]
+  (let []
+    (lsb/write-int w (count sequence))
+    (lsb/write-int w (count ambs))
+    (doseq [[s _] ambs]
+      (lsb/write-int w s))
+    (doseq [[_ l] ambs]
+      (lsb/write-int w l))
+    (lsb/write-int w (count masks))
+    (doseq [[s _] masks]
+      (lsb/write-int w s))
+    (doseq [[_ l] masks]
+      (lsb/write-int w l))
+    (lsb/write-int w 0)
+    (write-twobit! w sequence)))
+
+(defn write-sequences
+  "Write all sequences to wtr.
+  Input sequences must be a sequence of maps."
+  [^TwoBitWriter wtr xs]
+  (let [seqs (map (fn [{:keys [name rname seq sequence]}]
+                    (let [chr-name (or name rname)
+                          seq-data (or seq sequence)]
+                      {:name chr-name
+                       :sequence seq-data
+                       :masks (mask-regions seq-data)
+                       :ambs (amb-regions seq-data)}))
+                  xs)]
+    (write-file-header! (.writer wtr) (count xs))
+    (write-index! (.writer wtr) seqs)
+    (doseq [s seqs]
+      (write-sequence! (.writer wtr) s))))

--- a/test/cljam/t_core.clj
+++ b/test/cljam/t_core.clj
@@ -199,6 +199,9 @@
       core/alignment-writer? true
       core/sam-writer? true
       core/bam-writer? false
+      core/sequence-writer? false
+      core/fasta-writer? false
+      core/twobit-writer? false
       core/variant-writer? false
       core/vcf-writer? false
       core/bcf-writer? false
@@ -211,6 +214,39 @@
       core/alignment-writer? true
       core/sam-writer? false
       core/bam-writer? true
+      core/sequence-writer? false
+      core/fasta-writer? false
+      core/twobit-writer? false
+      core/variant-writer? false
+      core/vcf-writer? false
+      core/bcf-writer? false
+      core/fastq-writer? false
+      core/bed-writer? false))
+
+  (with-open [r (core/writer (.getAbsolutePath (cio/file util/temp-dir "temp.fa")))]
+    (are [?pred ?expected]
+        (= (?pred r) ?expected)
+      core/alignment-writer? false
+      core/sam-writer? false
+      core/bam-writer? false
+      core/sequence-writer? true
+      core/fasta-writer? true
+      core/twobit-writer? false
+      core/variant-writer? false
+      core/vcf-writer? false
+      core/bcf-writer? false
+      core/fastq-writer? false
+      core/bed-writer? false))
+
+  (with-open [r (core/writer (.getAbsolutePath (cio/file util/temp-dir "temp.2bit")))]
+    (are [?pred ?expected]
+        (= (?pred r) ?expected)
+      core/alignment-writer? false
+      core/sam-writer? false
+      core/bam-writer? false
+      core/sequence-writer? true
+      core/fasta-writer? false
+      core/twobit-writer? true
       core/variant-writer? false
       core/vcf-writer? false
       core/bcf-writer? false
@@ -223,6 +259,9 @@
       core/alignment-writer? false
       core/sam-writer? false
       core/bam-writer? false
+      core/sequence-writer? false
+      core/fasta-writer? false
+      core/twobit-writer? false
       core/variant-writer?  true
       core/vcf-writer? true
       core/bcf-writer? false
@@ -235,6 +274,9 @@
       core/alignment-writer? false
       core/sam-writer? false
       core/bam-writer? false
+      core/sequence-writer? false
+      core/fasta-writer? false
+      core/twobit-writer? false
       core/variant-writer?  true
       core/vcf-writer? false
       core/bcf-writer? true
@@ -247,6 +289,9 @@
       core/alignment-writer? false
       core/sam-writer? false
       core/bam-writer? false
+      core/sequence-writer? false
+      core/fasta-writer? false
+      core/twobit-writer? false
       core/variant-writer?  false
       core/vcf-writer? false
       core/bcf-writer? false
@@ -259,6 +304,9 @@
       core/alignment-writer? false
       core/sam-writer? false
       core/bam-writer? false
+      core/sequence-writer? false
+      core/fasta-writer? false
+      core/twobit-writer? false
       core/variant-writer?  false
       core/vcf-writer? false
       core/bcf-writer? false

--- a/test/cljam/t_io.clj
+++ b/test/cljam/t_io.clj
@@ -27,6 +27,8 @@
             (= (io/writer-path r) (.getAbsolutePath (cio/file f)))))
       "sam"
       "bam"
+      "fasta"
+      "2bit"
       "fastq"
       "bed")
 
@@ -102,6 +104,18 @@
 
   (is
    (= (with-open [r (core/reader common/test-fa-file)]
+        (doall (io/read-all-sequences r)))
+      [{:name "ref", :sequence "AGCATGTTAGATAAGATAGCTGTGCTAGTAGGCAGTCAGCGCCAT"}
+       {:name "ref2", :sequence "AGGTTTTATAAAACAATTAAGTCTACAGAGCAACTACGCG"}]))
+
+  (is
+   (= (with-open [r (core/reader common/test-fa-file)]
+        (doall (io/read-all-sequences r {})))
+      [{:name "ref", :sequence "AGCATGTTAGATAAGATAGCTGTGCTAGTAGGCAGTCAGCGCCAT"}
+       {:name "ref2", :sequence "AGGTTTTATAAAACAATTAAGTCTACAGAGCAACTACGCG"}]))
+
+  (is
+   (= (with-open [r (core/reader common/test-fa-file)]
         (io/read-in-region r {:chr "ref" :start 1 :end 10}))
       "AGCATGTTAG"))
 
@@ -120,6 +134,17 @@
   (is
    (= (with-open [r (core/reader common/test-twobit-file)]
         (doall (io/read r {:mask? true})))
+      [{:name "ref", :sequence "AGCATGTTAGATAAGATAGCTGTGCTAGTAGGCAGTCAGCGCCAT"}
+       {:name "ref2", :sequence "aggttttataaaacaattaagtctacagagcaactacgcg"}]))
+  (is
+   (= (with-open [r (core/reader common/test-twobit-file)]
+        (doall (io/read-all-sequences r)))
+      [{:name "ref", :sequence "AGCATGTTAGATAAGATAGCTGTGCTAGTAGGCAGTCAGCGCCAT"}
+       {:name "ref2", :sequence "AGGTTTTATAAAACAATTAAGTCTACAGAGCAACTACGCG"}]))
+
+  (is
+   (= (with-open [r (core/reader common/test-twobit-file)]
+        (doall (io/read-all-sequences r {:mask? true})))
       [{:name "ref", :sequence "AGCATGTTAGATAAGATAGCTGTGCTAGTAGGCAGTCAGCGCCAT"}
        {:name "ref2", :sequence "aggttttataaaacaattaagtctacagagcaactacgcg"}]))
 

--- a/test/cljam/t_twobit.clj
+++ b/test/cljam/t_twobit.clj
@@ -1,7 +1,8 @@
 (ns cljam.t-twobit
   (:require [clojure.test :refer :all]
             [cljam.t-common :refer :all]
-            [cljam.twobit :as tb]))
+            [cljam.twobit :as tb]
+            [cljam.io :as io]))
 
 (deftest twobit-reference
   (with-open [r (tb/reader test-twobit-file)]
@@ -46,3 +47,21 @@
   (with-open [r (tb/reader test-twobit-be-n-file)]
     (is (= (tb/read-sequence r {:chr "ref"})
            "NNNNNGTTAGATAAGATAGCNNTGCTAGTAGGCAGTCNNNNCCAT"))))
+
+(deftest twobit-writer
+  (with-before-after {:before (prepare-cache!)
+                      :after (clean-cache!)}
+    (let [f (str temp-dir "/test.2bit")]
+      (with-open [r (tb/reader test-twobit-file)
+                  w (tb/writer f)]
+        (io/write-sequences w (io/read-all-sequences r {:mask? true})))
+      (is (same-file? f test-twobit-file))
+      (with-open [r1 (tb/reader f)
+                  r2 (tb/reader test-twobit-file)]
+        (is (= (io/read-all-sequences r1 {:mask? true}) (io/read-all-sequences r2 {:mask? true})))))
+
+    (let [f (str temp-dir "/test-n.2bit")]
+      (with-open [r (tb/reader test-twobit-n-file)
+                  w (tb/writer f)]
+        (io/write-sequences w (io/read-all-sequences r {:mask? true})))
+      (is (same-file? f test-twobit-n-file)))))


### PR DESCRIPTION
#### Summary
This PR adds (naive implementation of) writers for FASTA and 2bit format.

#### Changes
- Add protocol `ISequenceWriter` to `cljam.io`.
- Add `cljam.fasta.writer.FASTAWriter` and `cljam.twobit.writer.TwoBitWriter`.
- Moved readers in `cljam.twobit` to `cljam.twobit.reader`.
- Add function `read-all-sequences` to `ISequenceReader`.
- Fix docstring of `ISequenceReader`.
- Add tests.

#### Affected components
- `cljam.fasta`
- `cljam.twobit`

#### Notes
Performance is not yet optimized.