### PR TITLE
Improve performance of FASTA random reading

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
 language: clojure
-lein: 2.8.0
+lein: 2.8.1
 cache:
   directories:
     - $HOME/.m2

--- a/project.clj
+++ b/project.clj
@@ -30,7 +30,7 @@
                    :global-vars {*warn-on-reflection* true}}
              :1.7 {:dependencies [[org.clojure/clojure "1.7.0"]]}
              :1.8 {:dependencies [[org.clojure/clojure "1.8.0"]]}
-             :1.9 {:dependencies [[org.clojure/clojure "1.9.0-beta2"]]}
+             :1.9 {:dependencies [[org.clojure/clojure "1.9.0-RC1"]]}
              :uberjar {:dependencies [[org.clojure/clojure "1.8.0"]
                                       [org.apache.logging.log4j/log4j-api "2.9.1"]
                                       [org.apache.logging.log4j/log4j-core "2.9.1"]]

--- a/project.clj
+++ b/project.clj
@@ -20,7 +20,7 @@
                    :plugins [[lein-binplus "0.6.2" :exclusions [org.clojure/clojure]]
                              [lein-codox "0.10.3"]
                              [lein-marginalia "0.9.0" :exclusions [org.clojure/clojure]]
-                             [lein-cloverage "1.0.9" :exclusions [org.clojure/clojure org.tcrawley/dynapath]]
+                             [lein-cloverage "1.0.10" :exclusions [org.clojure/clojure org.tcrawley/dynapath]]
                              [net.totakke/lein-libra "0.1.0"]]
                    :test-selectors {:default #(not-any? % [:slow :remote])
                                     :slow :slow ; Slow tests with local resources

--- a/project.clj
+++ b/project.clj
@@ -19,7 +19,7 @@
                                   [org.tcrawley/dynapath "0.2.5"]]
                    :plugins [[lein-binplus "0.6.2" :exclusions [org.clojure/clojure]]
                              [lein-codox "0.10.3"]
-                             [lein-marginalia "0.9.0" :exclusions [org.clojure/clojure]]
+                             [lein-marginalia "0.9.1" :exclusions [org.clojure/clojure]]
                              [lein-cloverage "1.0.10" :exclusions [org.clojure/clojure org.tcrawley/dynapath]]
                              [net.totakke/lein-libra "0.1.0"]]
                    :test-selectors {:default #(not-any? % [:slow :remote])

--- a/project.clj
+++ b/project.clj
@@ -5,7 +5,7 @@
             :url "https://www.apache.org/licenses/LICENSE-2.0"}
   :dependencies [[org.clojure/tools.logging "0.4.0"]
                  [org.clojure/tools.cli "0.3.5"]
-                 [org.apache.commons/commons-compress "1.14"]
+                 [org.apache.commons/commons-compress "1.15"]
                  [clj-sub-command "0.3.0"]
                  [digest "1.4.6"]
                  [bgzf4j "0.1.0"]

--- a/project.clj
+++ b/project.clj
@@ -16,7 +16,7 @@
                                   [cavia "0.4.2"]
                                   [criterium "0.4.4"]
                                   [net.totakke/libra "0.1.0"]
-                                  [org.tcrawley/dynapath "0.2.5"]]
+                                  [org.tcrawley/dynapath "1.0.0"]]
                    :plugins [[lein-binplus "0.6.2" :exclusions [org.clojure/clojure]]
                              [lein-codox "0.10.3"]
                              [lein-marginalia "0.9.1" :exclusions [org.clojure/clojure]]

--- a/src/cljam/io/fasta/reader.clj
+++ b/src/cljam/io/fasta/reader.clj
@@ -1,7 +1,6 @@
 (ns cljam.io.fasta.reader
   (:refer-clojure :exclude [read])
-  (:require [clojure.string :as cstr]
-            [cljam.util :refer [graph?]]
+  (:require [cljam.util :refer [graph?]]
             [cljam.io.fasta.util :refer [header-line? parse-header-line]]
             [cljam.io.fasta-index.core :as fasta-index])
   (:import [java.io RandomAccessFile InputStream]

--- a/src/cljam/io/fasta/reader.clj
+++ b/src/cljam/io/fasta/reader.clj
@@ -5,7 +5,8 @@
             [cljam.io.fasta.util :refer [header-line? parse-header-line]]
             [cljam.io.fasta-index.core :as fasta-index])
   (:import [java.io RandomAccessFile InputStream]
-           [java.nio ByteBuffer]))
+           [java.nio ByteBuffer CharBuffer]
+           [java.nio.channels FileChannel$MapMode]))
 
 ;; FASTAReader
 ;; -----------
@@ -73,34 +74,35 @@
                      (map? s) (cons s (lazy-seq (read-fn* rdr name))))))]
     (read-fn rdr nil)))
 
-(defn- read-sequence-with-offset
-  [^FASTAReader rdr offset-start offset-end {:keys [mask?]}]
-  (let [len (- offset-end offset-start)
-        ba (byte-array len)
+(defn read-sequence
+  [^FASTAReader rdr name start end {:keys [mask?]}]
+  (let [fai @(.index-delay rdr)
+        {:keys [len]} (fasta-index/get-header fai name)
+        buf (CharBuffer/allocate (inc (- end start)))
         r ^RandomAccessFile (.reader rdr)]
-    (doto r
-      (.seek offset-start)
-      (.read ba 0 len))
-    (-> (String. ba)
-        (cstr/replace #"\n" "")
-        ((if mask? identity cstr/upper-case)))))
+    (when-let [[s e] (fasta-index/get-span fai name (dec start) end)]
+      (dotimes [_ (- 1 start)]
+        (.put buf \N))
+      (let [mbb (.. r getChannel (map FileChannel$MapMode/READ_ONLY s (- e s)))]
+        (if mask?
+          (while (.hasRemaining mbb)
+            (let [c (unchecked-char (.get mbb))]
+              (when-not (or (= \newline c) (= \return c))
+                (.put buf c))))
+          (while (.hasRemaining mbb)
+            (let [c (unchecked-long (.get mbb))]
+              (when-not (or (= 10 c) (= 13 c))
+                ;; toUpperCase works only for ASCII chars.
+                (.put buf (unchecked-char (bit-and c 0x5f))))))))
+      (dotimes [_ (- end len)]
+        (.put buf \N))
+      (.flip buf)
+      (.toString buf))))
 
 (defn read-whole-sequence
   [^FASTAReader rdr name opts]
-  (let [fai @(.index-delay rdr)
-        header (fasta-index/get-header fai name)
-        [offset-start offset-end] (fasta-index/get-span fai name 0 (:len header))]
-    (read-sequence-with-offset rdr offset-start offset-end opts)))
-
-(defn read-sequence
-  [^FASTAReader rdr name start end opts]
-  (let [fai @(.index-delay rdr)
-        header (fasta-index/get-header fai name)]
-    (when-let [[offset-start offset-end] (fasta-index/get-span fai name (dec start) end)]
-      (->> (concat (repeat (max 0 (- 1 start)) \N)
-                   (read-sequence-with-offset rdr offset-start offset-end opts)
-                   (repeat (max 0 (- end (:len header))) \N))
-           (apply str)))))
+  (let [{:keys [len]} (fasta-index/get-header @(.index-delay rdr) name)]
+    (read-sequence rdr name 1 len opts)))
 
 (defn read
   "Reads FASTA sequence data, returning its information as a lazy sequence."

--- a/test/cljam/io/fasta/core_test.clj
+++ b/test/cljam/io/fasta/core_test.clj
@@ -1,6 +1,5 @@
 (ns cljam.io.fasta.core-test
   (:require [clojure.test :refer :all]
-            [clojure.java.io :as cio]
             [clojure.string :as cstr]
             [cljam.test-common :refer :all]
             [cljam.io.fasta.core :as fa-core]))

--- a/test/cljam/io/sequence_test.clj
+++ b/test/cljam/io/sequence_test.clj
@@ -83,6 +83,16 @@
     (is (= (protocols/read-in-region rdr {:chr "ref2" :start 1 :end 16} {:mask? true})
            "aggttttataaaacaa"))))
 
+(deftest read-sequence-medium-fasta-test
+  (let [expect (str "tgaatcaCATCAATTAAGAACTTTCTTCACCACCCCTTCGCTGTCATC"
+                    "CTTTTCTCTCCACTATTCACCCAACATCATCCGGGACCAGAACTAATGTC"
+                    "AGCAAAGC")
+        u-expect (cstr/upper-case expect)]
+    (with-open [rdr (cseq/fasta-reader medium-fa-file)]
+      (is (= (cseq/read-sequence rdr {:chr "chr3" :start 2053 :end 2158}) u-expect))
+      (is (= (cseq/read-sequence rdr {:chr "chr3" :start 2053 :end 2158} {:mask? false}) u-expect))
+      (is (= (cseq/read-sequence rdr {:chr "chr3" :start 2053 :end 2158} {:mask? true}) expect)))))
+
 (deftest read-sequence-twobit-test
   (testing "reference test"
     (with-open [r (cseq/twobit-reader test-twobit-file)


### PR DESCRIPTION
#### Summary
Improve performance of FASTA random reading by **10x** using MappedByteBuffer and CharBuffer.

#### Changes
Current implementation of `read-sequence` for FASTA is slow because of multiple String generation.
byte array => String => String => String

This PR uses mmap and CharBuffer to generate String once.
MappedByteBuffer => CharBuffer => String

#### Benchmark
##### benchmarking code
```clojure
(are [reg opts] (c/quick-bench (with-open [rdr (cseq/reader "/path/to/hg38.fa")]
                                 (dorun (cseq/read-sequence rdr reg opts))))
  {:chr "chr1" :start 1 :end 248956422} {:mask? true}
  {:chr "chr1" :start 1 :end 248956422} {})
```

##### master
```
[{:chr "chr1", :start 1, :end 248956422} {:mask? true}]
time: 20.807584 sec, sd: 23.176079 ms
[{:chr "chr1", :start 1, :end 248956422} {}]
time: 22.297717 sec, sd: 30.394828 ms
```

##### this branch
```
[{:chr "chr1", :start 1, :end 248956422} {:mask? true}]
time: 1.994279 sec, sd: 9.574159 µs
[{:chr "chr1", :start 1, :end 248956422} {}]
time: 2.007051 sec, sd: 312.275365 µs
```

#### Tests

- `lein test :all` 🆗