### PR TITLE
Set up benchmarks

### DIFF
--- a/bench/cljam/algo/bam_indexer_bench.clj
+++ b/bench/cljam/algo/bam_indexer_bench.clj
@@ -1,0 +1,33 @@
+(ns cljam.algo.bam-indexer-bench
+  (:require [libra.bench :refer :all]
+            [libra.criterium :as c]
+            [cljam.test-common :as tcommon]
+            [cljam.algo.bam-indexer :as bai]))
+
+(defbench create-index-medium-bench
+  (tcommon/with-before-after {:before (tcommon/prepare-cache!)
+                              :after (tcommon/clean-cache!)}
+    (are [n] (c/quick-bench (bai/create-index tcommon/medium-bam-file
+                                              (str tcommon/temp-dir "/out-" n ".bai")
+                                              :n-threads n))
+      1
+      2
+      4)))
+
+;; BAM-indexing benchmark equivalent to being used in the SCfBM paper,
+;; https://doi.org/10.1186/s13029-016-0058-6.
+;; Note that it requires stupendous time and CPU resources.
+(when-let [bam (System/getenv "SCFBM_BENCH_BAM")]
+  (tcommon/with-before-after {:before (tcommon/prepare-cache!)
+                              :after (tcommon/clean-cache!)}
+    (defbench create-index-scfbm-bench
+      (are [n] (dur 10 (bai/create-index bam
+                                         (str tcommon/temp-dir "/out-" n ".bai")
+                                         :n-threads n))
+        1
+        2
+        3
+        4
+        6
+        8
+        12))))

--- a/bench/cljam/algo/depth_bench.clj
+++ b/bench/cljam/algo/depth_bench.clj
@@ -1,0 +1,28 @@
+(ns cljam.algo.depth-bench
+  (:require [libra.bench :refer :all]
+            [libra.criterium :as c]
+            [cljam.test-common :as tcommon]
+            [cljam.algo.depth :as depth]
+            [cljam.io.sam :as sam]))
+
+(defbench depth-medium-bench
+  (are [n] (c/quick-bench (with-open [rdr (sam/reader tcommon/medium-bam-file)]
+                            (depth/depth rdr {:chr "chr1" :start 1000000 :end 9999999} {:n-threads n})))
+    1
+    2
+    4))
+
+;; Simple pileup benchmark equivalent to being used in the SCfBM paper,
+;; https://doi.org/10.1186/s13029-016-0058-6.
+;; Note that it requires stupendous time and CPU/RAM resources.
+(when-let [bam (System/getenv "SCFBM_BENCH_BAM")]
+  (defbench lazy-depth-scfbm-bench
+    (are [n] (dur 10 (with-open [rdr (sam/reader bam)]
+                       (dorun (depth/lazy-depth rdr {:chr "1"} {:n-threads n}))))
+      1
+      2
+      3
+      4
+      6
+      8
+      12)))

--- a/project.clj
+++ b/project.clj
@@ -13,11 +13,14 @@
                  [camel-snake-kebab "0.4.0"]
                  [proton "0.1.2"]]
   :profiles {:dev {:dependencies [[org.clojure/clojure "1.8.0"]
-                                  [cavia "0.4.1"]]
-                   :plugins [[lein-binplus "0.6.2"]
+                                  [cavia "0.4.1"]
+                                  [criterium "0.4.4"]
+                                  [net.totakke/libra "0.1.0"]]
+                   :plugins [[lein-binplus "0.6.2" :exclusions [org.clojure/clojure]]
                              [lein-codox "0.10.3"]
                              [lein-marginalia "0.9.0" :exclusions [org.clojure/clojure]]
-                             [lein-cloverage "1.0.9" :exclusions [org.clojure/clojure]]]
+                             [lein-cloverage "1.0.9" :exclusions [org.clojure/clojure]]
+                             [net.totakke/lein-libra "0.1.0"]]
                    :test-selectors {:default #(not-any? % [:slow :remote])
                                     :slow :slow ; Slow tests with local resources
                                     :remote :remote ; Tests with remote resources


### PR DESCRIPTION
Sets up a benchmark environment using [Libra](https://github.com/totakke/libra).

cljam is a performance-sensitive project, so that we have to take care with degradation when changing it. Libra provides an easy way to check the performance, which is similar to clojure.test and `lein test`.

As a beginning, I added BAM-indexing and depth benchmarks in this PR. `lein libra` runs all defined benchmarks. If you want to run a specific benchmark, you can use `:only` selector: `lein libra :only cljam.algo.depth-bench`.

Libra is still an in-development framework, but I think it has minimum requirements for benchmarking. I plan to add convenient features to it, such as meta-tag selector, CPU/RAM checking, and individual JVMs.