### PR TITLE
Remove N padding for out-of-range bases in read-sequence.

### DIFF
--- a/src/cljam/io/fasta/core.clj
+++ b/src/cljam/io/fasta/core.clj
@@ -59,9 +59,7 @@
 
 (defn read-sequence
   [rdr {:keys [chr start end]} opts]
-  (if (and (nil? start) (nil? end))
-    (reader/read-whole-sequence rdr chr opts)
-    (reader/read-sequence rdr chr start end opts)))
+  (reader/read-sequence rdr chr start end opts))
 
 (defn read
   [rdr]

--- a/src/cljam/io/fasta/reader.clj
+++ b/src/cljam/io/fasta/reader.clj
@@ -79,7 +79,7 @@
     (when-let [len (:len (fasta-index/get-header fai name))]
       (let [start' (max 1 (or start 1))
             end' (min len (or end len))]
-        (when (<= 1 start' end' len)
+        (when (<= start' end')
           (let [buf (CharBuffer/allocate (inc (- end' start')))
                 r ^RandomAccessFile (.reader rdr)]
             (when-let [[s e] (fasta-index/get-span fai name (dec start') end')]

--- a/src/cljam/io/fasta/reader.clj
+++ b/src/cljam/io/fasta/reader.clj
@@ -75,33 +75,27 @@
 
 (defn read-sequence
   [^FASTAReader rdr name start end {:keys [mask?]}]
-  (let [fai @(.index-delay rdr)
-        {:keys [len]} (fasta-index/get-header fai name)
-        buf (CharBuffer/allocate (inc (- end start)))
-        r ^RandomAccessFile (.reader rdr)]
-    (when-let [[s e] (fasta-index/get-span fai name (dec start) end)]
-      (dotimes [_ (- 1 start)]
-        (.put buf \N))
-      (let [mbb (.. r getChannel (map FileChannel$MapMode/READ_ONLY s (- e s)))]
-        (if mask?
-          (while (.hasRemaining mbb)
-            (let [c (unchecked-char (.get mbb))]
-              (when-not (or (= \newline c) (= \return c))
-                (.put buf c))))
-          (while (.hasRemaining mbb)
-            (let [c (unchecked-long (.get mbb))]
-              (when-not (or (= 10 c) (= 13 c))
-                ;; toUpperCase works only for ASCII chars.
-                (.put buf (unchecked-char (bit-and c 0x5f))))))))
-      (dotimes [_ (- end len)]
-        (.put buf \N))
-      (.flip buf)
-      (.toString buf))))
-
-(defn read-whole-sequence
-  [^FASTAReader rdr name opts]
-  (let [{:keys [len]} (fasta-index/get-header @(.index-delay rdr) name)]
-    (read-sequence rdr name 1 len opts)))
+  (let [fai @(.index-delay rdr)]
+    (when-let [len (:len (fasta-index/get-header fai name))]
+      (let [start' (max 1 (or start 1))
+            end' (min len (or end len))]
+        (when (<= 1 start' end' len)
+          (let [buf (CharBuffer/allocate (inc (- end' start')))
+                r ^RandomAccessFile (.reader rdr)]
+            (when-let [[s e] (fasta-index/get-span fai name (dec start') end')]
+              (let [mbb (.. r getChannel (map FileChannel$MapMode/READ_ONLY s (- e s)))]
+                (if mask?
+                  (while (.hasRemaining mbb)
+                    (let [c (unchecked-char (.get mbb))]
+                      (when-not (or (= \newline c) (= \return c))
+                        (.put buf c))))
+                  (while (.hasRemaining mbb)
+                    (let [c (unchecked-long (.get mbb))]
+                      (when-not (or (= 10 c) (= 13 c))
+                        ;; toUpperCase works only for ASCII chars.
+                        (.put buf (unchecked-char (bit-and c 0x5f))))))))
+              (.flip buf)
+              (.toString buf))))))))
 
 (defn read
   "Reads FASTA sequence data, returning its information as a lazy sequence."

--- a/src/cljam/io/twobit/reader.clj
+++ b/src/cljam/io/twobit/reader.clj
@@ -99,25 +99,25 @@
    (when-let [[n {:keys [offset]}]
               (first (filter (fn [[i {:keys [name]}]] (= name chr)) (map vector (range) (.file-index rdr))))]
      (let [{:keys [len ambs masks header-offset]} @(nth (.seq-index rdr) n) ;; Potential seek & read.
-           start' (or start 1)
-           end' (or end len)
-           start-offset (quot (dec (max 1 start')) 4)
-           end-offset (quot (dec (min len end')) 4)
-           ba (byte-array (- end-offset start-offset -1))
-           cb (CharBuffer/allocate (inc (- end' start')))]
-       (.seek ^RandomAccessFile (.reader rdr) (+ offset header-offset start-offset))
-       (.readFully ^RandomAccessFile (.reader rdr) ba)
-       (dotimes [out-pos (inc (- end' start'))]
-         (let [ref-pos (+ out-pos start')
-               ba-pos (- (quot (dec ref-pos) 4) start-offset)
-               bit-pos (mod (dec ref-pos) 4)]
-           (if (<= 1 ref-pos len)
-             (.put cb (.charAt ^String (twobit-to-str (+ (aget ba ba-pos) 128)) bit-pos))
-             (.put cb \N))))
-       (replace-ambs! cb ambs start' end')
-       (when mask? (mask! cb masks start' end'))
-       (.rewind cb)
-       (.toString cb)))))
+           start' (max 1 (or start 1))
+           end' (min len (or end len))]
+       (when (<= 1 start' end' len)
+         (let [start-offset (quot (dec start') 4)
+               end-offset (quot (dec end') 4)
+               ba (byte-array (- end-offset start-offset -1))
+               cb (CharBuffer/allocate (inc (- end' start')))]
+           (.seek ^RandomAccessFile (.reader rdr) (+ offset header-offset start-offset))
+           (.readFully ^RandomAccessFile (.reader rdr) ba)
+           (dotimes [out-pos (inc (- end' start'))]
+             (let [ref-pos (+ out-pos start')
+                   ba-pos (- (quot (dec ref-pos) 4) start-offset)
+                   bit-pos (mod (dec ref-pos) 4)]
+               (when (<= 1 ref-pos len)
+                 (.put cb (.charAt ^String (twobit-to-str (+ (aget ba ba-pos) 128)) bit-pos)))))
+           (replace-ambs! cb ambs start' end')
+           (when mask? (mask! cb masks start' end'))
+           (.rewind cb)
+           (.toString cb)))))))
 
 (defn- read-all-sequences*
   [rdr chrs option]

--- a/src/cljam/io/twobit/reader.clj
+++ b/src/cljam/io/twobit/reader.clj
@@ -101,7 +101,7 @@
      (let [{:keys [len ambs masks header-offset]} @(nth (.seq-index rdr) n) ;; Potential seek & read.
            start' (max 1 (or start 1))
            end' (min len (or end len))]
-       (when (<= 1 start' end' len)
+       (when (<= start' end')
          (let [start-offset (quot (dec start') 4)
                end-offset (quot (dec end') 4)
                ba (byte-array (- end-offset start-offset -1))


### PR DESCRIPTION
#### Summary
Fix for #120 [comment](https://github.com/chrovis/cljam/pull/120#issuecomment-343369370)

#### Tests

- `lein test :all` 🆗