### PR TITLE
Improve sorter.

### DIFF
--- a/src/cljam/cli.clj
+++ b/src/cljam/cli.clj
@@ -131,6 +131,9 @@
 (def ^:private sort-cli-options
   [["-o" "--order ORDER" "Sorting order of alignments <coordinate|queryname>"
     :default "coordinate"]
+   ["-c" "--chunk CHUNK" "Maximum number of alignments sorted per thread."
+    :default sorter/default-chunk-size
+    :parse-fn #(Integer/parseInt %)]
    ["-h" "--help" "Print help"]])
 
 (defn- sort-usage [options-summary]
@@ -152,8 +155,8 @@
       (with-open [r (reader in)
                   w (writer out)]
         (condp = (:order options)
-          (name sorter/order-coordinate) (sorter/sort-by-pos r w)
-          (name sorter/order-queryname) (sorter/sort-by-qname r w)))))
+          (name sorter/order-coordinate) (sorter/sort-by-pos r w {:chunk-size (:chunk options)})
+          (name sorter/order-queryname) (sorter/sort-by-qname r w {:chunk-size (:chunk options)})))))
   nil)
 
 ;; ### index command

--- a/src/cljam/cli.clj
+++ b/src/cljam/cli.clj
@@ -139,7 +139,7 @@
 (defn- sort-usage [options-summary]
   (->> ["Sort alignments by leftmost coordinates."
         ""
-        "Usage: cljam sort [-o ORDER] <in.bam|sam> <out.bam|sam>"
+        "Usage: cljam sort [-o ORDER] [-c CHUNK] <in.bam|sam> <out.bam|sam>"
         ""
         "Options:"
         options-summary]

--- a/src/cljam/sam/reader.clj
+++ b/src/cljam/sam/reader.clj
@@ -33,15 +33,17 @@
   (read-alignments [this]
     (io/read-alignments this {} {}))
   (read-alignments [this region]
-    (io/read-alignments this {} {}))
+    (io/read-alignments this region {}))
   (read-alignments [this {:keys [chr start end] :as region} option]
     (if (or chr start end)
       (read-alignments-in-region* this region option)
       (read-alignments* this)))
   (read-blocks [this]
     (io/read-blocks this {}))
-  (read-blocks [this option]
-    (read-blocks* this)))
+  (read-blocks [this region]
+    (io/read-blocks this region {}))
+  (read-blocks [this region option]
+    (read-blocks* this option)))
 
 (defn- read-alignments*
   [^SAMReader sam-reader]
@@ -59,12 +61,44 @@
                 (if end (<= (:pos a) end) true)))
    (read-alignments* sam-reader)))
 
-(defn- read-blocks*
-  [^SAMReader sam-reader]
-  (when-let [line (.readLine ^BufferedReader (.reader sam-reader))]
+(defn- parse-coordinate
+  [^String line]
+  (let [t0 (.indexOf line (int \tab) 0)
+        t1 (.indexOf line (int \tab) (unchecked-inc t0))
+        t2 (.indexOf line (int \tab) (unchecked-inc t1))
+        t3 (.indexOf line (int \tab) (unchecked-inc t2))
+        flag (Integer/parseInt (.substring line (unchecked-inc t0) t1))
+        rname (.substring line (unchecked-inc t1) t2)
+        pos (Integer/parseInt (.substring line (unchecked-inc t2) t3))]
+    {:data line
+     :rname rname
+     :pos pos
+     :flag flag}))
+
+(defn- parse-qname
+  [^String line]
+  (let [t0 (.indexOf line (int \tab) 0)
+        t1 (.indexOf line (int \tab) (unchecked-inc t0))
+        qname (.substring line 0 t0)
+        flag (Integer/parseInt (.substring line (unchecked-inc t0) t1))]
+    {:data line
+     :qname qname
+     :flag flag}))
+
+(defn- read-blocks**
+  [parse-fn ^BufferedReader rdr]
+  (when-let [line (.readLine rdr)]
     (if-not (= (first line) \@)
-      (cons {:line line} (lazy-seq (read-blocks* sam-reader)))
-      (lazy-seq (read-blocks* sam-reader)))))
+      (cons (parse-fn line) (lazy-seq (read-blocks** parse-fn rdr)))
+      (lazy-seq (read-blocks** parse-fn rdr)))))
+
+(defn- read-blocks*
+  [^SAMReader sam-reader {:keys [mode] :or {mode :normal}}]
+  (let [parse-fn (case mode
+                   :normal (fn [line] {:data line})
+                   :coordinate parse-coordinate
+                   :queryname parse-qname)]
+    (read-blocks** parse-fn (.reader sam-reader))))
 
 (defn- read-header* [^BufferedReader rdr]
   (->> (line-seq rdr)

--- a/src/cljam/sam/writer.clj
+++ b/src/cljam/sam/writer.clj
@@ -49,7 +49,7 @@
   [^SAMWriter sam-writer blocks]
   (let [wtr ^BufferedWriter (.writer sam-writer)]
    (doseq [b blocks]
-     (.write wtr ^String (:line b))
+     (.write wtr ^String (:data b))
      (.newLine wtr))))
 
 ;; Public

--- a/src/cljam/sorter.clj
+++ b/src/cljam/sorter.clj
@@ -1,184 +1,184 @@
 (ns cljam.sorter
   "Sorter of SAM/BAM format alignments."
-  (:require [clojure.java.io :refer [file]]
+  (:require [clojure.java.io :as cio]
             [clojure.tools.logging :as logging]
-            [clojure.string :as cstr]
-            (cljam [core :refer [sam-reader? sam-writer? bam-reader? bam-writer?]]
-                   ;; [sam :as sam]
-                   [bam :as bam]
-                   [common :refer [version]]
+            [com.climate.claypoole :as cp]
+            [cljam [core :as core]
+                   [common :as common]
                    [util :as util]
-                   [io :as io])
-            [cljam.util.sam-util :as sam-util]))
+                   [io :as io]])
+  (:import [java.io Closeable File]
+           [java.util PriorityQueue]))
 
-(def ^:private chunk-size 1500000)
+(def ^:const default-chunk-size 1500000)
+(def ^:const order-unknown :unknown)
+(def ^:const order-coordinate :coordinate)
+(def ^:const order-queryname :queryname)
 
-(def order-unknown :unknown)
-(def order-coordinate :coordinate)
-(def order-queryname :queryname)
-
-(defn- make-ref-map
-  [hdr]
-  (->> hdr
-       sam-util/make-refs
-       (map :name)
-       (map-indexed (fn [i val] {val i}))
-       (into {})))
-
-;; Coordinate sorter
-;; -----------------
-
-(defn- replace-header [hdr vn so]
+(defn- replace-header
+  "Replace version number and sorting info of the header."
+  [hdr vn so]
   (assoc hdr :HD {:VN vn, :SO so}))
 
-(defn- compare-key-pos [ref-map b1 b2]
-  (if (= (:rname b1) (:rname b2))
-    (if (= (:pos b1) (:pos b2))
-      (compare (:qname b1) (:qname b2))
-      (compare (:pos b1) (:pos b2)))
-    (cond
-     (= (:rname b1) "*") 1
-     (= (:rname b2) "*") -1
-     :else (compare (get ref-map (:rname b1))
-                    (get ref-map (:rname b2))))))
+(defn- refmap
+  [refs]
+  (into {} (map-indexed (fn [i x] [(:name x) i])) refs))
 
-(defn- sort-alignments-by-pos [rdr]
-  (let [ref-map (make-ref-map (io/read-header rdr))]
-    (sort (partial compare-key-pos ref-map) (io/read-blocks rdr {} {:mode :coordinate}))))
+;; comparators
+;; -----------
 
-;; Queryname sorter
-;; ----------------
+(defn- coordinate-key
+  [rname->id {:keys [rname ref-id ^int pos ^int flag]}]
+  (unchecked-add
+   Long/MIN_VALUE
+   (bit-or
+    (bit-shift-left (int (or ref-id (rname->id rname -1))) 32)
+    (bit-shift-left pos 1)
+    (bit-and 1 (unsigned-bit-shift-right flag 4)))))
 
-;; (defn- compkey-qname [hdr aln]
-;;   [(.indexOf ^List (map :name (sam-util/make-refs hdr)) (:rname aln))
-;;    (:qname aln)
-;;    (bit-and (:flag aln) 0xc0)])
+(defn- queryname-key
+  [{:keys [qname ^int flag]}]
+  (str
+   qname
+   (bit-and 3 (unsigned-bit-shift-right flag 6))))
 
-;; (defn- sort-alignments-by-qname [rdr]
-;;   (->> (sort-by (partial compkey-qname (:header sam)) (:alignments sam))
-;;        (assoc sam :alignments)))
+(defn- sort-by-index
+  "Same as sort-by but caching results of keyfn."
+  [keyfn coll]
+  (sort-by :index (map (fn [x] (assoc x :index (keyfn x))) coll)))
 
 ;; split/merge
 ;; -----------
 
-(defn gen-cache-filename
-  [prefix i]
-  (format "%s/%s_%05d.cache" util/temp-dir prefix i))
+(defn- same-type?
+  "Returns true if given files are the same type."
+  [f & files]
+  (apply = (core/file-type f) (map core/file-type files)))
 
-(defn gen-sorted-cache-filename
-  [prefix i]
-  (format "%s/%s_%05d.sorted.cache" util/temp-dir prefix i))
+(defn- split**
+  "Splits SAM/BAM file into multiple files each containing alignments up to chunk-size.
+  name-fn must be a function taking a int value i and returning a path string for i-th output.
+  read-fn must produce a sequence of alignments and write-fn must consume the splitted sequence."
+  [rdr chunk-size name-fn read-fn write-fn]
+  (let [hdr (replace-header (io/read-header rdr) common/version (name order-coordinate))]
+    (logging/info "Splitting...")
+    (cp/with-shutdown! [p (cp/threadpool (cp/ncpus))]
+      (->> (read-fn rdr)
+           (sequence
+            (comp
+             (partition-all (or chunk-size default-chunk-size))
+             (map-indexed (fn [i xs] [(name-fn i) xs]))))
+           (cp/pmap
+            p
+            (fn [[f xs]]
+              (logging/info (str "Sorting " (count xs) " alignments..."))
+              (with-open [wtr (core/writer f)]
+                (io/write-header wtr hdr)
+                (io/write-refs wtr hdr)
+                (write-fn wtr xs hdr))
+              f))
+           doall))))
 
-(defn- find-head
-  [keyfn l]
-  (reduce (fn [e1 e2]
-            (let [v (keyfn e1 e2)]
-              (cond
-                (or (zero? v)
-                    (neg? v)) e1
-                (pos? v) e2)))
-          l))
+(defn- split*
+  "Splits SAM/BAM files with appropriate reader/writer functions."
+  [rdr chunk-size name-fn mode sort-fn]
+  (let [block? (same-type? (io/reader-path rdr) (name-fn 0))
+        read-fn (if block?
+                  (fn [r] (io/read-blocks r {} {:mode mode}))
+                  io/read-alignments)
+        write-fn (if block?
+                   (fn [w xs _] (io/write-blocks w (sort-fn xs)))
+                   (fn [w xs hdr] (io/write-alignments w (sort-fn xs) hdr)))]
+    (split** rdr chunk-size name-fn read-fn write-fn)))
 
-(defn- head
-  [blocks ref-map]
-  (->> blocks
-       (map-indexed vector)
-       (filter (fn [[_ b]] (not (nil? b))))
-       (find-head (fn [[idx1 b1] [idx2 b2]]
-                    (compare-key-pos ref-map b1 b2)))))
+(defn- head-pq
+  "Take a smallest element from sequences in priority queue."
+  [^PriorityQueue q]
+  (when-not (.isEmpty q)
+    (let [x (.poll q)]
+      (when-let [nx (next x)]
+        (.add q nx))
+      (first x))))
 
-(defn split-sam
-  [rdr name-fn]
-  (let [hdr (io/read-header rdr)]
-    (doall
-     (->> (io/read-blocks rdr)
-          (partition-all chunk-size)
-          (map-indexed vector)
-          (map (fn [[i blks]]
-                 (let [f (name-fn i)]
-                   (with-open [wtr (bam/writer f)]
-                     (io/write-header wtr hdr)
-                     (io/write-refs wtr hdr)
-                     (io/write-blocks wtr blks))
-                   f)))))))
+(defn merge-sorted-seqs-by
+  "Returns a lazy sequence from pre-sorted sequences.
+  Each sequences must be sorted by key-fn.
+  Returns first sequence if only 1 sequence is given."
+  [key-fn seqs]
+  (if (= (count seqs) 1)
+    (first seqs)
+    (let [pq (PriorityQueue.
+              (int (count seqs))
+              (fn pq-cmp [x y] (compare (key-fn (first x)) (key-fn (first y)))))]
+      (doseq [s seqs]
+        (.add pq s))
+      (take-while some? (repeatedly (fn repeat-head-pq [] (head-pq pq)))))))
 
-(defn merge-sam
-  [wtr header name-fn n]
-  (let [rdrs (map #(bam/reader (name-fn %) :ignore-index true) (range n))
-        ref-map (make-ref-map header)]
-    (io/write-header wtr header)
-    (io/write-refs wtr header)
-    (loop [blocks-list (map #(io/read-blocks % {} {:mode :coordinate}) rdrs)]
-      (let [candidates (map first blocks-list)]
-        (when-not (every? nil? candidates)
-          (let [[i b] (head candidates ref-map)]
-            (io/write-blocks wtr [b])
-            (recur (map
-                    (fn [[idx blocks]]
-                      (if (= idx i)
-                        (drop 1 blocks)
-                        blocks))
-                    (map-indexed vector blocks-list)))))))))
+(defn- merge**
+  "Merges multiple SAM/BAM files into single SAM/BAM file."
+  [wtr hdr files key-fn read-fn write-fn]
+  (let [rdrs (map #(core/reader % :ignore-index true) files)
+        alns (map read-fn rdrs)]
+    (io/write-header wtr hdr)
+    (io/write-refs wtr hdr)
+    (write-fn wtr (merge-sorted-seqs-by key-fn alns) hdr)
+    (doseq [rdr rdrs]
+      (.close ^Closeable rdr))))
 
-(defn clean-split-merge-cache
-  [name-fn sorted-name-fn count]
-  (letfn [(clean [path]
-            (let [f (file path)]
-              (when (.exists f)
-                (.delete f))))]
-    (doseq [i (range count)]
-      (clean (name-fn i))
-      (clean (sorted-name-fn i)))))
+(defn- merge*
+  "Merges multiple SAM/BAM files with appropriate reader/writer functions."
+  [wtr hdr files mode key-fn]
+  (let [block? (apply same-type? (io/writer-path wtr) files)
+        read-fn (if block?
+                  (fn [r] (io/read-blocks r {} {:mode mode}))
+                  io/read-alignments)
+        write-fn (if block?
+                   (fn [w xs _] (io/write-blocks w xs))
+                   io/write-alignments)]
+    (merge** wtr hdr files key-fn read-fn write-fn)))
 
 ;; Sorter
 ;; ------
 
-(defmulti sort-by-pos (fn [rdr wtr]
-                        (cond
-                          (and (sam-reader? rdr) (sam-writer? wtr)) :sam
-                          (and (bam-reader? rdr) (bam-writer? wtr)) :bam
-                          :else nil)))
+(defn- clean-all!
+  "Deletes all files in list."
+  [files]
+  (doseq [f (map cio/file files)
+          :when (.exists ^File f)]
+    (.delete ^File f)))
 
-(defmethod sort-by-pos :sam [rdr wtr]
-  (throw (ex-info "SAM not supported yet." {:type :sam-not-supported}))
-  ;; TODO implement
-  )
+(defn- gen-cache-filename
+  "Generates i-th cache filename."
+  [fmt prefix i]
+  (format "%s/%s_%05d.%s" util/temp-dir prefix i fmt))
 
-(defmethod sort-by-pos :bam [rdr wtr]
-  (when (and (bam-reader? rdr)
-             (bam-writer? wtr))
-    (let [basename (util/basename (.getName (file (io/reader-path rdr))))
-          cache-name-fn (partial gen-cache-filename basename)
-          sorted-cache-name-fn (partial gen-sorted-cache-filename basename)
-          splited-files (split-sam rdr cache-name-fn)
-          num-splited (count splited-files)
-          hdr (replace-header (into (sorted-map) (io/read-header rdr))
-                              version
-                              (name order-coordinate))]
-      (doseq [idxs (partition-all util/num-cores (range num-splited))]
-        (doall
-         (pmap
-          (fn [i]
-            (let [r (bam/reader (cache-name-fn i) :ignore-index true)
-                  blks (sort-alignments-by-pos r)]
-              (with-open [w (bam/writer (sorted-cache-name-fn i))]
-                (io/write-header w hdr)
-                (io/write-refs w hdr)
-                (io/write-blocks w blks))))
-          idxs)))
-      (merge-sam wtr hdr sorted-cache-name-fn num-splited)
-      (clean-split-merge-cache cache-name-fn sorted-cache-name-fn num-splited))))
+(defn sort!
+  "Sort alignments of rdr by mode and writes them to wtr.
+  :coordinate and :queryname are available for mode."
+  [rdr wtr {:keys [mode chunk-size cache-fmt] :or {cache-fmt :bam} :as option}]
+  (let [name-fn (->> rdr
+                     io/reader-path
+                     util/basename
+                     (partial gen-cache-filename (name cache-fmt)))
+        key-fn (case mode
+                 :coordinate (partial coordinate-key (refmap (io/read-refs rdr)))
+                 :queryname queryname-key)
+        splitted-files (split* rdr chunk-size name-fn mode #(sort-by-index key-fn %))
+        hdr (replace-header (io/read-header rdr) common/version (name mode))]
+    (logging/info (str "Merging from " (count splitted-files) " files..."))
+    (merge* wtr hdr splitted-files mode key-fn)
+    (logging/info "Deleting cache files...")
+    (clean-all! splitted-files)))
 
-(defn sort-by-qname [rdr wtr]
-  (throw (ex-info "Query name sortor is not available yet." {:type :method-not-available}))
-  ;; (let [alns (sort-alignments-by-qname rdr)
-  ;;       hdr (replace-header (into (sorted-map) (io/read-header rdr))
-  ;;                           version
-  ;;                           (name order-queryname))]
-  ;;   (io/write-header wtr hdr)
-  ;;   (io/write-refs wtr hdr)
-  ;;   (io/write-alignments wtr alns hdr))
-  )
+(defn sort-by-pos
+  "Sort alignments by chromosomal position."
+  [rdr wtr & [option]]
+  (sort! rdr wtr (into (or option {}) {:mode :coordinate})))
+
+(defn sort-by-qname
+  "Sort alignments by query name."
+  [rdr wtr & [option]]
+  (sort! rdr wtr (into (or option {}) {:mode :queryname})))
 
 (defn sorted-by?
   "Returns true if the sam is sorted, false if not. It is detected by

--- a/test/cljam/t_bam.clj
+++ b/test/cljam/t_bam.clj
@@ -100,16 +100,20 @@
       (is (= (data->clj (io/read-blocks rdr))
              test-sorted-bam-data)))
     (with-open [rdr (bam/reader test-sorted-bam-file :ignore-index false)]
-      (is (= (map #(dissoc % :pos :qname :rname) (data->clj (io/read-blocks rdr {:chr "ref2"})))
+      (is (= (map #(dissoc % :pos :qname :rname :flag :ref-id)
+                  (data->clj (io/read-blocks rdr {:chr "ref2"})))
              (drop 6 test-sorted-bam-data))))
     (with-open [rdr (bam/reader test-sorted-bam-file :ignore-index false)]
-      (is (= (map #(dissoc % :pos :qname :rname) (data->clj (io/read-blocks rdr {:chr "ref2" :start 2})))
+      (is (= (map #(dissoc % :pos :qname :rname :flag :ref-id)
+                  (data->clj (io/read-blocks rdr {:chr "ref2" :start 2})))
              (drop 7 test-sorted-bam-data))))
     (with-open [rdr (bam/reader test-sorted-bam-file :ignore-index false)]
-      (is (= (map #(dissoc % :pos :qname :rname) (data->clj (io/read-blocks rdr {:chr "ref2" :end 2})))
+      (is (= (map #(dissoc % :pos :qname :rname :flag :ref-id)
+                  (data->clj (io/read-blocks rdr {:chr "ref2" :end 2})))
              (take 2 (drop 6 test-sorted-bam-data)))))
     (with-open [rdr (bam/reader test-sorted-bam-file :ignore-index false)]
-      (is (= (map #(dissoc % :pos :qname :rname) (data->clj (io/read-blocks rdr {:chr "ref2" :start 4 :end 12})))
+      (is (= (map #(dissoc % :pos :qname :rname :flag :ref-id)
+                  (data->clj (io/read-blocks rdr {:chr "ref2" :start 4 :end 12})))
              (take 3 (drop 8 test-sorted-bam-data)))))))
 
 (deftest bamreader-invalid-files

--- a/test/cljam/t_cli.clj
+++ b/test/cljam/t_cli.clj
@@ -57,26 +57,22 @@
 (deftest about-sort-by-pos
   (with-before-after {:before (prepare-cache!)
                       :after (clean-cache!)}
-    ;; see https://gitlab.xcoo.jp/chrovis/cljam/issues/12
-    ;; (is (not-throw? (with-out-file temp-out (cli/sort ["-o" "coordinate" test-sam-file temp-sam])))) ; TODO: future
-    ;; (is (= (slurp-sam-for-test temp-sam) test-sam-sorted-by-pos)) ; TODO: future
-    ;; (is (not-throw? (check-sort-order (slurp-sam-for-test temp-sam)
-    ;;                                   test-sam-sorted-by-pos))) ; TODO: future
-    (is (not-throw? (with-out-file temp-out (cli/sort ["-o" "coordinate" test-bam-file temp-bam]))))
+    (is (not-throw? (with-out-file temp-out (cli/sort ["-o" "coordinate" test-sam-file temp-sam]))))
+    (is (= (slurp-sam-for-test temp-sam) test-sam-sorted-by-pos))
+    (is (not-throw? (check-sort-order (slurp-sam-for-test temp-sam) test-sam-sorted-by-pos)))
+    (is (not-throw? (with-out-file temp-out (cli/sort ["-o" "coordinate" "-c" "4" test-bam-file temp-bam]))))
     (is (= (slurp-bam-for-test temp-bam) test-sam-sorted-by-pos))
-    (is (not-throw? (check-sort-order (slurp-bam-for-test temp-bam)
-                                      test-sam-sorted-by-pos)))
+    (is (not-throw? (check-sort-order (slurp-bam-for-test temp-bam) test-sam-sorted-by-pos)))
     (is (thrown? IllegalArgumentException (with-out-file temp-out (cli/sort ["-o" "coordinate" test-fa-file temp-bam]))))
     (is (thrown? IllegalArgumentException (with-out-file temp-out (cli/sort ["-o" "coordinate" test-bam-file (str temp-dir "/test.unknown")]))))))
 
 (deftest about-sort-by-qname
   (with-before-after {:before (prepare-cache!)
                       :after (clean-cache!)}
-    ;; (is (not-throw? (with-out-file temp-out (cli/sort ["-o" "queryname" test-sam-file temp-sam])))) ; TODO: future
-    ;; (is (= (slurp-sam-for-test temp-sam) test-sam-sorted-by-qname)) ; TODO: future
-    ;; (is (not-throw? (with-out-file temp-out (cli/sort ["-o" "queryname" test-bam-file temp-bam])))) ; TODO: future
-    ;; (is (= (slurp-bam-for-test temp-bam) test-sam-sorted-by-qname)) ; TODO: future
-    ))
+    (is (not-throw? (with-out-file temp-out (cli/sort ["-o" "queryname" test-sam-file temp-sam]))))
+    (is (= (slurp-sam-for-test temp-sam) test-sam-sorted-by-qname))
+    (is (not-throw? (with-out-file temp-out (cli/sort ["-o" "queryname" test-bam-file temp-bam]))))
+    (is (= (slurp-bam-for-test temp-bam) test-sam-sorted-by-qname))))
 
 (deftest about-index
   (with-before-after {:before (do (prepare-cache!)

--- a/test/cljam/t_common.clj
+++ b/test/cljam/t_common.clj
@@ -1,6 +1,7 @@
 (ns cljam.t-common
   (:require [digest]
             [clojure.java.io :refer [file]]
+            [cljam.core :as core]
             [cljam.sam :as sam]
             [cljam.bam :as bam]
             [cljam.io :as io]
@@ -198,18 +199,18 @@
     (map to-sam-alignment))})
 
 (def test-sam-blocks
-  [{:line "r003\t16\tref\t29\t30\t6H5M\t*\t0\t0\tTAGGC\t*"}
-   {:line "r001\t163\tref\t7\t30\t8M4I4M1D3M\t=\t37\t39\tTTAGATAAAGAGGATACTG\t*\tXX:B:S,12561,2,20,112"}
-   {:line "r002\t0\tref\t9\t30\t1S2I6M1P1I1P1I4M2I\t*\t0\t0\tAAAAGATAAGGGATAAA\t*"}
-   {:line "r003\t0\tref\t9\t30\t5H6M\t*\t0\t0\tAGCTAA\t*"}
-   {:line "x3\t0\tref2\t6\t30\t9M4I13M\t*\t0\t0\tTTATAAAACAAATAATTAAGTCTACA\t??????????????????????????"}
-   {:line "r004\t0\tref\t16\t30\t6M14N1I5M\t*\t0\t0\tATAGCTCTCAGC\t*"}
-   {:line "r001\t83\tref\t37\t30\t9M\t=\t7\t-39\tCAGCGCCAT\t*"}
-   {:line "x1\t0\tref2\t1\t30\t20M\t*\t0\t0\tAGGTTTTATAAAACAAATAA\t????????????????????"}
-   {:line "x2\t0\tref2\t2\t30\t21M\t*\t0\t0\tGGTTTTATAAAACAAATAATT\t?????????????????????"}
-   {:line "x4\t0\tref2\t10\t30\t25M\t*\t0\t0\tCAAATAATTAAGTCTACAGAGCAAC\t?????????????????????????"}
-   {:line "x6\t0\tref2\t14\t30\t23M\t*\t0\t0\tTAATTAAGTCTACAGAGCAACTA\t???????????????????????"}
-   {:line "x5\t0\tref2\t12\t30\t24M\t*\t0\t0\tAATAATTAAGTCTACAGAGCAACT\t????????????????????????"}])
+  [{:data "r003\t16\tref\t29\t30\t6H5M\t*\t0\t0\tTAGGC\t*"}
+   {:data "r001\t163\tref\t7\t30\t8M4I4M1D3M\t=\t37\t39\tTTAGATAAAGAGGATACTG\t*\tXX:B:S,12561,2,20,112"}
+   {:data "r002\t0\tref\t9\t30\t1S2I6M1P1I1P1I4M2I\t*\t0\t0\tAAAAGATAAGGGATAAA\t*"}
+   {:data "r003\t0\tref\t9\t30\t5H6M\t*\t0\t0\tAGCTAA\t*"}
+   {:data "x3\t0\tref2\t6\t30\t9M4I13M\t*\t0\t0\tTTATAAAACAAATAATTAAGTCTACA\t??????????????????????????"}
+   {:data "r004\t0\tref\t16\t30\t6M14N1I5M\t*\t0\t0\tATAGCTCTCAGC\t*"}
+   {:data "r001\t83\tref\t37\t30\t9M\t=\t7\t-39\tCAGCGCCAT\t*"}
+   {:data "x1\t0\tref2\t1\t30\t20M\t*\t0\t0\tAGGTTTTATAAAACAAATAA\t????????????????????"}
+   {:data "x2\t0\tref2\t2\t30\t21M\t*\t0\t0\tGGTTTTATAAAACAAATAATT\t?????????????????????"}
+   {:data "x4\t0\tref2\t10\t30\t25M\t*\t0\t0\tCAAATAATTAAGTCTACAGAGCAAC\t?????????????????????????"}
+   {:data "x6\t0\tref2\t14\t30\t23M\t*\t0\t0\tTAATTAAGTCTACAGAGCAACTA\t???????????????????????"}
+   {:data "x5\t0\tref2\t12\t30\t24M\t*\t0\t0\tAATAATTAAGTCTACAGAGCAACT\t????????????????????????"}])
 
 (defn get-shuffled-test-sam
   []
@@ -415,13 +416,18 @@
               (case (compare (:pos prev) (:pos one))
                 -1 true
                 1 (throw (Exception. "pos not sorted"))
-                (case (compare (:qname prev) (:qname one))
+                (case (compare (bit-and 16 (:flag prev)) (bit-and 16 (:flag one)))
                   -1 true
-                  1 (throw (Exception. "qname not sorted"))
+                  1 (throw (Exception. "reverse flag not sorted"))
                   true))
               one)
             (filter #(= rname (:rname %)) (:alignments target-sam))))
         target-rnames))))
+
+(defn qname-sorted? [f]
+  (with-open [r (core/reader f :ignore-index true)]
+    (let [x (map :qname (io/read-alignments r))]
+      (= x (sort x)))))
 
 ;; Utilities
 ;; ---------

--- a/test/cljam/t_sorter.clj
+++ b/test/cljam/t_sorter.clj
@@ -1,6 +1,7 @@
 (ns cljam.t-sorter
   (:require [clojure.test :refer :all]
             [cljam.t-common :refer :all]
+            [cljam.core :as core]
             [cljam.sam :as sam]
             [cljam.bam :as bam]
             [cljam.sorter :as sorter])
@@ -15,103 +16,141 @@
 (def tmp-shuffled-sam-file (str temp-dir "/" "tmp.shuffled.sam"))
 (def tmp-shuffled-bam-file (str temp-dir "/" "tmp.shuffled.bam"))
 
-(def tmp-coordinate-sorted-sam-file-2 (str temp-dir "/" "tmp.coordinate.sorted.2.sam"))
-(def tmp-coordinate-sorted-bam-file-2 (str temp-dir "/" "tmp.coordinate.sorted.2.bam"))
+(def tmp-coordinate-sorted-sam-sam-file (str temp-dir "/" "tmp.coordinate.sorted.2.sam.sam"))
+(def tmp-coordinate-sorted-sam-bam-file (str temp-dir "/" "tmp.coordinate.sorted.2.sam.bam"))
+(def tmp-coordinate-sorted-bam-bam-file (str temp-dir "/" "tmp.coordinate.sorted.2.bam.bam"))
+(def tmp-coordinate-sorted-bam-sam-file (str temp-dir "/" "tmp.coordinate.sorted.2.bam.sam"))
 
 (def tmp-queryname-sorted-sam-file-2 (str temp-dir "/" "tmp.queryname.sorted.2.sam"))
 (def tmp-queryname-sorted-bam-file-2 (str temp-dir "/" "tmp.queryname.sorted.2.bam"))
 
 (defn- prepare-shuffled-files!
   []
-  (spit-sam-for-test tmp-shuffled-sam-file (get-shuffled-test-sam))
-  (spit-bam-for-test tmp-shuffled-bam-file (get-shuffled-test-sam)))
+  (let [x (get-shuffled-test-sam)]
+    (spit-sam-for-test tmp-shuffled-sam-file x)
+    (spit-bam-for-test tmp-shuffled-bam-file x)))
 
 (defn- with-reader
   [target-fn src-file & [dst-file]]
-  (let [src-rdr (cond
-                 (re-find #"\.sam$" src-file) (sam/reader src-file)
-                 (re-find #"\.bam$" src-file) (bam/reader src-file :ignore-index true)
-                 :else (throw (RuntimeException.
-                               (str "invalid file suffix " src-file))))
-        dst-wtr (if dst-file
-                  (cond
-                   (not dst-file) nil
-                   (re-find #"\.sam$" dst-file) (sam/writer dst-file)
-                   (re-find #"\.bam$" dst-file) (bam/writer dst-file)
-                   :else (throw (RuntimeException.
-                                 (str "invalid file suffix " dst-file))))
-                  nil)]
+  (let [src-rdr (core/reader src-file)
+        dst-wtr (when dst-file (core/writer dst-file))]
     (if-not (nil? dst-wtr)
       (with-open [src ^Closeable src-rdr
                   dst ^Closeable dst-wtr] (target-fn src dst))
       (with-open [src ^Closeable src-rdr] (target-fn src)))))
 
-(deftest about-sorting-a-sam-by-chromosomal-positions
+(deftest sort-test-files
+  (with-before-after {:before (prepare-cache!)
+                      :after (clean-cache!)}
+    ;; tests by test-sam-file and test-bam-file
+    (is (not-throw? (with-reader sorter/sort-by-pos test-sam-file tmp-coordinate-sorted-sam-file)))
+    (is (not-throw? (with-reader sorter/sort-by-pos test-bam-file tmp-coordinate-sorted-bam-file)))
+    (is (not-throw? (with-reader sorter/sort-by-qname test-sam-file tmp-queryname-sorted-sam-file)))
+    (is (not-throw? (with-reader sorter/sort-by-qname test-bam-file tmp-queryname-sorted-bam-file)))
+    (is (not (with-reader sorter/sorted-by? test-sam-file)))
+    (is (not (with-reader sorter/sorted-by? test-bam-file)))
+    (is (with-reader sorter/sorted-by? tmp-coordinate-sorted-sam-file))
+    (is (with-reader sorter/sorted-by? tmp-coordinate-sorted-bam-file))
+    (is (with-reader sorter/sorted-by? tmp-queryname-sorted-sam-file))
+    (is (with-reader sorter/sorted-by? tmp-queryname-sorted-bam-file))
+    (is (= (with-reader sorter/sort-order test-sam-file)
+           sorter/order-unknown))
+    (is (= (with-reader sorter/sort-order test-bam-file)
+           sorter/order-unknown))
+    (is (= (with-reader sorter/sort-order tmp-coordinate-sorted-sam-file)
+           sorter/order-coordinate))
+    (is (= (with-reader sorter/sort-order tmp-coordinate-sorted-bam-file)
+           sorter/order-coordinate))
+    (is (= (with-reader sorter/sort-order tmp-queryname-sorted-sam-file)
+           sorter/order-queryname))
+    (is (= (with-reader sorter/sort-order tmp-queryname-sorted-bam-file)
+           sorter/order-queryname))
+    (is (qname-sorted? tmp-queryname-sorted-sam-file))
+    (is (qname-sorted? tmp-queryname-sorted-bam-file))))
+
+(deftest about-sorting-shuffled-files
   (with-before-after {:before (do (prepare-cache!)
                                   (prepare-shuffled-files!))
                       :after (clean-cache!)}
-    ;; tests by test-sam-file and test-bam-file
-    (is (thrown? Exception
-                 (with-reader sorter/sort-by-pos test-sam-file tmp-coordinate-sorted-sam-file)))
-    (is (not-throw? (with-reader sorter/sort-by-pos test-bam-file tmp-coordinate-sorted-bam-file)))
-    ;; (is (not-throw? (with-reader sorter/sort-by-qname test-sam-file tmp-queryname-sorted-sam-file))) ; TODO: future
-    ;; (is (not-throw? (with-reader sorter/sort-by-qname test-bam-file tmp-queryname-sorted-bam-file))) ; TODO: future
-    (is (not (with-reader sorter/sorted-by? test-sam-file)))
-    (is (not (with-reader sorter/sorted-by? test-bam-file)))
-    (is (not (with-reader sorter/sorted-by? tmp-coordinate-sorted-sam-file)))
-    (is (with-reader sorter/sorted-by? tmp-coordinate-sorted-bam-file))
-    ;; (is (with-reader sorter/sorted-by? tmp-queryname-sorted-sam-file)) ; TODO: future
-    ;; (is (with-reader sorter/sorted-by? tmp-queryname-sorted-bam-file)) ; TODO: future
-    (is (= (with-reader sorter/sort-order test-sam-file) sorter/order-unknown))
-    (is (= (with-reader sorter/sort-order test-bam-file) sorter/order-unknown))
-    (is (= (with-reader sorter/sort-order tmp-coordinate-sorted-sam-file)
-           sorter/order-unknown))
-    (is (= (with-reader sorter/sort-order tmp-coordinate-sorted-bam-file)
-           sorter/order-coordinate))
-    ;; (is (= (with-reader sorter/sort-order tmp-queryname-sorted-sam-file)
-    ;;        sorter/order-queryname)) ; TODO: future
-    ;; (is (= (with-reader sorter/sort-order tmp-queryname-sorted-bam-file)
-    ;;        sorter/order-queryname)) ; TODO: future
     ;; tests by shuffled files (its may sorted by chance)
-    (is (thrown? Exception
-                 (with-reader sorter/sort-by-pos tmp-shuffled-sam-file tmp-coordinate-sorted-sam-file-2)))
-    (is (nil? (with-reader sorter/sort-by-pos tmp-shuffled-bam-file tmp-coordinate-sorted-bam-file-2)))
-    ;; (is (not-throw? (with-reader sorter/sort-by-qname tmp-shuffled-sam-file tmp-coordinate-sorted-sam-file-2))) ; TODO: future
-    ;; (is (not-throw? (with-reader sorter/sort-by-qname tmp-shuffled-bam-file tmp-coordinate-sorted-bam-file-2))) ; TODO: future
-    (is (not-throw? (with-reader sorter/sorted-by? tmp-shuffled-sam-file)))
-    (is (not-throw? (with-reader sorter/sorted-by? tmp-shuffled-bam-file)))
-    (is (not (with-reader sorter/sorted-by? tmp-coordinate-sorted-sam-file-2)))
-    (is (with-reader sorter/sorted-by? tmp-coordinate-sorted-bam-file-2))
-    ;; (is (with-reader sorter/sorted-by? tmp-queryname-sorted-sam-file-2)) ; TODO: future
-    ;; (is (with-reader sorter/sorted-by? tmp-queryname-sorted-bam-file-2)) ; TODO: future
+    (is (not-throw? (with-reader sorter/sort-by-pos tmp-shuffled-sam-file tmp-coordinate-sorted-sam-sam-file)))
+    (is (not-throw? (with-reader sorter/sort-by-pos tmp-shuffled-sam-file tmp-coordinate-sorted-sam-bam-file)))
+    (is (not-throw? (with-reader sorter/sort-by-pos tmp-shuffled-bam-file tmp-coordinate-sorted-bam-sam-file)))
+    (is (not-throw? (with-reader sorter/sort-by-pos tmp-shuffled-bam-file tmp-coordinate-sorted-bam-bam-file)))
+    (is (not-throw? (with-reader sorter/sort-by-qname tmp-shuffled-sam-file tmp-queryname-sorted-sam-file-2)))
+    (is (not-throw? (with-reader sorter/sort-by-qname tmp-shuffled-bam-file tmp-queryname-sorted-bam-file-2)))
+    (is (not (with-reader sorter/sorted-by? tmp-shuffled-sam-file)))
+    (is (not (with-reader sorter/sorted-by? tmp-shuffled-bam-file)))
+    (is (with-reader sorter/sorted-by? tmp-coordinate-sorted-sam-sam-file))
+    (is (with-reader sorter/sorted-by? tmp-coordinate-sorted-sam-bam-file))
+    (is (with-reader sorter/sorted-by? tmp-coordinate-sorted-bam-sam-file))
+    (is (with-reader sorter/sorted-by? tmp-coordinate-sorted-bam-bam-file))
+    (is (with-reader sorter/sorted-by? tmp-queryname-sorted-sam-file-2))
+    (is (with-reader sorter/sorted-by? tmp-queryname-sorted-bam-file-2))
     (is (get #{:queryname :coordinate :unsorted :unknown}
              (with-reader sorter/sort-order tmp-shuffled-sam-file)))
     (is (get #{:queryname :coordinate :unsorted :unknown}
              (with-reader sorter/sort-order tmp-shuffled-bam-file)))
-    (is (= (with-reader sorter/sort-order tmp-coordinate-sorted-sam-file-2)
-           sorter/order-unknown))
-    (is (= (with-reader sorter/sort-order tmp-coordinate-sorted-bam-file-2)
+    (is (= (with-reader sorter/sort-order tmp-coordinate-sorted-sam-sam-file)
            sorter/order-coordinate))
-    ;; (is (= (with-reader sorter/sort-order tmp-queryname-sorted-sam-file-2)
-    ;;        sorter/order-queryname)) ; TODO: future
-    ;; (is (= (with-reader sorter/sort-order tmp-queryname-sorted-bam-file-2)
-    ;;        sorter/order-queryname)) ; TODO: future
+    (is (= (with-reader sorter/sort-order tmp-coordinate-sorted-sam-bam-file)
+           sorter/order-coordinate))
+    (is (= (with-reader sorter/sort-order tmp-coordinate-sorted-bam-sam-file)
+           sorter/order-coordinate))
+    (is (= (with-reader sorter/sort-order tmp-coordinate-sorted-bam-bam-file)
+           sorter/order-coordinate))
+    (is (= (with-reader sorter/sort-order tmp-queryname-sorted-sam-file-2)
+           sorter/order-queryname))
+    (is (= (with-reader sorter/sort-order tmp-queryname-sorted-bam-file-2)
+           sorter/order-queryname))
     ;; check sorting order
-    (is (not-throw? (check-sort-order (slurp-sam-for-test tmp-coordinate-sorted-sam-file-2) (slurp-sam-for-test tmp-coordinate-sorted-sam-file))))
-    (is (not-throw? (check-sort-order (slurp-bam-for-test tmp-coordinate-sorted-bam-file-2) (slurp-bam-for-test tmp-coordinate-sorted-bam-file))))
+    (is (not-throw? (check-sort-order (slurp-sam-for-test tmp-coordinate-sorted-sam-sam-file))))
+    (is (not-throw? (check-sort-order (slurp-sam-for-test tmp-coordinate-sorted-bam-sam-file))))
+    (is (not-throw? (check-sort-order (slurp-bam-for-test tmp-coordinate-sorted-sam-bam-file))))
+    (is (not-throw? (check-sort-order (slurp-bam-for-test tmp-coordinate-sorted-bam-bam-file))))
+    (is (qname-sorted? tmp-queryname-sorted-sam-file-2))
+    (is (qname-sorted? tmp-queryname-sorted-bam-file-2))
     ;; compare generated files
-    (is (= (slurp-sam-for-test tmp-coordinate-sorted-sam-file-2)
-           (slurp-sam-for-test tmp-coordinate-sorted-sam-file)))
-    (is (= (slurp-bam-for-test tmp-coordinate-sorted-bam-file-2)
-           (slurp-bam-for-test tmp-coordinate-sorted-bam-file)))
-    ;; (is (= (slurp-sam-for-test tmp-queryname-sorted-sam-file-2)
-    ;;        (slurp-sam-for-test tmp-queryname-sorted-sam-file))) ; TODO: future
-    ;; (is (= (slurp-bam-for-test tmp-queryname-sorted-bam-file-2)
-    ;;        (slurp-bam-for-test tmp-queryname-sorted-bam-file))) ; TODO: future
-    ;; TODO: Add test sorter/sort-by-pos with bam file includes many blocks
-    ;;       (Currently, testing bam files have only one block)
-    ;; (is (not-throw? (with-reader sorter/sort-by-pos many-blocks-bam-file (str temp-dir "/many.bam"))))
-    ))
+    (is (= (slurp-sam-for-test tmp-coordinate-sorted-sam-sam-file)
+           (slurp-bam-for-test tmp-coordinate-sorted-sam-bam-file)
+           (slurp-sam-for-test tmp-coordinate-sorted-bam-sam-file)
+           (slurp-bam-for-test tmp-coordinate-sorted-bam-bam-file)))
+    (is (= (slurp-sam-for-test tmp-queryname-sorted-sam-file-2)
+           (slurp-bam-for-test tmp-queryname-sorted-bam-file-2)))))
+
+(deftest about-sorting-small-chunks
+  (with-before-after {:before (do (prepare-cache!)
+                                  (prepare-shuffled-files!))
+                      :after (clean-cache!)}
+    ;; coordinate
+    (is (not-throw?
+         (with-open [r (core/reader tmp-shuffled-bam-file :ignore-index true)
+                     w (core/writer tmp-coordinate-sorted-bam-bam-file)]
+           (sorter/sort-by-pos r w {:chunk-size 3}))))
+    (is (with-reader sorter/sorted-by? tmp-coordinate-sorted-bam-bam-file))
+    (is (not-throw? (check-sort-order (slurp-bam-for-test tmp-coordinate-sorted-bam-bam-file))))
+
+    (is (not-throw?
+         (with-open [r (core/reader tmp-shuffled-sam-file :ignore-index true)
+                     w (core/writer tmp-coordinate-sorted-sam-sam-file)]
+           (sorter/sort-by-pos r w {:chunk-size 3 :cache-fmt :sam}))))
+    (is (with-reader sorter/sorted-by? tmp-coordinate-sorted-sam-sam-file))
+    (is (not-throw? (check-sort-order (slurp-sam-for-test tmp-coordinate-sorted-sam-sam-file))))
+
+    ;; queryname
+    (is (not-throw?
+         (with-open [r (core/reader tmp-shuffled-bam-file :ignore-index true)
+                     w (core/writer tmp-queryname-sorted-bam-file-2)]
+           (sorter/sort-by-qname r w {:chunk-size 3}))))
+    (with-reader sorter/sorted-by? tmp-queryname-sorted-bam-file-2)
+    (is (qname-sorted? tmp-queryname-sorted-bam-file-2))
+
+    (is (not-throw?
+         (with-open [r (core/reader tmp-shuffled-bam-file :ignore-index true)
+                     w (core/writer tmp-queryname-sorted-sam-file-2)]
+           (sorter/sort-by-qname r w {:chunk-size 3 :cache-fmt :sam}))))
+    (with-reader sorter/sorted-by? tmp-queryname-sorted-sam-file-2)
+    (is (qname-sorted? tmp-queryname-sorted-sam-file-2))))
 
 (deftest-slow about-sorting-medium-file
   (with-before-after {:before (prepare-cache!)


### PR DESCRIPTION
#### Summary
This PR improves functions and performance of `cljam.sorter`.
Also resolves task 7 in #61.

#### Changes
- Improve performance of `sort-by-pos` (about 2x faster).
- Implemented `sort-by-qname`.
- Configurable chunk size.
- Sort SAM and directly output to BAM and vice versa.
- Add tests.

#### Affected modules
- `cljam.sorter`
- `cljam.bam`
- `cljam.sam`

#### Notes
- `sort-by-pos` does not check `qname`, the same as samtools.