### PR TITLE
Fix test of BCF writer

### DIFF
--- a/src/cljam/bcf/reader.clj
+++ b/src/cljam/bcf/reader.clj
@@ -146,8 +146,9 @@
     (.position shared 0)
     (assoc m :chr (:id (contigs chrom-id)) :pos pos :rlen rlen)))
 
-(defn- parse-data-line-deep [{:keys [^ByteBuffer shared ^ByteBuffer individual]}]
+(defn- parse-data-line-deep
   "Parses full data of a variant. Returns a map containing indices for meta-info."
+  [{:keys [^ByteBuffer shared ^ByteBuffer individual]}]
   (let [chrom-id (lsb/read-int shared)
         pos (inc (lsb/read-int shared))
         rlen (lsb/read-int shared)

--- a/test/cljam/bcf/t_writer.clj
+++ b/test/cljam/bcf/t_writer.clj
@@ -49,15 +49,13 @@
 
 (deftest about-encode-variant-indv
   (let [bb (#'bcf-writer/encode-variant-indv
-            {:genotype {0 [0 1] 1 [16 32] :n-sample 2}})]
+            {:genotype {0 [0 1] 1 [16 32]} :n-sample 2})]
     (is
      (= (seq (.array ^ByteBuffer bb))
         [0x11 0
          0x11 0 1
          0x11 1
-         0x11 16 32]))))
-
-(deftest about-encode-variant-indv
+         0x11 16 32])))
   (let [bb (#'bcf-writer/encode-variant-indv
             {:genotype {0 [[2 3] [4 3] [4 4]] 1 [48 48 43] 2 [1 8 5] 3 [[51 51] [51 51] [nil nil]]}
              :n-sample 3})]


### PR DESCRIPTION
Fixes test redefinition and order of arg vec and docstring.