### PR TITLE
Tweak the normalization function for chromosome name

### DIFF
--- a/src/cljam/util/chromosome.clj
+++ b/src/cljam/util/chromosome.clj
@@ -45,7 +45,7 @@
              normalize-chromosome-prefix)
          (if version-suffix (cstr/lower-case version-suffix)))))
 
-(defn is-primary?
+(defn is-primary-chromosome?
   [s]
   (not (nil? (re-matches #"^chr([0-9]{1,2}|X|Y|M|MT)$"
                          (normalize-chromosome-key s)))))

--- a/src/cljam/util/chromosome.clj
+++ b/src/cljam/util/chromosome.clj
@@ -13,6 +13,11 @@
   [s]
   (cstr/replace s #"(?i)^chr" ""))
 
+(defn- split-version-suffix
+  [s]
+  (let [[_ base suffix leftover] (re-matches #"(.+?)((?i)v[0-9](_alt|_random)?)?$" s)]
+    [base suffix]))
+
 (defn- normalize-chromosome-prefix
   [s]
   (if-let [[_ base leftover] (re-matches #"(?i)chr([0-9]{1,2}|X|Y|M|MT|Un)(.*)" s)]
@@ -32,7 +37,9 @@
 (defn normalize-chromosome-key
   "Normalizes chromosome name."
   [s]
-  (-> s
-      normalize-name
-      prepend-chromosome-prefix
-      normalize-chromosome-prefix))
+  (let [[base version-suffix] (split-version-suffix s)]
+    (str (-> base
+             normalize-name
+             prepend-chromosome-prefix
+             normalize-chromosome-prefix)
+         (if version-suffix (cstr/lower-case version-suffix)))))

--- a/src/cljam/util/chromosome.clj
+++ b/src/cljam/util/chromosome.clj
@@ -15,7 +15,7 @@
 
 (defn- split-version-suffix
   [s]
-  (let [[_ base suffix leftover] (re-matches #"(.+?)((?i)v[0-9](_alt|_random)?)?$" s)]
+  (let [[_ base suffix _] (re-matches #"(.+?)((?i)v[0-9](_alt|_random)?)?" s)]
     [base suffix]))
 
 (defn- normalize-chromosome-prefix
@@ -46,5 +46,5 @@
 
 (defn is-primary-chromosome?
   [s]
-  (not (nil? (re-matches #"^chr([0-9]{1,2}|X|Y|M|MT)$"
-                         (normalize-chromosome-key s)))))
+  (some? (re-matches #"^chr([0-9]{1,2}|X|Y|M|MT)"
+                     (normalize-chromosome-key s))))

--- a/src/cljam/util/chromosome.clj
+++ b/src/cljam/util/chromosome.clj
@@ -1,6 +1,7 @@
 (ns cljam.util.chromosome
   "Utilities for handling chromosome name."
-  (:require [clojure.string :as cstr]))
+  (:require [clojure.string :as cstr]
+            [clojure.string :as string]))
 
 (defn normalize-name
   [s]
@@ -43,3 +44,8 @@
              prepend-chromosome-prefix
              normalize-chromosome-prefix)
          (if version-suffix (cstr/lower-case version-suffix)))))
+
+(defn is-primary?
+  [s]
+  (not (nil? (re-matches #"^chr([0-9]{1,2}|X|Y|M|MT)$"
+                         (normalize-chromosome-key s)))))

--- a/src/cljam/util/chromosome.clj
+++ b/src/cljam/util/chromosome.clj
@@ -1,7 +1,6 @@
 (ns cljam.util.chromosome
   "Utilities for handling chromosome name."
-  (:require [clojure.string :as cstr]
-            [clojure.string :as string]))
+  (:require [clojure.string :as cstr]))
 
 (defn normalize-name
   [s]

--- a/test/cljam/util/t_chromosome.clj
+++ b/test/cljam/util/t_chromosome.clj
@@ -89,8 +89,8 @@
     "chr14_KI270723v1_random" "chr14_KI270723" "v1_random"
     "chr14_KI270723V1_Random" "chr14_KI270723" "V1_Random"))
 
-(deftest is-primary?-test
-  (are [?key ?pattern] (= (chr/is-primary? ?key) ?pattern)
+(deftest is-primary-chromosome?-test
+  (are [?key ?pattern] (= (chr/is-primary-chromosome? ?key) ?pattern)
     "chr1" true
     "chr22" true
 

--- a/test/cljam/util/t_chromosome.clj
+++ b/test/cljam/util/t_chromosome.clj
@@ -88,3 +88,17 @@
 
     "chr14_KI270723v1_random" "chr14_KI270723" "v1_random"
     "chr14_KI270723V1_Random" "chr14_KI270723" "V1_Random"))
+
+(deftest is-primary?-test
+  (are [?key ?pattern] (= (chr/is-primary? ?key) ?pattern)
+    "chr1" true
+    "chr22" true
+
+    "1" true
+    "X" true
+
+    "Un" false
+    "chrUn_KI270316v1" false
+
+    "chr4_GL000257v2_alt" false
+    "14_KI270723V1_random" false))

--- a/test/cljam/util/t_chromosome.clj
+++ b/test/cljam/util/t_chromosome.clj
@@ -69,6 +69,11 @@
     ;; TODO: Add more SN name
     )
 
+  ;; test for cascaded normalization
+  (is (= (-> "17_KI270730V1_RANDOM" chr/normalize-chromosome-key)
+         (-> "17_KI270730V1_RANDOM" chr/normalize-chromosome-key chr/normalize-chromosome-key)
+         (-> "17_KI270730V1_RANDOM" chr/normalize-chromosome-key chr/normalize-chromosome-key chr/normalize-chromosome-key)))
+
   (are [?key ?trimmed-key] (= (chr/trim-chromosome-key ?key) ?trimmed-key)
     "chr1" "1"
     "Chr2" "2"

--- a/test/cljam/util/t_chromosome.clj
+++ b/test/cljam/util/t_chromosome.clj
@@ -54,6 +54,18 @@
     "NC_007605" "NC_007605"
     "hs37d5" "hs37d5"
 
+    "chr4_GL000257v2_alt" "chr4_GL000257v2_alt"
+    "4_GL000257v2_alt" "chr4_GL000257v2_alt"
+    "chr4_GL000257V2_ALT" "chr4_GL000257v2_alt"
+
+    "chr14_KI270723v1_random" "chr14_KI270723v1_random"
+    "14_KI270723v1_random" "chr14_KI270723v1_random"
+    "14_KI270723V1_Random" "chr14_KI270723v1_random"
+
+    "chrUn_KI270316v1" "chrUn_KI270316v1"
+    "Un_KI270316v1" "chrUn_KI270316v1"
+    "Un_KI270316V1" "chrUn_KI270316v1"
+
     ;; TODO: Add more SN name
     )
 
@@ -66,3 +78,13 @@
 
     ;; TODO: Add more SN name
     ))
+
+(def split-version-suffix #'chr/split-version-suffix)
+
+(deftest split-version-suffix-test
+  (are [?key ?base ?version-suffix] (= (split-version-suffix ?key) [?base ?version-suffix])
+    "chr4_GL000257v2_alt" "chr4_GL000257" "v2_alt"
+    "chr4_GL000257V2_ALT" "chr4_GL000257" "V2_ALT"
+
+    "chr14_KI270723v1_random" "chr14_KI270723" "v1_random"
+    "chr14_KI270723V1_Random" "chr14_KI270723" "V1_Random"))


### PR DESCRIPTION
This PR adds following features,

- Parse a suffix which represents contig type and version (e.g. `v2_alt`)
- Keep that suffix in lower case to work with reference files that are available from UCSC
- Add a function to determine whether chromosome name is a primary one
