### PR TITLE
Refactor cljam.algo.level.

### DIFF
--- a/src/cljam/algo/level.clj
+++ b/src/cljam/algo/level.clj
@@ -1,12 +1,11 @@
 (ns cljam.algo.level
   "Level analyzer of alignments in BAM."
-  (:require [clojure.java.io :refer [file]]
+  (:require [clojure.java.io :as cio]
             [com.climate.claypoole :as cp]
             [cljam.common :refer [get-exec-n-threads *n-threads*]]
             [cljam.io.protocols :as protocols]
             [cljam.io.sam :as sam]
-            [cljam.io.util :refer [sam-reader? bam-reader?]]
-            [cljam.io.sam.util :as sam-util]
+            [cljam.io.util :as io-util]
             [cljam.util :as util]))
 
 (defmulti add-level
@@ -15,118 +14,69 @@
   {:arglists '([rdr wtr])}
   (fn [rdr wtr]
     (cond
-      (sam-reader? rdr) :sam
-      (bam-reader? rdr) :bam
+      (and (io-util/sam-reader? rdr) (io-util/sam-writer? wtr)) :sam
+      (and (io-util/bam-reader? rdr) (io-util/bam-writer? wtr)) :bam
       :else nil)))
 
 (defmethod add-level :sam
-  [rdr wtr]
+  [_ _]
   (throw (ex-info "SAM not supported yet." {:type :sam-not-supported}))
   ;; TODO implement
   )
 
-(defn- collide?
-  "Returns true if two given segments are overlapped.
-  Segment must be represented as a vector of length two."
-  [[s1 e1] [s2 e2]]
-  (cond
-    (< e1 s2) false
-    (< e2 s1) false
-    :else true))
+(defn- add-level!
+  "Append level info to :options of an alignment. Requires volatile vector as a state."
+  [state a]
+  (let [pos (long (:pos a))
+        end (long (:end a))
+        s @state
+        lv (loop [i 0 x (first s) xs (next s)]
+             (if-not x
+               (do (vswap! state conj end) i)
+               (if (< x pos)
+                 (do (vswap! state assoc i end) i)
+                 (recur (inc i) (first xs) (next xs)))))]
+    (update a :options conj {:LV {:type "i" :value (int lv)}})))
 
-(defn- map-with-state
-  "Like map, returns a lazy sequence consisting of the results of applying f to each items of coll.
-  The difference is that f must take a state and return the updated one."
-  [f state coll]
-  (lazy-seq (when-let [s (seq coll)]
-              (let [[next-state result] (f state (first s))]
-                (cons result (map-with-state f next-state (rest s)))))))
-
-(defn- calc-level
-  "Calculates updated alignments with level information as an option.
-  levels is a vector consisting of rightmost segments in each level.
-  alignment is a deeply parsed alignment data with pos and seq.
-  This returns updated levels and alignment as a vector."
-  [levels {:keys [pos] :as alignment}]
-  (let [segment [pos (sam-util/get-end alignment)]
-        level (or (some identity (map-indexed #(when-not (collide? segment %2) %1) (vals levels)))
-                  (count levels))]
-    [(assoc levels level segment)
-     (update alignment :options conj {:LV {:type "i" :value (int level)}})]))
-
-(defn- clean!
-  "Deletes a cache file at given path."
-  [path]
-  (let [f (file path)]
-    (when (.exists f)
-      (.delete f))))
-
-(defn- create-level-cache!
-  "Create a temporary BAM file consisting of alignments of a single chromosome."
-  [chr length source-path cache-path]
-  (with-open [local-rdr (sam/bam-reader source-path :ignore-index true)
-              cache-wtr (sam/bam-writer cache-path)]
-    (let [hdr (sam/read-header local-rdr)
-          alignments (->> {:depth :deep}
-                          (sam/read-alignments local-rdr)
-                          (map-with-state calc-level (sorted-map)))]
-      (sam/write-header cache-wtr hdr)
-      (sam/write-refs cache-wtr hdr)
-      (sam/write-alignments cache-wtr alignments hdr))))
+(defn- cache-path
+  "Create a path to the cache file."
+  [rdr i]
+  (->> i
+       (format "%s_%06d.bam" (util/basename (protocols/reader-path rdr)))
+       (cio/file util/temp-dir)
+       (.getCanonicalPath)))
 
 (defn- add-level-mt
   "Adds level information to alignments from rdr and write them to wtr.
   Level calculation process is multithreaded."
   [rdr wtr]
-  (let [source-path (protocols/reader-path rdr)
-        cache-name-fn #(->> (str (util/basename source-path) "_" % ".cache")
-                            (file util/temp-dir)
-                            (.getPath))
-        level-cache-name-fn #(->> (str (util/basename source-path) "_" % ".level.cache")
-                                  (file util/temp-dir)
-                                  (.getPath))
-        hdr (sam/read-header rdr)
-        ;; Split into BAM files according to chromosomes.
-        caches (doall
-                (map (fn [{:keys [SN LN]}]
-                       (let [cache-path (cache-name-fn SN)
-                             blocks (sam/read-blocks rdr {:chr SN :start 0 :end LN})]
-                         (with-open [cache-wtr (sam/bam-writer cache-path)]
-                           (sam/write-header cache-wtr hdr)
-                           (sam/write-refs cache-wtr hdr)
-                           (sam/write-blocks cache-wtr blocks))
-                         cache-path))
-                     (hdr :SQ)))
-        leval-caches (cp/with-shutdown! [pool (cp/threadpool (get-exec-n-threads))]
-                       (doall
-                        (cp/pmap pool
-                                 (fn [{:keys [SN LN]}]
-                                   (let [cache-path (cache-name-fn SN)
-                                         level-cache-path (level-cache-name-fn SN)]
-                                     (create-level-cache! SN LN cache-path level-cache-path)
-                                     (clean! cache-path)
-                                     level-cache-path))
-                                 (hdr :SQ))))]
-    (doseq [cache caches]
-      (clean! cache))
-    ;; Merge cache files
+  (let [hdr (sam/read-header rdr)]
     (sam/write-header wtr hdr)
     (sam/write-refs wtr hdr)
-    (doseq [cache leval-caches]
-      (with-open [cache-rdr (sam/bam-reader cache :ignore-index true)]
-        (sam/write-blocks wtr (sam/read-blocks cache-rdr)))
-      (clean! cache))))
-
-(defn- check-bam-sorted!
-  "Checks if the bam file is sorted by coordinate and throws an exception if not."
-  [rdr]
-  (when-not (-> rdr sam/read-header :HD :SO (= "coordinate"))
-    (throw (ex-info "Source BAM file must be sorted by coordinate."
-                    {:type :bam-not-sorted}))))
+    (cp/with-shutdown! [p (cp/threadpool (get-exec-n-threads))]
+      ;; split and compute levels
+      (let [xs (cp/pfor p [[i {:keys [name]}] (map vector (range) (sam/read-refs rdr))]
+                 (let [cache (cache-path rdr i)]
+                   (with-open [r (sam/reader rdr)
+                               w (sam/writer cache)]
+                     (sam/write-header w hdr)
+                     (sam/write-refs w hdr)
+                     (->> {:chr name}
+                          (sam/read-alignments r)
+                          (map (partial add-level! (volatile! [])))
+                          (#(sam/write-alignments w % hdr))))
+                   cache))]
+        ;; merge
+        (doseq [cache xs]
+          (with-open [r (sam/reader cache :ignore-index true)]
+            (sam/write-blocks wtr (sam/read-blocks r)))
+          (.delete (cio/file cache)))))))
 
 (defmethod add-level :bam
   [rdr wtr & {:keys [n-threads]
               :or {n-threads 0}}]
-  (check-bam-sorted! rdr)
+  (when-not (-> rdr sam/read-header :HD :SO (= "coordinate"))
+    (throw (ex-info "Source BAM file must be sorted by coordinate."
+                    {:type :bam-not-sorted})))
   (binding [*n-threads* n-threads]
     (add-level-mt rdr wtr)))


### PR DESCRIPTION
#### Summary
Refactored `cljam.algo.level`

#### Changes
- Reduced the number of stages, 3 => 2.
  - [before] serial splitting -> parallel processing -> serial merging
  - [after] parallel processing & splitting -> serial merging
- Use volatile thread-local state to compute levels.