### PR TITLE
Add `read-indices` to ISequenceReader protocol.

### DIFF
--- a/src/cljam/io/fasta/core.clj
+++ b/src/cljam/io/fasta/core.clj
@@ -89,6 +89,8 @@
     ([this region option]
      (protocols/read-sequence this region option)))
   protocols/ISequenceReader
+  (read-indices
+    [this] (read-indices this))
   (read-all-sequences
     ([this] (protocols/read-all-sequences this {}))
     ([this opts]

--- a/src/cljam/io/protocols.clj
+++ b/src/cljam/io/protocols.clj
@@ -55,6 +55,8 @@
     "Writes variants to thee VCF/BCF file."))
 
 (defprotocol ISequenceReader
+  (read-indices [this]
+    "Reads metadata of indexed sequences in FASTA/2BIT file.")
   (read-all-sequences [this] [this option]
     "Reads all sequences of FASTA/2BIT file.")
   (read-sequence [this region] [this region option]

--- a/src/cljam/io/sequence.clj
+++ b/src/cljam/io/sequence.clj
@@ -53,6 +53,12 @@
   ([rdr] (protocols/read-all-sequences rdr))
   ([rdr option] (protocols/read-all-sequences rdr option)))
 
+(defn read-indices
+  "Reads metadata of indexed sequences. Returns a vector of maps containing
+  :name, :len and other format-specific keys."
+  [rdr]
+  (protocols/read-indices rdr))
+
 ;; Writing
 ;; -------
 

--- a/src/cljam/io/twobit/reader.clj
+++ b/src/cljam/io/twobit/reader.clj
@@ -127,6 +127,14 @@
    (for [{:keys [name offset]} (.file-index rdr)]
      {:name name :sequence (read-sequence rdr {:chr name} option)})))
 
+(defn read-indices
+  "Reads metadata of indexed sequences."
+  [^TwoBitReader rdr]
+  (mapv
+   (fn [fi si] (merge fi @si))
+   (.file-index rdr)
+   (.seq-index rdr)))
+
 (extend-type TwoBitReader
   protocols/IReader
   (reader-path [this] (.f this))
@@ -134,6 +142,8 @@
     ([this] (protocols/read this {}))
     ([this option] (protocols/read-all-sequences this option)))
   protocols/ISequenceReader
+  (read-indices
+    [this] (read-indices this))
   (read-all-sequences
     ([this] (protocols/read-all-sequences this {}))
     ([this option]

--- a/test/cljam/io/sequence_test.clj
+++ b/test/cljam/io/sequence_test.clj
@@ -25,6 +25,18 @@
       test-fai-file
       (Object.))))
 
+(deftest read-indices-test
+  (testing "fasta"
+    (with-open [rdr (cseq/reader test-fa-file)]
+      (is (= (cseq/read-indices rdr)
+             [{:name "ref", :len 45, :offset 5, :line-blen 45, :line-len 46}
+              {:name "ref2", :len 40, :offset 57, :line-blen 40, :line-len 41}]))))
+  (testing "twobit"
+    (with-open [rdr (cseq/reader test-twobit-file)]
+      (is (= (cseq/read-indices rdr)
+             [{:name "ref", :len 45, :offset 33, :ambs [], :masks [], :header-offset 16}
+              {:name "ref2", :len 40, :offset 61, :ambs [], :masks [[1 40]], :header-offset 24}])))))
+
 (deftest read-sequence-fasta-test
   (with-open [rdr (cseq/fasta-reader test-fa-file)]
     (is (= (cseq/read-sequence rdr {:chr "ref" :start 5 :end 10}) "TGTTAG"))


### PR DESCRIPTION
#### Summary
Add `read-indices` to ISequenceReader protocol, which was defined only for FASTA but not for 2bit.
Also defined an alias function in `cljam.io.sequence`.

#### Tests

- `lein test :all` 🆗