### PR TITLE
Move coverage phase to build stages

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,15 +14,16 @@ env:
     - VERSION='1.8'
     - VERSION='1.9'
 script: lein with-profile dev,$VERSION test
-after_success:
-  - CLOVERAGE_VERSION=1.0.9 lein cloverage -e '^cljam.main' --codecov
-  - bash <(curl -s https://codecov.io/bash) -f target/coverage/codecov.json
 jobs:
   include:
+    - stage: coverage
+      jdk: oraclejdk8
+      script:
+        - CLOVERAGE_VERSION=1.0.9 lein cloverage -e '^cljam.main' --codecov
+        - bash <(curl -s https://codecov.io/bash) -f target/coverage/codecov.json
     - stage: deploy
       jdk: oraclejdk8
       script: skip
-      after_success: echo skip
       deploy:
         provider: script
         script: ./deploy-snapshot.sh


### PR DESCRIPTION
The coverage phase accounts for about 2/3 of each build time on CI, and superfluous coverages are currently measured. By moving coverage phase to build stages, the coverage phase will be executed just once and a total of build time will be shortened.