### PR TITLE
Use lazy pmap for lazy-depth

### DIFF
--- a/src/cljam/algo/depth.clj
+++ b/src/cljam/algo/depth.clj
@@ -1,6 +1,7 @@
 (ns cljam.algo.depth
   "Provides algorithms for calculating simple depth of coverage."
   (:require [com.climate.claypoole :as cp]
+            [com.climate.claypoole.lazy :as lazy]
             [cljam.common :as common]
             [cljam.util :as util]
             [cljam.io.sam :as sam]
@@ -34,10 +35,10 @@
                    (if (= n-threads 1)
                      (map (fn [[start end]]
                             (count-for-positions (read-fn rdr start end) start end)) xs)
-                     (cp/pmap (dec n-threads)
-                              (fn [[start end]]
-                                (with-open [r (sam/clone-bam-reader rdr)]
-                                  (count-for-positions (read-fn r start end) start end))) xs)))]
+                     (lazy/pmap (dec n-threads)
+                                (fn [[start end]]
+                                  (with-open [r (sam/clone-bam-reader rdr)]
+                                    (count-for-positions (read-fn r start end) start end))) xs)))]
     (->> (util/divide-region start end step)
          count-fn
          (apply concat))))


### PR DESCRIPTION
`com.climate.claypoole/pmap` consumes extra elements, so that it is inappropriate for lazy sequence. Instead, `cljam.algo.depth/lazy-depth` uses `com.climate.claypoole.lazy/pmap` by this change.

`lazy/pmap` is inferior in speed to `cp/pmap`, but current cljam provides non-lazy `depth` function for performance. I think `lazy/pmap` is useful to handle returned lazy sequence of `lazy-depth`.