### PR TITLE
Upgrade dependencies

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -28,8 +28,8 @@
              :1.8 {:dependencies [[org.clojure/clojure "1.8.0"]]}
              :1.9 {:dependencies [[org.clojure/clojure "1.9.0-alpha14"]]}
              :uberjar {:dependencies [[org.clojure/clojure "1.8.0"]
-                                      [org.apache.logging.log4j/log4j-api "2.8.2"]
-                                      [org.apache.logging.log4j/log4j-core "2.8.2"]]
+                                      [org.apache.logging.log4j/log4j-api "2.9.0"]
+                                      [org.apache.logging.log4j/log4j-core "2.9.0"]]
                        :resource-paths ["bin-resources"]
                        :main cljam.tools.main
                        :jvm-opts ["-Dclojure.compiler.direct-linking=true"]

--- a/project.clj
+++ b/project.clj
@@ -26,7 +26,7 @@
                    :global-vars {*warn-on-reflection* true}}
              :1.7 {:dependencies [[org.clojure/clojure "1.7.0"]]}
              :1.8 {:dependencies [[org.clojure/clojure "1.8.0"]]}
-             :1.9 {:dependencies [[org.clojure/clojure "1.9.0-alpha14"]]}
+             :1.9 {:dependencies [[org.clojure/clojure "1.9.0-alpha19"]]}
              :uberjar {:dependencies [[org.clojure/clojure "1.8.0"]
                                       [org.apache.logging.log4j/log4j-api "2.9.0"]
                                       [org.apache.logging.log4j/log4j-core "2.9.0"]]

--- a/project.clj
+++ b/project.clj
@@ -7,7 +7,7 @@
                  [org.clojure/tools.cli "0.3.5"]
                  [org.apache.commons/commons-compress "1.14"]
                  [clj-sub-command "0.3.0"]
-                 [digest "1.4.5"]
+                 [digest "1.4.6"]
                  [bgzf4j "0.1.0"]
                  [com.climate/claypoole "1.1.4"]
                  [camel-snake-kebab "0.4.0"]


### PR DESCRIPTION
Upgrading outdated dependencies 😀 

- [digest 1.4.6](https://github.com/tebeka/clj-digest/blob/7aee230d8b0e18223a2570df53c0cc6351a93245/ChangeLog#L1-L2)
- [clojure 1.9.0-alpha19](https://clojure.org/community/devchangelog)
- [log4j 2.9.0](https://logging.apache.org/log4j/2.x/changes-report.html#a2.9.0)

`lein test :all` 🆗 