### PR TITLE
Add a logging configuration for cli

### DIFF
--- a/bin-resources/log4j2.xml
+++ b/bin-resources/log4j2.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Configuration>
+  <Appenders>
+    <Console name="StdOut" target="SYSTEM_OUT">
+      <ThresholdFilter level="WARN" onMatch="DENY" onMismatch="NEUTRAL"/>
+      <PatternLayout pattern="%m%n"/>
+    </Console>
+    <Console name="StdErr" target="SYSTEM_ERR">
+      <ThresholdFilter level="WARN"/>
+      <PatternLayout pattern="%m%n"/>
+    </Console>
+  </Appenders>
+  <Loggers>
+    <Root level="INFO">
+      <AppenderRef ref="StdOut"/>
+      <AppenderRef ref="StdErr"/>
+    </Root>
+  </Loggers>
+</Configuration>

--- a/project.clj
+++ b/project.clj
@@ -27,7 +27,11 @@
              :1.7 {:dependencies [[org.clojure/clojure "1.7.0"]]}
              :1.8 {:dependencies [[org.clojure/clojure "1.8.0"]]}
              :1.9 {:dependencies [[org.clojure/clojure "1.9.0-alpha14"]]}
-             :uberjar {:main cljam.tools.main
+             :uberjar {:dependencies [[org.clojure/clojure "1.8.0"]
+                                      [org.apache.logging.log4j/log4j-api "2.8.2"]
+                                      [org.apache.logging.log4j/log4j-core "2.8.2"]]
+                       :resource-paths ["bin-resources"]
+                       :main cljam.tools.main
                        :jvm-opts ["-Dclojure.compiler.direct-linking=true"]
                        :aot :all}}
   :deploy-repositories [["snapshots" {:url "https://clojars.org/repo/"

--- a/src/cljam/tools/cli.clj
+++ b/src/cljam/tools/cli.clj
@@ -25,7 +25,8 @@
 (defn- exit
   "Exits the program with the status after printing the message."
   [status message]
-  (println message)
+  (binding [*out* (if (zero? status) *out* *err*)]
+    (println message))
   (System/exit status))
 
 (defn- error-msg
@@ -392,7 +393,6 @@
       :dict    (dict args)
       :level   (level args)
       :version (version args)
-      (do (println "Invalid command. See 'cljam --help'.")
-          (when (seq cands)
-            (newline)
-            (exit 1 (candidate-message cands)))))))
+      (exit 1 (str "Invalid command. See 'cljam --help'."
+                   (when (seq cands)
+                     (str \newline (candidate-message cands))))))))


### PR DESCRIPTION
Adds a logging configuration (`bin-resources/log4j2.xml`) for cli executable and fixes cli printing. `INFO` logs are printed to stdout and `WARN/ERROR` logs are printed to stderr.
