### PR TITLE
Fix StackOverflowError in cljam.io.protocols/read-in-region

### DIFF
--- a/src/cljam/io/bam/reader.clj
+++ b/src/cljam/io/bam/reader.clj
@@ -64,7 +64,7 @@
         (read-blocks-randomly* this chr start end decoder))))
   protocols/IRegionReader
   (read-in-region [this region]
-    (protocols/read-in-region this region))
+    (protocols/read-in-region this region {}))
   (read-in-region [this region _]
     (protocols/read-alignments this region)))
 

--- a/test/cljam/io/sequence_test.clj
+++ b/test/cljam/io/sequence_test.clj
@@ -5,6 +5,7 @@
             [cljam.test-common :refer :all]
             [cljam.io.fasta.core :as fa-core]
             [cljam.io.sequence :as cseq]
+            [cljam.io.protocols :as protocols]
             [cljam.util :as util]))
 
 (deftest reader-test
@@ -58,7 +59,14 @@
     (is (= (cseq/read-sequence rdr {:chr "ref2"} {:mask? false})
            "AGGTTTTATAAAACAATTAAGTCTACAGAGCAACTACGCG"))
     (is (= (cseq/read-sequence rdr {:chr "ref2"} {:mask? true})
-           "aggttttataaaacaattaagtctacagagcaactacgcg"))))
+           "aggttttataaaacaattaagtctacagagcaactacgcg")))
+  (with-open [rdr (cseq/fasta-reader test-fa-file)]
+    (is (= (protocols/read-in-region rdr {:chr "ref2" :start 1 :end 16})
+           "AGGTTTTATAAAACAA"))
+    (is (= (protocols/read-in-region rdr {:chr "ref2" :start 1 :end 16} {:mask? false})
+           "AGGTTTTATAAAACAA"))
+    (is (= (protocols/read-in-region rdr {:chr "ref2" :start 1 :end 16} {:mask? true})
+           "aggttttataaaacaa"))))
 
 (deftest read-sequence-twobit-test
   (testing "reference test"
@@ -80,7 +88,10 @@
       (is (= (for [i (range 1 45) j (range i 46)]
                (cseq/read-sequence r {:chr "ref" :start i :end j}))
              (for [i (range 1 45) j (range i 46)]
-               (subs "AGCATGTTAGATAAGATAGCTGTGCTAGTAGGCAGTCAGCGCCAT" (dec i) j))))))
+               (subs "AGCATGTTAGATAAGATAGCTGTGCTAGTAGGCAGTCAGCGCCAT" (dec i) j))))
+      (is (= (protocols/read-in-region r {:chr "ref2" :start 1 :end 40}) "AGGTTTTATAAAACAATTAAGTCTACAGAGCAACTACGCG"))
+      (is (= (protocols/read-in-region r {:chr "ref2" :start 1 :end 40} {:mask? false}) "AGGTTTTATAAAACAATTAAGTCTACAGAGCAACTACGCG"))
+      (is (= (protocols/read-in-region r {:chr "ref2" :start 1 :end 40} {:mask? true}) "aggttttataaaacaattaagtctacagagcaactacgcg"))))
   (testing "reference test with N"
     (with-open [r (cseq/twobit-reader test-twobit-n-file)
                 c (cseq/reader r)]


### PR DESCRIPTION
#### Summary
This PR fixes StackOverflowError in multiple-arity function `cljam.io.protocols/read-in-region` for `cljam.io.bam.reader/BAMReader`.

#### Problem
- Calling the function with 2 args causes `StackOverflowError`.
- `StackOverflowError` does not occurs with 3 args.

#### Cause
2 args function invokes itself instead of 3 args version.

#### Changes
Append an empty map as 3rd arg.

#### Tests
- Added some tests for `cljam.io.protocols/read-in-region` with `.bam`, `.fa` and `.2bit`.
- `lein test :all` 🆗