### PR TITLE
Make index reading of FASTA reader delayed

### DIFF
--- a/src/cljam/algo/dict.clj
+++ b/src/cljam/algo/dict.clj
@@ -10,7 +10,7 @@
   "Creates a FASTA sequence dictionary file (.dict) from the specified FASTA
   file. The unfinished file will be deleted when failing."
   [fasta out-dict]
-  (with-open [r (cseq/fasta-reader fasta :ignore-index true)]
+  (with-open [r (cseq/fasta-reader fasta)]
     (dict-core/create-dict out-dict
                            (fa-core/read-headers r)
                            (fa-core/read-sequences r)

--- a/src/cljam/io/fasta/reader.clj
+++ b/src/cljam/io/fasta/reader.clj
@@ -9,7 +9,7 @@
 ;; FASTAReader
 ;; -----------
 
-(deftype FASTAReader [reader f index]
+(deftype FASTAReader [reader f index-delay]
   java.io.Closeable
   (close [this]
     (.close ^java.io.Closeable (.reader this))))
@@ -85,22 +85,20 @@
 
 (defn read-whole-sequence
   [^FASTAReader rdr name]
-  (if-let [fai (.index rdr)]
-    (let [header (fasta-index/get-header fai name)
-          [offset-start offset-end] (fasta-index/get-span fai name 0 (:len header))]
-      (read-sequence-with-offset rdr offset-start offset-end))
-    (throw (Exception. "FASTA index not found"))))
+  (let [fai @(.index-delay rdr)
+        header (fasta-index/get-header fai name)
+        [offset-start offset-end] (fasta-index/get-span fai name 0 (:len header))]
+    (read-sequence-with-offset rdr offset-start offset-end)))
 
 (defn read-sequence
   [^FASTAReader rdr name start end]
-  (if-let [fai (.index rdr)]
-    (let [header (fasta-index/get-header fai name)]
-      (when-let [[offset-start offset-end] (fasta-index/get-span fai name (dec start) end)]
-        (->> (concat (repeat (max 0 (- 1 start)) \N)
-                       (read-sequence-with-offset rdr offset-start offset-end)
-                       (repeat (max 0 (- end (:len header))) \N))
-             (apply str))))
-    (throw (Exception. "FASTA index not found"))))
+  (let [fai @(.index-delay rdr)
+        header (fasta-index/get-header fai name)]
+    (when-let [[offset-start offset-end] (fasta-index/get-span fai name (dec start) end)]
+      (->> (concat (repeat (max 0 (- 1 start)) \N)
+                   (read-sequence-with-offset rdr offset-start offset-end)
+                   (repeat (max 0 (- end (:len header))) \N))
+           (apply str)))))
 
 (defn read
   "Reads FASTA sequence data, returning its information as a lazy sequence."

--- a/src/cljam/io/sequence.clj
+++ b/src/cljam/io/sequence.clj
@@ -17,11 +17,10 @@
 ;; -------
 
 (defn ^FASTAReader fasta-reader
-  "Returns an open cljam.io.fasta.reader.FASTAReader of f with options:
-    :ignore-index - returns reader without index, default false.
-  Should be used inside with-open to ensure the reader is properly closed."
-  [f & options]
-  (fa-core/reader f options))
+  "Returns an open cljam.io.fasta.reader.FASTAReader of f. Should be used inside
+  with-open to ensure the reader is properly closed."
+  [f]
+  (fa-core/reader f))
 
 (defn ^TwoBitReader twobit-reader
   "Returns an open cljam.io.twobit.reader.TwoBitReader of f. Should be used
@@ -32,9 +31,9 @@
 (defn ^Closeable reader
   "Selects suitable reader from f's extension, returning the open reader. This
   function supports FASTA and TwoBit formats."
-  [f & options]
+  [f]
   (case (io-util/file-type f)
-    :fasta (apply fasta-reader f options)
+    :fasta (fasta-reader f)
     :2bit (twobit-reader f)
     (throw (IllegalArgumentException. "Invalid file type"))))
 

--- a/test/cljam/io/fasta/t_core.clj
+++ b/test/cljam/io/fasta/t_core.clj
@@ -7,27 +7,27 @@
 (def illegal-fasta-file test-tabix-file)
 
 (deftest read-headers-test
-  (with-open [rdr (fa-core/reader test-fa-file {})]
+  (with-open [rdr (fa-core/reader test-fa-file)]
     (is (= (fa-core/read-headers rdr) test-fa-header))))
 
 (deftest read-indices-test
-  (with-open [rdr (fa-core/reader test-fa-file {})]
+  (with-open [rdr (fa-core/reader test-fa-file)]
     (is (= (fa-core/read-indices rdr)
            [{:name "ref" :len 45 :offset 5 :line-blen 45 :line-len 46}
             {:name "ref2" :len 40 :offset 57 :line-blen 40 :line-len 41}]))))
 
 (deftest read-sequences-test
-  (with-open [rdr (fa-core/reader test-fa-file {})]
+  (with-open [rdr (fa-core/reader test-fa-file)]
     (is (= (fa-core/read-sequences rdr) test-fa-sequences))))
 
 (deftest read-test
-  (with-open [rdr (fa-core/reader test-fa-file {})]
+  (with-open [rdr (fa-core/reader test-fa-file)]
     (is (= (fa-core/read rdr) test-fa-data))
     (is (= (fa-core/read rdr) [{:len 0}]))
     (is (not-throw? (fa-core/reset rdr)))
     (is (= (fa-core/read rdr) test-fa-data)))
-  (is (thrown? java.io.IOException
-               (with-open [rdr (fa-core/reader test-tabix-file {})]
+  (is (thrown? Exception
+               (with-open [rdr (fa-core/reader test-tabix-file)]
                  (fa-core/read rdr)))))
 
 (deftest sequential-read-test

--- a/test/cljam/io/t_sequence.clj
+++ b/test/cljam/io/t_sequence.clj
@@ -103,8 +103,8 @@
       (is (same-file? f test-fa-file))
       (is (same-file? (str f ".fai") test-fai-file))
 
-      (with-open [r1 (cseq/fasta-reader f :ignore-index false)
-                  r2 (cseq/fasta-reader test-fa-file :ignore-index false)]
+      (with-open [r1 (cseq/fasta-reader f)
+                  r2 (cseq/fasta-reader test-fa-file)]
         (is (= (map (juxt :rname :seq) (fa-core/read r1))
                (map (juxt :rname :seq) (fa-core/read r2))))))
 
@@ -112,8 +112,8 @@
       (with-open [r (cseq/fasta-reader test-fa-file)
                   w (cseq/fasta-writer f)]
         (cseq/write-sequences w (map (fn [s] (update s :seq (fn [x] (map cstr/upper-case x)))) (fa-core/read r))))
-      (with-open [r1 (cseq/fasta-reader f :ignore-index false)
-                  r2 (cseq/fasta-reader test-fa-file :ignore-index false)]
+      (with-open [r1 (cseq/fasta-reader f)
+                  r2 (cseq/fasta-reader test-fa-file)]
         (is (= (map (juxt :rname (comp cstr/upper-case :seq)) (fa-core/read r1))
                (map (juxt :rname (comp cstr/upper-case :seq)) (fa-core/read r2))))))
 
@@ -127,8 +127,8 @@
       (is (same-file? f medium-fa-file))
       (is (same-file? (str f ".fai") medium-fai-file))
 
-      (with-open [r1 (cseq/fasta-reader f :ignore-index false)
-                  r2 (cseq/fasta-reader medium-fa-file :ignore-index false)]
+      (with-open [r1 (cseq/fasta-reader f)
+                  r2 (cseq/fasta-reader medium-fa-file)]
         (is (= (map (juxt :rname :seq) (fa-core/read r1))
                (map (juxt :rname :seq) (fa-core/read r2))))))
 
@@ -151,8 +151,8 @@
         (cseq/write-sequences w (fa-core/sequential-read test-fa-file)))
       (is (= (fa-core/sequential-read f)
              (fa-core/sequential-read test-fa-file)))
-      (with-open [r1 (cseq/fasta-reader f :ignore-index false)
-                  r2 (cseq/fasta-reader test-fa-file :ignore-index false)]
+      (with-open [r1 (cseq/fasta-reader f)
+                  r2 (cseq/fasta-reader test-fa-file)]
         (is (= (map (juxt :rname (comp cstr/upper-case :seq)) (fa-core/read r1))
                (map (juxt :rname (comp cstr/upper-case :seq)) (fa-core/read r2))))))
 
@@ -160,9 +160,9 @@
       (with-open [r (cseq/fasta-reader test-fa-file)
                   w (cseq/fasta-writer f {:create-index? false})]
         (cseq/write-sequences w (fa-core/read r)))
-
       (is (thrown? java.io.FileNotFoundException
-                   (with-open [r (cseq/fasta-reader f :ignore-index false)] nil))))))
+                   (with-open [r (cseq/fasta-reader f)]
+                     (cseq/read-sequence r {:chr "ref"})))))))
 
 (deftest write-sequences-twobit-test
   (with-before-after {:before (prepare-cache!)


### PR DESCRIPTION
for consistency with https://github.com/chrovis/cljam/pull/96#discussion_r131858258. `:ignore-index` option is removed.