### PR TITLE
Fix parsing SAM header values containing ':'.

### DIFF
--- a/src/cljam/io/sam/util.clj
+++ b/src/cljam/io/sam/util.clj
@@ -16,7 +16,7 @@
   (into
    {}
    (map (fn [kv]
-          (let [[k v] (cstr/split kv #":")]
+          (let [[k v] (cstr/split kv #":" 2)]
             [(keyword k)
              (case k
                "LN" (Integer/parseInt v)

--- a/test/cljam/io/sam/util_test.clj
+++ b/test/cljam/io/sam/util_test.clj
@@ -10,7 +10,12 @@
   (is (= (sam-util/parse-header "@HD	VN:1.3	SO:coordinate\n@SQ	SN:ref	LN:10\n@SQ	SN:ref2	LN:20\n@PG	ID:cljam	PN:cljam	VN:1.0	CL:java -jar cljam.jar")
          {:HD {:VN "1.3" :SO "coordinate"}
           :SQ [{:SN "ref" :LN 10} {:SN "ref2" :LN 20}]
-          :PG [{:ID "cljam" :PN "cljam" :VN "1.0" :CL "java -jar cljam.jar"}]})))
+          :PG [{:ID "cljam" :PN "cljam" :VN "1.0" :CL "java -jar cljam.jar"}]}))
+  (is (= (sam-util/parse-header "@HD\tVN:1.4\tSO:coordinate\n@SQ\tSN:FOO:BAR:10-100;BAZ|QUX,QUUX\tLN:1\n@PG\tID:cljam\tPN:cljam\tVN:1.0\tCL:cljam")
+         {:HD {:VN "1.4" :SO "coordinate"}
+          :SQ [{:SN "FOO:BAR:10-100;BAZ|QUX,QUUX"
+                :LN 1}]
+          :PG [{:ID "cljam" :PN "cljam" :VN "1.0" :CL "cljam"}]})))
 
 (def nibble-table "=ACMGRSVTWYHKDBN")
 


### PR DESCRIPTION
#### Summary
Don't discard substring after second `:` when parsing SAM header.

#### Problem
Complex SAM headers can be modified unexpectedly.

##### input sam
```
@SQ	SN:A:B;100-200;++;chr1:100-200	LN:400
```

##### output sam
```
@SQ	SN:A	LN:400
```

#### Cause
```clojure
(clojure.string/split "SN:A:B;100-200;++;chr1:100-200" #":")
; => ["SN" "A" "B;100-200;++;chr1" "100-200"]
```
`clojure.string/split` with 2 args splits given string at all ocurrence of the regex.
#### Changes
Pass `2` as 3rd arg (`limit`) of `clojure.string/split`.

#### Affects
SAM/BAM I/O

#### Tests

- `lein test :all` 🆗