### PR TITLE
Fix a bug that 2bit reader incorrectly reads small n

### DIFF
--- a/src/cljam/io/twobit/reader.clj
+++ b/src/cljam/io/twobit/reader.clj
@@ -114,8 +114,8 @@
            (if (<= 1 ref-pos len)
              (.put cb (.charAt ^String (twobit-to-str (+ (aget ba ba-pos) 128)) bit-pos))
              (.put cb \N))))
-       (when mask? (mask! cb masks start' end'))
        (replace-ambs! cb ambs start' end')
+       (when mask? (mask! cb masks start' end'))
        (.rewind cb)
        (.toString cb)))))
 


### PR DESCRIPTION
Current 2bit reader cannot reads small `n` correctly even if `:mask? true` is specified.

For example, when reading the following 2bit file,

```
>ref
nnNN
```

`n` are replaced with `N`.

```clojure
(with-open [rdr (cseq/reader "path/to/nnNN.2bit")]
  (doall (cseq/read-all-sequences rdr {:mask? true})))
;;=> ({:name "ref", :sequence "NNNN"})
```

This patch fixes that issue.

```clojure
(with-open [rdr (cseq/reader "path/to/nnNN.2bit")]
  (doall (cseq/read-all-sequences rdr {:mask? true})))
;;=> ({:name "ref", :sequence "nnNN"})
```