### PR TITLE
Refactor BAI I/O

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -11,7 +11,7 @@
                  [bgzf4j "0.1.0"]
                  [com.climate/claypoole "1.1.4"]
                  [camel-snake-kebab "0.4.0"]
-                 [proton "0.1.1"]]
+                 [proton "0.1.2"]]
   :profiles {:dev {:dependencies [[org.clojure/clojure "1.8.0"]
                                   [cavia "0.4.1"]]
                    :plugins [[lein-binplus "0.6.2"]

--- a/src/cljam/algo/bam_indexer.clj
+++ b/src/cljam/algo/bam_indexer.clj
@@ -7,7 +7,7 @@
 (defn create-index
   "Creates a BAM index file from the BAM file."
   [in-bam out-bai & {:keys [n-threads] :or {n-threads 0}}]
-  (with-open [r (sam/bam-reader in-bam :ignore-index true)]
+  (with-open [r (sam/bam-reader in-bam)]
     (binding [*n-threads* n-threads]
       (bai-core/create-index out-bai
                              (sam/read-blocks r {} {:mode :pointer})

--- a/src/cljam/algo/level.clj
+++ b/src/cljam/algo/level.clj
@@ -68,7 +68,7 @@
                    cache))]
         ;; merge
         (doseq [cache xs]
-          (with-open [r (sam/reader cache :ignore-index true)]
+          (with-open [r (sam/reader cache)]
             (sam/write-blocks wtr (sam/read-blocks r)))
           (.delete (cio/file cache)))))))
 

--- a/src/cljam/algo/sorter.clj
+++ b/src/cljam/algo/sorter.clj
@@ -118,7 +118,7 @@
 (defn- merge**
   "Merges multiple SAM/BAM files into single SAM/BAM file."
   [wtr hdr files key-fn read-fn write-fn]
-  (let [rdrs (map #(sam/reader % :ignore-index true) files)
+  (let [rdrs (map sam/reader files)
         alns (map read-fn rdrs)]
     (sam/write-header wtr hdr)
     (sam/write-refs wtr hdr)

--- a/src/cljam/io/bam/core.clj
+++ b/src/cljam/io/bam/core.clj
@@ -1,13 +1,14 @@
 (ns cljam.io.bam.core
   "The core of BAM features."
   (:require [clojure.java.io :as cio]
+            [clojure.string :as cstr]
             [cljam.io.bam [common :refer [bam-magic]]
                           [reader :as reader]
                           [writer :as writer]]
             [cljam.io.bam-index :as bai]
             [cljam.io.util.lsb :as lsb])
   (:import java.util.Arrays
-           [java.io DataInputStream DataOutputStream IOException]
+           [java.io DataInputStream DataOutputStream IOException FileNotFoundException]
            [bgzf4j BGZFInputStream BGZFOutputStream]
            cljam.io.bam.reader.BAMReader
            cljam.io.bam.writer.BAMWriter))
@@ -15,22 +16,29 @@
 ;; Reading
 ;; -------
 
-(defn- bam-index [f & {:keys [ignore]
-                       :or {ignore false}}]
-  (if-not ignore
-    (let [bai-f (str f ".bai")]
-      (if (.isFile (cio/file bai-f))
-        (bai/bam-index bai-f)
-        (throw (IOException. "Could not find BAM Index file"))))))
+(defn- bam-index
+  "Load an index file (BAI) for the given BAM file."
+  [bam-path {:keys [ignore]}]
+  (let [bai-path (->> ["$1.bai" ".bai" "$1.BAI" ".BAI"]
+                      (eduction
+                       (comp
+                        (map #(cstr/replace bam-path #"(?i)(\.bam)$" %))
+                        (filter #(.isFile (cio/file %)))))
+                      first)]
+    (if (and bai-path (not ignore))
+      (bai/bam-index bai-path)
+      (throw (FileNotFoundException. (str "Could not find BAM Index file for " bam-path))))))
 
-(defn ^BAMReader reader [f {:keys [ignore-index]
-                            :or {ignore-index false}}]
+(defn ^BAMReader reader
+  "Creates a `cljam.io.bam.BAMReader` instancer for the given path.
+  Pass {:ignore-index true} to force to ignore BAI file."
+  [f {:keys [ignore-index]}]
   (let [rdr (BGZFInputStream. (cio/file f))
         data-rdr (DataInputStream. rdr)]
     (when-not (Arrays/equals ^bytes (lsb/read-bytes data-rdr 4) (.getBytes ^String bam-magic))
       (throw (IOException. "Invalid BAM file")))
     (let [{:keys [header refs]} (reader/load-headers data-rdr)
-          index-delay (delay (bam-index f :ignore ignore-index))]
+          index-delay (delay (bam-index f {:ignore ignore-index}))]
       (BAMReader. (.getAbsolutePath (cio/file f))
                   header refs rdr data-rdr index-delay (.getFilePointer rdr)))))
 

--- a/src/cljam/io/bam/decoder.clj
+++ b/src/cljam/io/bam/decoder.clj
@@ -150,9 +150,9 @@
       {:rname rname, :pos pos, :meta {:cigar-bytes cigar-bytes}})))
 
 (defn pointer-decode-alignment-block
-  [block refs]
+  [block _]
   (let [buffer (ByteBuffer/wrap (:data block))]
-    (let [rname       (or (sam-util/ref-name refs (lsb/read-int buffer)) "*")
+    (let [ref-id      (lsb/read-int buffer)
           pos         (inc (lsb/read-int buffer))
           l-read-name (int (lsb/read-ubyte buffer))
           _           (lsb/skip buffer 3)
@@ -160,7 +160,7 @@
           flag        (lsb/read-ushort buffer)
           _           (lsb/skip buffer (+ 16 l-read-name))
           cigar-bytes (lsb/read-bytes buffer (* n-cigar-op 4))]
-      {:flag flag, :rname rname, :pos pos,
+      {:flag flag, :ref-id ref-id, :pos pos,
        :meta {:chunk {:beg (:pointer-beg block),
                       :end (:pointer-end block)}
               :cigar-bytes cigar-bytes}})))

--- a/src/cljam/io/bam_index/chunk.clj
+++ b/src/cljam/io/bam_index/chunk.clj
@@ -6,54 +6,56 @@
 ;;; It consists of a start position and a end position.
 ;;; A chunk is a map like `{:beg 10, :end 20}`.
 
+(defrecord Chunk [^long beg ^long end])
+
 (defn compare
   "Returns a negative if chunk1 is earlier than chunk2, a positive if it is
   later, 0 if it is equal."
-  [chunk1 chunk2]
-  (let [ret (Long/signum (- (:beg chunk1) (:beg chunk2)))]
+  [^Chunk chunk1 ^Chunk chunk2]
+  (let [ret (Long/signum (- (.beg chunk1) (.beg chunk2)))]
     (if (zero? ret)
-      (Long/signum (- (:end chunk1) (:end chunk2)))
+      (Long/signum (- (.end chunk1) (.end chunk2)))
       ret)))
 
 (defn overlap?
   "Returns true if the two chunks overlap."
-  [chunk1 chunk2]
+  [^Chunk chunk1 ^Chunk chunk2]
   (let [comparison (compare chunk1 chunk2)]
     (or (zero? comparison)
         (let [left (if (neg? comparison) chunk1 chunk2)
               right (if (pos? comparison) chunk1 chunk2)
-              left-fp (bgzf/get-block-address (:end left))
-              right-fp (bgzf/get-block-address (:beg right))]
+              left-fp (bgzf/get-block-address (.end left))
+              right-fp (bgzf/get-block-address (.beg right))]
           (or (> left-fp right-fp)
               (and (= left-fp right-fp)
-                   (let [left-offset (bgzf/get-block-offset (:end left))
-                         right-offset (bgzf/get-block-offset (:beg right))]
+                   (let [left-offset (bgzf/get-block-offset (.end left))
+                         right-offset (bgzf/get-block-offset (.beg right))]
                      (> left-offset right-offset))))))))
 
 (defn adjacent?
   "Returns true if the two chunks are adjacent."
-  [chunk1 chunk2]
-  (or (and (= (bgzf/get-block-address (:end chunk1))
-              (bgzf/get-block-address (:beg chunk2)))
-           (= (bgzf/get-block-offset (:end chunk1))
-              (bgzf/get-block-offset (:beg chunk2))))
-      (and (= (bgzf/get-block-address (:beg chunk1))
-              (bgzf/get-block-address (:end chunk2)))
-           (= (bgzf/get-block-offset (:beg chunk1))
-              (bgzf/get-block-offset (:end chunk2))))))
+  [^Chunk chunk1 ^Chunk chunk2]
+  (or (and (= (bgzf/get-block-address (.end chunk1))
+              (bgzf/get-block-address (.beg chunk2)))
+           (= (bgzf/get-block-offset (.end chunk1))
+              (bgzf/get-block-offset (.beg chunk2))))
+      (and (= (bgzf/get-block-address (.beg chunk1))
+              (bgzf/get-block-address (.end chunk2)))
+           (= (bgzf/get-block-offset (.beg chunk1))
+              (bgzf/get-block-offset (.end chunk2))))))
 
 (defn optimize-chunks
-  [chunks min-offset]
+  [chunks ^long min-offset]
   (let [chunks (sort compare chunks)]
-    (loop [[f & r] chunks
-           last-chunk nil
-           ret []]
+    (loop [[^Chunk f & r] chunks
+           ^Chunk last-chunk nil
+           ret (transient [])]
       (if f
         (cond
-         (<= (:end f) min-offset) (recur r last-chunk ret)
-         (nil? last-chunk) (recur r f (conj ret f))
+         (<= (.end f) min-offset) (recur r last-chunk ret)
+         (nil? last-chunk) (recur r f (conj! ret f))
          (and (not (overlap? last-chunk f))
-              (not (adjacent? last-chunk f))) (recur r f (conj ret f))
-         (> (:end f) (:end last-chunk)) (let [l (assoc last-chunk :end (:end f))] (recur r l (conj (pop ret) l)))
+              (not (adjacent? last-chunk f))) (recur r f (conj! ret f))
+         (> (.end f) (.end last-chunk)) (let [l (assoc last-chunk :end (.end f))] (recur r l (conj! (pop! ret) l)))
          :else (recur r last-chunk ret))
-        ret))))
+        (persistent! ret)))))

--- a/src/cljam/io/sam.clj
+++ b/src/cljam/io/sam.clj
@@ -23,11 +23,10 @@
   (sam-reader/reader f))
 
 (defn ^BAMReader bam-reader
-  "Returns an open cljam.io.bam.reader.BAMReader of f with option:
-   :ignore-index - returns reader without index, default false.
-  Should be used inside with-open to ensure the reader is properly closed."
-  [f & option]
-  (bam-core/reader f option))
+  "Returns an open cljam.io.bam.reader.BAMReader of f. Should be used inside
+  with-open to ensure the reader is properly closed."
+  [f]
+  (bam-core/reader f))
 
 (defn ^BAMReader clone-bam-reader
   "Clones bam reader sharing persistent objects."
@@ -38,11 +37,11 @@
   "Selects suitable reader from f's extension, returning the reader. Opens a new
   reader if given a path, clones the reader if given a reader. This function
   supports SAM and BAM formats."
-  [f & option]
+  [f]
   (if (string? f)
     (case (io-util/file-type f)
       :sam (sam-reader f)
-      :bam (apply bam-reader f option)
+      :bam (bam-reader f)
       (throw (IllegalArgumentException. "Invalid file type")))
     (cond
       (io-util/bam-reader? f) (clone-bam-reader f)

--- a/src/cljam/tools/cli.clj
+++ b/src/cljam/tools/cli.clj
@@ -64,7 +64,7 @@
       (with-open [^Closeable r (condp = (:format options)
                                  "auto" (sam/reader f)
                                  "sam"  (sam/sam-reader f)
-                                 "bam"  (sam/bam-reader f :ignore-index true))]
+                                 "bam"  (sam/bam-reader f))]
         (when (:header options)
           (println (stringify-header (sam/read-header r))))
         (doseq [aln (sam/read-alignments r {})]
@@ -260,7 +260,7 @@
      (not= (count arguments) 1) (exit 1 (pileup-usage summary))
      errors (exit 1 (error-msg errors)))
     (let [f (first arguments)]
-      (with-open [r (sam/reader f :ignore-index false)]
+      (with-open [r (sam/reader f)]
         (when (= (type r) cljam.io.sam.reader.SAMReader)
           (exit 1 "Not support SAM file"))
         (when-not (sorter/sorted-by? r)
@@ -347,7 +347,7 @@
       (not= (count arguments) 2) (exit 1 (level-usage summary))
       errors (exit 1 (error-msg errors)))
     (let [[in out] arguments]
-      (with-open [r (sam/reader in :ignore-index false)
+      (with-open [r (sam/reader in)
                   w (sam/writer out)]
         (level/add-level r w))))
   nil)

--- a/test/cljam/algo/t_bam_indexer.clj
+++ b/test/cljam/algo/t_bam_indexer.clj
@@ -39,7 +39,7 @@
                                     ;; generate incomplete bam on the fly
                                     (spit-bam-for-test f test-sam-incomplete-alignments)
                                     ;; TODO: go independent from sorter
-                                    (with-open [rdr (sam/bam-reader f :ignore-index true)
+                                    (with-open [rdr (sam/bam-reader f)
                                                 wtr (sam/bam-writer sorted-f)]
                                       (sorter/sort-by-pos rdr wtr)))
                         :after (clean-cache!)}

--- a/test/cljam/algo/t_sorter.clj
+++ b/test/cljam/algo/t_sorter.clj
@@ -128,7 +128,7 @@
                       :after (clean-cache!)}
     ;; coordinate
     (is (not-throw?
-         (with-open [r (sam/reader tmp-shuffled-bam-file :ignore-index true)
+         (with-open [r (sam/reader tmp-shuffled-bam-file)
                      w (sam/writer tmp-coordinate-sorted-bam-bam-file)]
            (sorter/sort-by-pos r w {:chunk-size 3}))))
     (is (with-reader sorter/sorted-by? tmp-coordinate-sorted-bam-bam-file))
@@ -136,7 +136,7 @@
     (is (coord-sorted? tmp-coordinate-sorted-bam-bam-file))
 
     (is (not-throw?
-         (with-open [r (sam/reader tmp-shuffled-sam-file :ignore-index true)
+         (with-open [r (sam/reader tmp-shuffled-sam-file)
                      w (sam/writer tmp-coordinate-sorted-sam-sam-file)]
            (sorter/sort-by-pos r w {:chunk-size 3 :cache-fmt :sam}))))
     (is (with-reader sorter/sorted-by? tmp-coordinate-sorted-sam-sam-file))
@@ -145,14 +145,14 @@
 
     ;; queryname
     (is (not-throw?
-         (with-open [r (sam/reader tmp-shuffled-bam-file :ignore-index true)
+         (with-open [r (sam/reader tmp-shuffled-bam-file)
                      w (sam/writer tmp-queryname-sorted-bam-file-2)]
            (sorter/sort-by-qname r w {:chunk-size 3}))))
     (with-reader sorter/sorted-by? tmp-queryname-sorted-bam-file-2)
     (is (qname-sorted? tmp-queryname-sorted-bam-file-2))
 
     (is (not-throw?
-         (with-open [r (sam/reader tmp-shuffled-bam-file :ignore-index true)
+         (with-open [r (sam/reader tmp-shuffled-bam-file)
                      w (sam/writer tmp-queryname-sorted-sam-file-2)]
            (sorter/sort-by-qname r w {:chunk-size 3 :cache-fmt :sam}))))
     (with-reader sorter/sorted-by? tmp-queryname-sorted-sam-file-2)

--- a/test/cljam/io/t_sam.clj
+++ b/test/cljam/io/t_sam.clj
@@ -80,61 +80,61 @@
   (with-before-after {:before (do (prepare-cache!)
                                   (spit-bam-for-test temp-bam-file test-sam))
                       :after (clean-cache!)}
-    (with-open [rdr (sam/bam-reader temp-bam-file :ignore-index false)]
+    (with-open [rdr (sam/bam-reader temp-bam-file)]
       (is (= (sam/read-refs rdr) test-sam-refs))
       (is (= (sam/read-alignments rdr) (:alignments test-sam))))
-    (with-open [rdr (sam/bam-reader temp-bam-file :ignore-index false)]
+    (with-open [rdr (sam/bam-reader temp-bam-file)]
       (is (= (sam/read-refs rdr) test-sam-refs))
       (is (thrown? Exception (sam/read-alignments rdr {:chr "ref2"}))))
-    (with-open [rdr (sam/bam-reader temp-bam-file :ignore-index false)]
+    (with-open [rdr (sam/bam-reader temp-bam-file)]
       (is (= (sam/read-refs rdr) test-sam-refs))
       (is (= (sam/read-alignments rdr {:depth :deep}) (:alignments test-sam))))
-    (with-open [rdr (sam/bam-reader temp-bam-file :ignore-index false)]
+    (with-open [rdr (sam/bam-reader temp-bam-file)]
       (is (= (sam/read-refs rdr) test-sam-refs))
       (is (shallow= (sam/read-alignments rdr {:depth :shallow})
                     (:alignments test-sam))))
-    (with-open [rdr (sam/bam-reader temp-bam-file :ignore-index false)]
+    (with-open [rdr (sam/bam-reader temp-bam-file)]
       (is (= (sam/read-refs rdr) test-sam-refs))
       (is (pointer= (sam/read-alignments rdr {:depth :pointer})
                     (:alignments test-sam))))
-    (with-open [rdr (sam/bam-reader temp-bam-file :ignore-index false)]
+    (with-open [rdr (sam/bam-reader temp-bam-file)]
       (is (= (sam/read-refs rdr) test-sam-refs))
       (is (= (data->clj (sam/read-blocks rdr)) test-sam-data)))
-    (with-open [rdr (sam/bam-reader temp-bam-file :ignore-index false)]
+    (with-open [rdr (sam/bam-reader temp-bam-file)]
       (is (= (sam/read-refs rdr) test-sam-refs))
       (is (thrown? Exception (data->clj (sam/read-blocks rdr {:chr "ref2"})))))))
 
 (deftest bam-reader-with-index-test
   (with-before-after {:before (prepare-cache!)
                       :after (clean-cache!)}
-    (with-open [rdr (sam/bam-reader test-sorted-bam-file :ignore-index false)]
+    (with-open [rdr (sam/bam-reader test-sorted-bam-file)]
       (is (= (sam/read-alignments rdr {:chr "ref2"})
              (drop 6 (:alignments test-sam-sorted-by-pos)))))
-    (with-open [rdr (sam/bam-reader test-sorted-bam-file :ignore-index false)]
+    (with-open [rdr (sam/bam-reader test-sorted-bam-file)]
       (is (= (sam/read-alignments rdr {:chr "ref2" :start 21})
              (drop 7 (:alignments test-sam-sorted-by-pos)))))
-    (with-open [rdr (sam/bam-reader test-sorted-bam-file :ignore-index false)]
+    (with-open [rdr (sam/bam-reader test-sorted-bam-file)]
       (is (= (sam/read-alignments rdr {:chr "ref2" :end 9})
              (take 3 (drop 6 (:alignments test-sam-sorted-by-pos))))))
-    (with-open [rdr (sam/bam-reader test-sorted-bam-file :ignore-index false)]
+    (with-open [rdr (sam/bam-reader test-sorted-bam-file)]
       (is (= (sam/read-alignments rdr {:chr "ref2" :start 10 :end 12})
              (take 5 (drop 6 (:alignments test-sam-sorted-by-pos))))))
-    (with-open [rdr (sam/bam-reader test-sorted-bam-file :ignore-index false)]
+    (with-open [rdr (sam/bam-reader test-sorted-bam-file)]
       (is (= (data->clj (sam/read-blocks rdr))
              test-sorted-bam-data)))
-    (with-open [rdr (sam/bam-reader test-sorted-bam-file :ignore-index false)]
+    (with-open [rdr (sam/bam-reader test-sorted-bam-file)]
       (is (= (map #(dissoc % :pos :qname :rname :flag :ref-id)
                   (data->clj (sam/read-blocks rdr {:chr "ref2"})))
              (drop 6 test-sorted-bam-data))))
-    (with-open [rdr (sam/bam-reader test-sorted-bam-file :ignore-index false)]
+    (with-open [rdr (sam/bam-reader test-sorted-bam-file)]
       (is (= (map #(dissoc % :pos :qname :rname :flag :ref-id)
                   (data->clj (sam/read-blocks rdr {:chr "ref2" :start 2})))
              (drop 7 test-sorted-bam-data))))
-    (with-open [rdr (sam/bam-reader test-sorted-bam-file :ignore-index false)]
+    (with-open [rdr (sam/bam-reader test-sorted-bam-file)]
       (is (= (map #(dissoc % :pos :qname :rname :flag :ref-id)
                   (data->clj (sam/read-blocks rdr {:chr "ref2" :end 2})))
              (take 2 (drop 6 test-sorted-bam-data)))))
-    (with-open [rdr (sam/bam-reader test-sorted-bam-file :ignore-index false)]
+    (with-open [rdr (sam/bam-reader test-sorted-bam-file)]
       (is (= (map #(dissoc % :pos :qname :rname :flag :ref-id)
                   (data->clj (sam/read-blocks rdr {:chr "ref2" :start 4 :end 12})))
              (take 3 (drop 8 test-sorted-bam-data)))))))
@@ -142,14 +142,14 @@
 (deftest bam-reader-invalid-test
   (with-before-after {:before (prepare-cache!)
                       :after (clean-cache!)}
-    (is (thrown? Exception (sam/bam-reader invalid-bam-file-1 :ignore-index true)))
-    (is (thrown? java.io.IOException (sam/bam-reader invalid-bam-file-2 :ignore-index true)))
-    (is (thrown? java.io.IOException (sam/bam-reader not-found-bam-file :ignore-index true)))))
+    (is (thrown? Exception (sam/bam-reader invalid-bam-file-1)))
+    (is (thrown? java.io.IOException (sam/bam-reader invalid-bam-file-2)))
+    (is (thrown? java.io.IOException (sam/bam-reader not-found-bam-file)))))
 
 (deftest-slow bam-reader-medium-test
   (with-before-after {:before (prepare-cache!)
                       :after (clean-cache!)}
-    (with-open [rdr (sam/bam-reader medium-bam-file :ignore-index true)]
+    (with-open [rdr (sam/bam-reader medium-bam-file)]
       (let [header (sam/read-header rdr)
             refs (sam/read-refs rdr)
             alns (sam/read-alignments rdr)]
@@ -164,7 +164,7 @@
   (with-before-after {:before (do (prepare-cache!)
                                   (prepare-cavia!))
                       :after (clean-cache!)}
-    (with-open [rdr (sam/bam-reader large-bam-file :ignore-index true)]
+    (with-open [rdr (sam/bam-reader large-bam-file)]
       (is (= (sam/read-refs rdr) large-sam-refs))
       (is (not-throw? (sam/read-alignments rdr))))))
 

--- a/test/cljam/t_common.clj
+++ b/test/cljam/t_common.clj
@@ -81,7 +81,7 @@
      :alignments (doall (sam/read-alignments r {}))}))
 
 (defn slurp-bam-for-test [f]
-  (with-open [r (sam/bam-reader f :ignore-index true)]
+  (with-open [r (sam/bam-reader f)]
     {:header (sam/read-header r)
      :alignments (doall (sam/read-alignments r {}))}))
 
@@ -438,7 +438,7 @@
         target-rnames))))
 
 (defn coord-sorted? [f]
-  (with-open [r (sam/reader f :ignore-index true)]
+  (with-open [r (sam/reader f)]
     (let [rname->id (into {} (map-indexed (fn [i v] [(:name v) i]) (sam/read-refs r)))
           upos #(if (zero? %) Integer/MAX_VALUE %)]
       (some?
@@ -455,7 +455,7 @@
         (sam/read-alignments r))))))
 
 (defn qname-sorted? [f]
-  (with-open [r (sam/reader f :ignore-index true)]
+  (with-open [r (sam/reader f)]
     (some?
      (reduce
       (fn [r x]

--- a/test/cljam/tools/t_cli.clj
+++ b/test/cljam/tools/t_cli.clj
@@ -131,7 +131,7 @@
                  (with-out-file temp-out (cli/level [test-bam-file temp-bam]))))
     (is (not-throw? (with-out-file temp-out (cli/level [test-sorted-bam-file
                                                         temp-bam]))))
-    (with-open [rdr (sam/bam-reader temp-bam :ignore-index true)]
+    (with-open [rdr (sam/bam-reader temp-bam)]
       (is (= (map #(first (keep :LV (:options %)))
                   (sam/read-alignments rdr))
              test-sorted-bam-levels)))))


### PR DESCRIPTION
#### summary

Overall refactoring of BAI module, including performance improvements.

#### changes

- Use the linear index to reduce spans.
    - For some reason, the linear index was not used to optimize chunks.
    - > Given a region [rbeg,rend), we only need to visit a chunk whose end file offset is larger than the file offset of the 16kbp window containing rbeg.
- Search more BAI files for a BAM file.
    - Given `"foo.bam"`, `["foo.bam.bai", "foo.bai", "foo.bam.BAI", "foo.BAI"]` are now looked up.
- Use records for chunks.
- Use ref-index instead of rname in bam index writer.
- Remove unused local vars.

Thanks.