### PR TITLE
Add region option to view command

### DIFF
--- a/src/cljam/io/bam/reader.clj
+++ b/src/cljam/io/bam/reader.clj
@@ -27,6 +27,12 @@
     (protocols/read this {}))
   (read [this region]
     (protocols/read-alignments this region))
+  (indexed? [this]
+    (try
+      @(.index-delay this)
+      true
+      (catch FileNotFoundException _
+        false)))
   protocols/IAlignmentReader
   (read-header [this]
     (.header this))

--- a/src/cljam/io/bcf/reader.clj
+++ b/src/cljam/io/bcf/reader.clj
@@ -21,6 +21,7 @@
   (reader-path [this] (.f this))
   (read [this] (protocols/read this {}))
   (read [this option] (read-variants this option))
+  (indexed? [_] false)
   protocols/IRegionReader
   (read-in-region [this region]
     (protocols/read-in-region this region {}))

--- a/src/cljam/io/bed.clj
+++ b/src/cljam/io/bed.clj
@@ -20,6 +20,7 @@
   (reader-path [this] (.f this))
   (read [this] (protocols/read this {}))
   (read [this option] (read-fields this))
+  (indexed? [_] false)
   protocols/IRegionReader
   (read-in-region [this region]
     (protocols/read-in-region this region {}))

--- a/src/cljam/io/fasta/core.clj
+++ b/src/cljam/io/fasta/core.clj
@@ -82,6 +82,12 @@
   (read
     ([this] (protocols/read this {}))
     ([this option] (protocols/read-all-sequences this option)))
+  (indexed? [this]
+    (try
+      @(.index-delay this)
+      true
+      (catch FileNotFoundException _
+        false)))
   protocols/IRegionReader
   (read-in-region
     ([this region]

--- a/src/cljam/io/fastq.clj
+++ b/src/cljam/io/fastq.clj
@@ -15,7 +15,8 @@
   protocols/IReader
   (reader-path [this] (.f this))
   (read [this] (read-sequences this))
-  (read [this opts] (read-sequences this opts)))
+  (read [this opts] (read-sequences this opts))
+  (indexed? [_] false))
 
 (deftype FASTQWriter [writer f]
   Closeable

--- a/src/cljam/io/protocols.clj
+++ b/src/cljam/io/protocols.clj
@@ -12,7 +12,9 @@
   (reader-path [this]
     "Returns the file's absolute path.")
   (read [this] [this option]
-    "Sequentially reads contents of the file."))
+    "Sequentially reads contents of the file.")
+  (indexed? [this]
+    "Returns true if the reader can be randomly accessed, false if not."))
 
 (defprotocol IWriter
   (writer-path [this]

--- a/src/cljam/io/sam.clj
+++ b/src/cljam/io/sam.clj
@@ -68,6 +68,12 @@
   ([rdr region] (protocols/read-blocks rdr region))
   ([rdr region option] (protocols/read-blocks rdr region option)))
 
+(defn indexed?
+  "Returns true if the reader can be randomly accessed, false if not. Note this
+  function immediately realizes a delayed index."
+  [rdr]
+  (protocols/indexed? rdr))
+
 ;; Writing
 ;; -------
 

--- a/src/cljam/io/sam/reader.clj
+++ b/src/cljam/io/sam/reader.clj
@@ -21,6 +21,7 @@
     (protocols/read this {}))
   (read [this region]
     (protocols/read-alignments this region))
+  (indexed? [_] false)
   protocols/IRegionReader
   (read-in-region [this region]
     (protocols/read-in-region this region {}))

--- a/src/cljam/io/sequence.clj
+++ b/src/cljam/io/sequence.clj
@@ -59,6 +59,12 @@
   [rdr]
   (protocols/read-indices rdr))
 
+(defn indexed?
+  "Returns true if the reader can be randomly accessed, false if not. Note this
+  function immediately realizes a delayed index."
+  [rdr]
+  (protocols/indexed? rdr))
+
 ;; Writing
 ;; -------
 

--- a/src/cljam/io/twobit/reader.clj
+++ b/src/cljam/io/twobit/reader.clj
@@ -141,6 +141,7 @@
   (read
     ([this] (protocols/read this {}))
     ([this option] (protocols/read-all-sequences this option)))
+  (indexed? [_] true)
   protocols/ISequenceReader
   (read-indices
     [this] (read-indices this))

--- a/src/cljam/io/vcf/reader.clj
+++ b/src/cljam/io/vcf/reader.clj
@@ -23,6 +23,7 @@
   (reader-path [this] (.f this))
   (read [this] (read-variants this))
   (read [this option] (read-variants this option))
+  (indexed? [_] false)
   protocols/IRegionReader
   (read-in-region [this region]
     (protocols/read-in-region this region {}))

--- a/test/cljam/io/fasta/core_test.clj
+++ b/test/cljam/io/fasta/core_test.clj
@@ -1,10 +1,14 @@
 (ns cljam.io.fasta.core-test
   (:require [clojure.test :refer :all]
+            [clojure.java.io :as cio]
             [clojure.string :as cstr]
             [cljam.test-common :refer :all]
             [cljam.io.fasta.core :as fa-core]))
 
 (def illegal-fasta-file test-tabix-file)
+
+(def temp-test-fa-file (str temp-dir "/test.fa"))
+(def temp-medium-fa-file (str temp-dir "/medium.fa"))
 
 (deftest read-headers-test
   (with-open [rdr (fa-core/reader test-fa-file)]

--- a/test/cljam/io/sequence_test.clj
+++ b/test/cljam/io/sequence_test.clj
@@ -8,6 +8,9 @@
             [cljam.io.protocols :as protocols]
             [cljam.util :as util]))
 
+(def temp-test-fa-file (str temp-dir "/test.fa"))
+(def temp-medium-fa-file (str temp-dir "/medium.fa"))
+
 (deftest reader-test
   (testing "fasta"
     (with-open [rdr (cseq/reader test-fa-file)
@@ -131,6 +134,24 @@
     (with-open [r (cseq/twobit-reader test-twobit-be-n-file)]
       (is (= (cseq/read-sequence r {:chr "ref"})
              "NNNNNGTTAGATAAGATAGCNNTGCTAGTAGGCAGTCNNNNCCAT")))))
+
+(deftest indexed?-test
+  (testing "fasta"
+    (are [f] (with-open [rdr (cseq/reader f)]
+               (true? (cseq/indexed? rdr)))
+      test-fa-file
+      medium-fa-file)
+    (with-before-after {:before (do (prepare-cache!)
+                                    (cio/copy (cio/file test-fa-file) (cio/file temp-test-fa-file))
+                                    (cio/copy (cio/file medium-fa-file) (cio/file temp-medium-fa-file)))
+                        :after (clean-cache!)}
+      (are [f] (with-open [rdr (cseq/reader f)]
+                 (false? (cseq/indexed? rdr)))
+        temp-test-fa-file
+        temp-medium-fa-file)))
+  (testing "twobit"
+    (with-open [rdr (cseq/reader test-twobit-file)]
+      (true? (cseq/indexed? rdr)))))
 
 (deftest writer-test
   (testing "fasta"

--- a/test/cljam/tools/cli_test.clj
+++ b/test/cljam/tools/cli_test.clj
@@ -29,11 +29,14 @@
   (with-before-after {:before (prepare-cache!)
                       :after (clean-cache!)}
     ;; NB: "view" output format may change in future
-    (is (not-throw? (with-out-file temp-out (cli/view [test-sam-file]))))
-    (is (not-throw? (with-out-file temp-out (cli/view ["-f" "sam" test-sam-file]))))
-    (is (not-throw? (with-out-file temp-out (cli/view [test-bam-file]))))
-    (is (not-throw? (with-out-file temp-out (cli/view ["-f" "bam" test-bam-file]))))
-    (is (not-throw? (with-out-file temp-out (cli/view ["--header" test-bam-file]))))))
+    (are [args] (not-throw? (with-out-file temp-out (cli/view args)))
+      [test-sam-file]
+      ["-f" "sam" test-sam-file]
+      [test-bam-file]
+      ["-f" "bam" test-bam-file]
+      ["--header" test-bam-file]
+      ["-r" "ref2" test-sorted-bam-file]
+      ["-r" "ref2:10-200" test-sorted-bam-file])))
 
 (deftest about-convert
   (with-before-after {:before (prepare-cache!)


### PR DESCRIPTION
Adds region option (`--region`, `-r`) to `view` command.

```console
$ lein run view -r ref2:1-9 test-resources/bam/test.sorted.bam
x1      0       ref2    1       30      20M     *       0       0       AGGTTTTATAAAACAAATAA    ????????????????????
x2      0       ref2    2       30      21M     *       0       0       GGTTTTATAAAACAAATAATT   ?????????????????????
x3      0       ref2    6       30      9M4I13M *       0       0       TTATAAAACAAATAATTAAGTCTACA      ??????????????????????????
```

This feature is only available for indexed BAM, so this PR adds `indexed?` predicate to check the existence of index.