### PR TITLE
Fix wrong padding of last bases in 2bit writer

### DIFF
--- a/src/cljam/io/twobit/writer.clj
+++ b/src/cljam/io/twobit/writer.clj
@@ -123,9 +123,9 @@
            unchecked-int
            (.write o)))
     (when (pos? (mod len 4))
-      (loop [b 0 i (mod len 4)]
+      (loop [b 0 i (mod len 4) j 1]
         (if (pos? i)
-          (recur (bit-or b (bit-shift-left (aget table (.get bb)) (* 2 (- 4 i)))) (dec i))
+          (recur (bit-or b (bit-shift-left (aget table (.get bb)) (* 2 (- 4 j)))) (dec i) (inc j))
           (.write o (unchecked-int b)))))))
 
 (defn- write-sequence!

--- a/test/cljam/io/sequence_test.clj
+++ b/test/cljam/io/sequence_test.clj
@@ -267,4 +267,13 @@
       (with-open [r (cseq/twobit-reader test-twobit-n-file)
                   w (cseq/twobit-writer f)]
         (cseq/write-sequences w (cseq/read-all-sequences r {:mask? true})))
-      (is (same-file? f test-twobit-n-file)))))
+      (is (same-file? f test-twobit-n-file)))
+
+    (let [f (str temp-dir "/test-2.2bit")
+          s [{:name "SEQ1" :sequence "AAAA"}
+             {:name "SEQ2" :sequence "AAAAG"}
+             {:name "SEQ3" :sequence "AAAAGC"}
+             {:name "SEQ4" :sequence "AAAAGCT"}
+             {:name "SEQ5" :sequence "AAAAGCTA"}]]
+      (with-open [w (cseq/writer f)] (cseq/write-sequences w s))
+      (with-open [r (cseq/reader f)] (is (= (cseq/read-all-sequences r) s))))))


### PR DESCRIPTION
#### Summary
Fix a bug that the last 1~3 bases were wrongly padded in the 2bit writer.

#### Problem
When sequence length is not a multiple of 4, last 1~3 bases are not correctly written.

#### Cause
In 2bit writer, every 4 bases are packed into a single byte.
The last bases will be packed from MSB and padded with 2r00.
But there was a bug in padding calculation.

#### Changes
Fix the padding.

#### Affects
2bit writer.

#### Tests

- `lein test :all` 🆗