### PR TITLE
Don't refer clojure.core/indexed? in cljam.io.

### DIFF
--- a/src/cljam/io/protocols.clj
+++ b/src/cljam/io/protocols.clj
@@ -1,6 +1,6 @@
 (ns cljam.io.protocols
   "Protocols of reader/writer for various file formats."
-  (:refer-clojure :exclude [read]))
+  (:refer-clojure :exclude [read indexed?]))
 
 (defrecord SAMAlignment
   [qname ^int flag rname ^int pos ^int end ^int mapq cigar rnext ^int pnext ^int tlen seq qual options])

--- a/src/cljam/io/sam.clj
+++ b/src/cljam/io/sam.clj
@@ -2,6 +2,7 @@
   "Functions to read and write the SAM (Sequence Alignment/Map) format and BAM
   (its binary equivalent). See https://samtools.github.io/hts-specs/ for the
   detail SAM/BAM specifications."
+  (:refer-clojure :exclude [indexed?])
   (:require [cljam.io.sam.reader :as sam-reader]
             [cljam.io.sam.writer :as sam-writer]
             [cljam.io.bam.core :as bam-core]

--- a/src/cljam/io/sequence.clj
+++ b/src/cljam/io/sequence.clj
@@ -1,6 +1,7 @@
 (ns cljam.io.sequence
   "Functions to read and write formats representing sequences such as FASTA and
   TwoBit."
+  (:refer-clojure :exclude [indexed?])
   (:require [cljam.io.fasta.core :as fa-core]
             [cljam.io.fasta.writer :as fa-writer]
             [cljam.io.protocols :as protocols]


### PR DESCRIPTION
#### Summary

Since [`clojure.core/indexed?` will be added in Clojure 1.9](https://github.com/clojure/clojure/blob/a8f1c6436a8bfe181b0a00cf9e44845dcbbb63ee/src/clj/clojure/core.clj#L6199-L6202), this PR excludes it from `cljam.io` module to suppress warnings.

#### Tests

- `lein test :all` 🆗