### PR TITLE
Java 9 compatibility

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,7 @@ cache:
 jdk:
   - oraclejdk9
   - oraclejdk8
+  - openjdk8
   - openjdk7
 env:
   matrix:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,11 +1,11 @@
 language: clojure
-lein: lein
+lein: 2.8.0
 cache:
   directories:
     - $HOME/.m2
 jdk:
+  - oraclejdk9
   - oraclejdk8
-  - oraclejdk7
   - openjdk7
 env:
   matrix:

--- a/project.clj
+++ b/project.clj
@@ -29,7 +29,7 @@
                    :global-vars {*warn-on-reflection* true}}
              :1.7 {:dependencies [[org.clojure/clojure "1.7.0"]]}
              :1.8 {:dependencies [[org.clojure/clojure "1.8.0"]]}
-             :1.9 {:dependencies [[org.clojure/clojure "1.9.0-alpha19"]]}
+             :1.9 {:dependencies [[org.clojure/clojure "1.9.0-beta2"]]}
              :uberjar {:dependencies [[org.clojure/clojure "1.8.0"]
                                       [org.apache.logging.log4j/log4j-api "2.9.0"]
                                       [org.apache.logging.log4j/log4j-core "2.9.0"]]

--- a/project.clj
+++ b/project.clj
@@ -15,11 +15,12 @@
   :profiles {:dev {:dependencies [[org.clojure/clojure "1.8.0"]
                                   [cavia "0.4.2-SNAPSHOT"]
                                   [criterium "0.4.4"]
-                                  [net.totakke/libra "0.1.0"]]
+                                  [net.totakke/libra "0.1.0"]
+                                  [org.tcrawley/dynapath "0.2.5"]]
                    :plugins [[lein-binplus "0.6.2" :exclusions [org.clojure/clojure]]
                              [lein-codox "0.10.3"]
                              [lein-marginalia "0.9.0" :exclusions [org.clojure/clojure]]
-                             [lein-cloverage "1.0.9" :exclusions [org.clojure/clojure]]
+                             [lein-cloverage "1.0.9" :exclusions [org.clojure/clojure org.tcrawley/dynapath]]
                              [net.totakke/lein-libra "0.1.0"]]
                    :test-selectors {:default #(not-any? % [:slow :remote])
                                     :slow :slow ; Slow tests with local resources

--- a/project.clj
+++ b/project.clj
@@ -11,7 +11,7 @@
                  [bgzf4j "0.1.0"]
                  [com.climate/claypoole "1.1.4"]
                  [camel-snake-kebab "0.4.0"]
-                 [proton "0.1.2"]]
+                 [proton "0.1.3"]]
   :profiles {:dev {:dependencies [[org.clojure/clojure "1.8.0"]
                                   [cavia "0.4.2-SNAPSHOT"]
                                   [criterium "0.4.4"]

--- a/project.clj
+++ b/project.clj
@@ -13,7 +13,7 @@
                  [camel-snake-kebab "0.4.0"]
                  [proton "0.1.3"]]
   :profiles {:dev {:dependencies [[org.clojure/clojure "1.8.0"]
-                                  [cavia "0.4.2-SNAPSHOT"]
+                                  [cavia "0.4.2"]
                                   [criterium "0.4.4"]
                                   [net.totakke/libra "0.1.0"]
                                   [org.tcrawley/dynapath "0.2.5"]]

--- a/project.clj
+++ b/project.clj
@@ -13,7 +13,7 @@
                  [camel-snake-kebab "0.4.0"]
                  [proton "0.1.2"]]
   :profiles {:dev {:dependencies [[org.clojure/clojure "1.8.0"]
-                                  [cavia "0.4.1"]
+                                  [cavia "0.4.2-SNAPSHOT"]
                                   [criterium "0.4.4"]
                                   [net.totakke/libra "0.1.0"]]
                    :plugins [[lein-binplus "0.6.2" :exclusions [org.clojure/clojure]]

--- a/project.clj
+++ b/project.clj
@@ -32,8 +32,8 @@
              :1.8 {:dependencies [[org.clojure/clojure "1.8.0"]]}
              :1.9 {:dependencies [[org.clojure/clojure "1.9.0-beta2"]]}
              :uberjar {:dependencies [[org.clojure/clojure "1.8.0"]
-                                      [org.apache.logging.log4j/log4j-api "2.9.0"]
-                                      [org.apache.logging.log4j/log4j-core "2.9.0"]]
+                                      [org.apache.logging.log4j/log4j-api "2.9.1"]
+                                      [org.apache.logging.log4j/log4j-core "2.9.1"]]
                        :resource-paths ["bin-resources"]
                        :main cljam.tools.main
                        :jvm-opts ["-Dclojure.compiler.direct-linking=true"]


### PR DESCRIPTION
#### Summary

- Use dynapath 0.2.5 to avoid ClassNotFoundException
    - cloverage 1.0.9 -> bultitude 0.2.8 -> dynapath 0.2.3
- Upgrade dependencies

#### Tests

- `lein test :all` 🆗