### PR TITLE
Rename test namespaces to conventional names

### DIFF
--- a/test/cljam/algo/bam_indexer_test.clj
+++ b/test/cljam/algo/bam_indexer_test.clj
@@ -1,8 +1,8 @@
-(ns cljam.algo.t-bam-indexer
+(ns cljam.algo.bam-indexer-test
   "Tests for cljam.algo.bam-indexer."
   (:require [clojure.test :refer :all]
             [clojure.java.io :as cio]
-            [cljam.t-common :refer :all]
+            [cljam.test-common :refer :all]
             [cljam.io.sam :as sam]
             [cljam.algo.sorter :as sorter]
             [cljam.algo.bam-indexer :as bai]))

--- a/test/cljam/algo/dedupe_test.clj
+++ b/test/cljam/algo/dedupe_test.clj
@@ -1,6 +1,6 @@
-(ns cljam.algo.t-dedupe
+(ns cljam.algo.dedupe-test
   (:require [clojure.test :refer :all]
-            [cljam.t-common :refer :all]
+            [cljam.test-common :refer :all]
             [cljam.algo.dedupe :as dedupe]))
 
 (deftest simple-pe-dedupe

--- a/test/cljam/algo/depth_test.clj
+++ b/test/cljam/algo/depth_test.clj
@@ -1,6 +1,6 @@
-(ns cljam.algo.t-depth
+(ns cljam.algo.depth-test
   (:require [clojure.test :refer :all]
-            [cljam.t-common :as common]
+            [cljam.test-common :as common]
             [cljam.io.sam :as sam]
             [cljam.algo.depth :as depth])
   (:import [clojure.lang LazySeq ArraySeq]))

--- a/test/cljam/algo/dict_test.clj
+++ b/test/cljam/algo/dict_test.clj
@@ -1,9 +1,9 @@
-(ns cljam.algo.t-dict
+(ns cljam.algo.dict-test
   "Tests for cljam.algo.dict."
   (:require [clojure.test :refer :all]
             [clojure.string :as string]
             [clojure.java.io :as cio]
-            [cljam.t-common :refer :all]
+            [cljam.test-common :refer :all]
             [cljam.algo.dict :as dict]))
 
 (defn same-dict-file? [f1 f2]

--- a/test/cljam/algo/fasta_indexer_test.clj
+++ b/test/cljam/algo/fasta_indexer_test.clj
@@ -1,8 +1,8 @@
-(ns cljam.algo.t-fasta-indexer
+(ns cljam.algo.fasta-indexer-test
   "Tests for cljam.fasta-indexer."
   (:require [clojure.test :refer :all]
             [clojure.java.io :as cio]
-            [cljam.t-common :refer :all]
+            [cljam.test-common :refer :all]
             [cljam.algo.fasta-indexer :as fai]))
 
 (def temp-fa-file (str temp-dir "/test.fa"))

--- a/test/cljam/algo/normal_test.clj
+++ b/test/cljam/algo/normal_test.clj
@@ -1,6 +1,6 @@
-(ns cljam.algo.t-normal
+(ns cljam.algo.normal-test
   (:require [clojure.test :refer :all]
-            [cljam.t-common :refer :all]
+            [cljam.test-common :refer :all]
             [cljam.algo.normal :refer :all]
             [cljam.io.sam :as sam]))
 

--- a/test/cljam/algo/pileup_test.clj
+++ b/test/cljam/algo/pileup_test.clj
@@ -1,6 +1,6 @@
-(ns cljam.algo.t-pileup
+(ns cljam.algo.pileup-test
   (:require [clojure.test :refer :all]
-            [cljam.t-common :refer :all]
+            [cljam.test-common :refer :all]
             [cljam.io.sam :as sam]
             [cljam.io.sequence :as cseq]
             [cljam.algo.pileup :as plp]

--- a/test/cljam/algo/sorter_test.clj
+++ b/test/cljam/algo/sorter_test.clj
@@ -1,6 +1,6 @@
-(ns cljam.algo.t-sorter
+(ns cljam.algo.sorter-test
   (:require [clojure.test :refer :all]
-            [cljam.t-common :refer :all]
+            [cljam.test-common :refer :all]
             [cljam.io.sam :as sam]
             [cljam.algo.sorter :as sorter])
   (:import [java.io Closeable]))

--- a/test/cljam/io/bam_index_test.clj
+++ b/test/cljam/io/bam_index_test.clj
@@ -1,7 +1,7 @@
-(ns cljam.io.t-bam-index
+(ns cljam.io.bam-index-test
   "Tests for cljam.io.bam-index."
   (:require [clojure.test :refer :all]
-            [cljam.t-common :refer :all]
+            [cljam.test-common :refer :all]
             [cljam.io.bam-index :as bai]))
 
 ;;; bin-index

--- a/test/cljam/io/bcf/writer_test.clj
+++ b/test/cljam/io/bcf/writer_test.clj
@@ -1,4 +1,4 @@
-(ns cljam.io.bcf.t-writer
+(ns cljam.io.bcf.writer-test
   (:require [clojure.test :refer :all]
             [cljam.io.bcf.writer :as bcf-writer])
   (:import [java.nio ByteBuffer]))

--- a/test/cljam/io/bed_test.clj
+++ b/test/cljam/io/bed_test.clj
@@ -1,6 +1,6 @@
-(ns cljam.io.t-bed
+(ns cljam.io.bed-test
   (:require [clojure.test :refer :all]
-            [cljam.t-common :refer :all]
+            [cljam.test-common :refer :all]
             [cljam.io.bed :as bed]
             [cljam.io.sam :as sam]
             [cljam.io.sam.util :as sam-util]

--- a/test/cljam/io/fasta/core_test.clj
+++ b/test/cljam/io/fasta/core_test.clj
@@ -1,7 +1,7 @@
-(ns cljam.io.fasta.t-core
+(ns cljam.io.fasta.core-test
   (:require [clojure.test :refer :all]
             [clojure.string :as cstr]
-            [cljam.t-common :refer :all]
+            [cljam.test-common :refer :all]
             [cljam.io.fasta.core :as fa-core]))
 
 (def illegal-fasta-file test-tabix-file)

--- a/test/cljam/io/fastq_test.clj
+++ b/test/cljam/io/fastq_test.clj
@@ -1,6 +1,6 @@
-(ns cljam.io.t-fastq
+(ns cljam.io.fastq-test
   (:require [clojure.test :refer :all]
-            [cljam.t-common :refer :all]
+            [cljam.test-common :refer :all]
             [clojure.java.io :as cio]
             [cljam.io.fastq :as fq]))
 

--- a/test/cljam/io/sam/util_test.clj
+++ b/test/cljam/io/sam/util_test.clj
@@ -1,8 +1,8 @@
-(ns cljam.io.sam.t-util
+(ns cljam.io.sam.util-test
   "Tests for cljam.io.sam.util."
   (:require [clojure.test :refer :all]
             [clojure.string :as cstr]
-            [cljam.t-common :refer :all]
+            [cljam.test-common :refer :all]
             [cljam.util :as util]
             [cljam.io.sam.util :as sam-util]))
 

--- a/test/cljam/io/sam_test.clj
+++ b/test/cljam/io/sam_test.clj
@@ -1,7 +1,7 @@
-(ns cljam.io.t-sam
+(ns cljam.io.sam-test
   (:require [clojure.test :refer :all]
             [clojure.java.io :as cio]
-            [cljam.t-common :refer :all]
+            [cljam.test-common :refer :all]
             [cljam.io.sam :as sam]
             [cljam.util :as util]))
 

--- a/test/cljam/io/sequence_test.clj
+++ b/test/cljam/io/sequence_test.clj
@@ -1,8 +1,8 @@
-(ns cljam.io.t-sequence
+(ns cljam.io.sequence-test
   (:require [clojure.test :refer :all]
             [clojure.java.io :as cio]
             [clojure.string :as cstr]
-            [cljam.t-common :refer :all]
+            [cljam.test-common :refer :all]
             [cljam.io.fasta.core :as fa-core]
             [cljam.io.sequence :as cseq]
             [cljam.util :as util]))

--- a/test/cljam/io/tabix_test.clj
+++ b/test/cljam/io/tabix_test.clj
@@ -1,6 +1,6 @@
-(ns cljam.io.t-tabix
+(ns cljam.io.tabix-test
   (:require [clojure.test :refer :all]
-            [cljam.t-common :refer :all]
+            [cljam.test-common :refer :all]
             [cljam.io.tabix :as tbi]))
 
 (deftest about-read-index-with-error

--- a/test/cljam/io/util/cigar_test.clj
+++ b/test/cljam/io/util/cigar_test.clj
@@ -1,4 +1,4 @@
-(ns cljam.io.util.t-cigar
+(ns cljam.io.util.cigar-test
   (:require [clojure.test :refer :all]
             [cljam.io.util.cigar :as cgr]))
 

--- a/test/cljam/io/util/lsb_test.clj
+++ b/test/cljam/io/util/lsb_test.clj
@@ -1,7 +1,7 @@
-(ns cljam.io.util.t-lsb
+(ns cljam.io.util.lsb-test
   (:require [clojure.test :refer :all]
             [clojure.java.io :as cio]
-            [cljam.t-common :as common]
+            [cljam.test-common :as common]
             [cljam.io.util.lsb :as lsb])
   (:import [java.nio ByteBuffer ByteOrder]
            [java.io RandomAccessFile DataInputStream FileInputStream]

--- a/test/cljam/io/util_test.clj
+++ b/test/cljam/io/util_test.clj
@@ -1,7 +1,7 @@
-(ns cljam.io.t-util
+(ns cljam.io.util-test
   (:require [clojure.test :refer :all]
             [clojure.java.io :as cio]
-            [cljam.t-common :refer :all]
+            [cljam.test-common :refer :all]
             [cljam.util :as util]
             [cljam.io.bed :as bed]
             [cljam.io.fastq :as fastq]

--- a/test/cljam/io/vcf/util_test.clj
+++ b/test/cljam/io/vcf/util_test.clj
@@ -1,7 +1,7 @@
-(ns cljam.io.vcf.t-util
+(ns cljam.io.vcf.util-test
   (:require  [clojure.test :refer :all]
              [clojure.string :as cstr]
-             [cljam.t-common :refer :all]
+             [cljam.test-common :refer :all]
              [cljam.io.vcf.util :as vcf-util]))
 
 (deftest about-parse-info

--- a/test/cljam/io/vcf/writer_test.clj
+++ b/test/cljam/io/vcf/writer_test.clj
@@ -1,6 +1,6 @@
-(ns cljam.io.vcf.t-writer
+(ns cljam.io.vcf.writer-test
   (:require [clojure.test :refer :all]
-            [cljam.t-common :refer :all]
+            [cljam.test-common :refer :all]
             [cljam.io.vcf.writer :as vcf-writer]))
 
 (deftest stringify-meta-info-pedigree

--- a/test/cljam/io/vcf_test.clj
+++ b/test/cljam/io/vcf_test.clj
@@ -1,7 +1,7 @@
-(ns cljam.io.t-vcf
+(ns cljam.io.vcf-test
   (:require [clojure.test :refer :all]
             [clojure.java.io :as cio]
-            [cljam.t-common :refer :all]
+            [cljam.test-common :refer :all]
             [cljam.io.vcf :as vcf]
             [cljam.util :as util])
   (:import bgzf4j.BGZFException))

--- a/test/cljam/test_common.clj
+++ b/test/cljam/test_common.clj
@@ -1,4 +1,4 @@
-(ns cljam.t-common
+(ns cljam.test-common
   (:require [digest]
             [clojure.java.io :refer [file]]
             [clojure.tools.logging :refer [*logger-factory*]]

--- a/test/cljam/tools/cli_test.clj
+++ b/test/cljam/tools/cli_test.clj
@@ -1,6 +1,6 @@
-(ns cljam.tools.t-cli
+(ns cljam.tools.cli-test
   (:require [clojure.test :refer :all]
-            [cljam.t-common :refer :all]
+            [cljam.test-common :refer :all]
             [clojure.java.io :as cio]
             [cljam.tools.cli :as cli]
             [cljam.io.sam :as sam])

--- a/test/cljam/util/chromosome_test.clj
+++ b/test/cljam/util/chromosome_test.clj
@@ -1,4 +1,4 @@
-(ns cljam.util.t-chromosome
+(ns cljam.util.chromosome-test
   (:require [clojure.test :refer :all]
             [cljam.util.chromosome :as chr]))
 

--- a/test/cljam/util/whole_genome_test.clj
+++ b/test/cljam/util/whole_genome_test.clj
@@ -1,4 +1,4 @@
-(ns cljam.util.t-whole-genome
+(ns cljam.util.whole-genome-test
   (:require [clojure.test :refer :all]
             [cljam.util.whole-genome :as wg]))
 

--- a/test/cljam/util_test.clj
+++ b/test/cljam/util_test.clj
@@ -1,4 +1,4 @@
-(ns cljam.t-util
+(ns cljam.util-test
   "Tests for cljam.util."
   (:require [clojure.test :refer :all]
             [cljam.util :as util]))


### PR DESCRIPTION
Renames test namespaces to conventional names of clojure.test. e.g. `cljam.util.t-chromosome` -> `cljam.util.chromosome-test`

[cider-test](http://cider.readthedocs.io/en/latest/running_tests/) infers a test namespace by adding a suffix, `-test`, so `t-some` namespace cannot be run by `cider-test-run-test`. The inference can be customized in local config, but I feel `some-test` style is better for clojure.test.