### PR TITLE
Fix parsing comma-separated number in region

### DIFF
--- a/src/cljam/util/region.clj
+++ b/src/cljam/util/region.clj
@@ -127,7 +127,7 @@
   "Parse a region string into a map."
   [region-str]
   (when region-str
-    (let [pattern #"([!-)+-<>-~][!-~]*?)(:(\d+)?(-(\d+))?)?"
+    (let [pattern #"([!-)+-<>-~][!-~]*?)(:([\d,]+)?(-([\d,]+))?)?"
           [_ chr _ start _ end] (re-matches pattern region-str)
           start' (proton/as-long start)
           end' (proton/as-long end)]

--- a/test/cljam/util/region_test.clj
+++ b/test/cljam/util/region_test.clj
@@ -210,6 +210,7 @@
     "chr1:1" {:chr "chr1", :start 1}
     "chr1:1-" {:chr "chr1:1-"}
     "chr1:1-2" {:chr "chr1", :start 1, :end 2}
+    "chr1:1,000-2,000" {:chr "chr1", :start 1000, :end 2000}
     "chr1:-2" {:chr "chr1", :end 2}
     "chr1:001-200" {:chr "chr1", :start 1, :end 200}
     "chr1:100-2" {:chr "chr1", :start 100, :end 2}
@@ -237,6 +238,7 @@
     "chr1:1" nil
     "chr1:1-" nil
     "chr1:1-2" {:chr "chr1", :start 1, :end 2}
+    "chr1:1,000-2,000" {:chr "chr1", :start 1000, :end 2000}
     "chr1:-2" nil
     "chr1:001-200" {:chr "chr1", :start 1, :end 200}
     "chr1:100-2" nil
@@ -269,4 +271,3 @@
     {:chr "chr1", :end 10} nil
     {:start 1} nil
     {:end 10} nil))
-


### PR DESCRIPTION
Adds support of comma-separated number in region.

```clojure
(region/parse-region "chr1:1,000-2,000")
;;=> {:chr "chr1", :start 1000, :end 2000}
```

SAMtools also supports such numbers.

```
5. A region should be presented in one of the following formats:
   `chr1', `chr2:1,000' and `chr3:1000-2,000'. When a region is
   specified, the input alignment file must be a sorted and indexed
   alignment (BAM/CRAM) file.
```