### PR TITLE
Add some BED manipulation APIs

### DIFF
--- a/src/cljam/io/bed.clj
+++ b/src/cljam/io/bed.clj
@@ -275,10 +275,10 @@
                  (let [len (get chrom-lengths chr)
                        x (first xs)]
                    (if (and x (= (:chr x) chr))
-                     (cond->> (complement (next xs) chrs (:end x))
+                     (cond->> (complement (next xs) chrs (inc (:end x)))
                        (< pos (:start x))
-                       (cons {:chr chr :start pos :end (:start x)}))
-                     (cond->> (complement xs (next chrs) 0)
+                       (cons {:chr chr :start pos :end (dec (:start x))}))
+                     (cond->> (complement xs (next chrs) 1)
                        (< pos len)
                        (cons {:chr chr :start pos :end len}))))
                  (when (seq xs)
@@ -286,7 +286,7 @@
                                   (:chr (first xs))
                                   " not specified")]
                      (throw (IllegalArgumentException. msg)))))))]
-      (complement (sort-fields xs) chrs 0))))
+      (complement (sort-fields xs) chrs 1))))
 
 (defn write-raw-fields
   "Write sequence of BED fields to writer without converting :start and :thick-start values."

--- a/src/cljam/io/bed.clj
+++ b/src/cljam/io/bed.clj
@@ -219,7 +219,11 @@
   "Returns a lazy sequence that is the intersection of the two BED sequences.
 
   The input sequences will first be sorted with sort-fields, which may cause
-  an extensive memory use for ones with a large number of elements."
+  an extensive memory use for ones with a large number of elements.
+  Note also that this function assumes the input sequences contain only valid
+  regions, and thus :start <= :end holds for each region. Make sure yourself
+  the input sequences meet the condition, or the function may return a wrong
+  result."
   [xs ys]
   (letfn [(intersect [xs ys]
             (lazy-seq
@@ -241,7 +245,11 @@
   in the sequence ys from the sequence xs.
 
   The input sequences will first be sorted with sort-fields, which may cause
-  an extensive memory use for ones with a large number of elements."
+  an extensive memory use for ones with a large number of elements.
+  Note also that this function assumes the input sequences contain only valid
+  regions, and thus :start <= :end holds for each region. Make sure yourself
+  the input sequences meet the condition, or the function may return a wrong
+  result."
   [xs ys]
   (letfn [(subtract [xs ys]
             (lazy-seq
@@ -267,7 +275,11 @@
   and returns a lazy sequence that is the complement of the BED sequence.
 
   The input sequence will first be sorted with sort-fields, which may cause
-  an extensive memory use for ones with a large number of elements."
+  an extensive memory use for ones with a large number of elements.
+  Note also that this function assumes the BED sequence contains only valid
+  regions, and thus :start <= :end holds for each region. Make sure yourself
+  the BED sequence meets the condition, or the function may return a wrong
+  result."
   [refs xs]
   (let [chr->len (into {} (map (juxt :name :len)) refs)
         chrs (sort-by chr/chromosome-order-key (map :name refs))]

--- a/src/cljam/io/bed.clj
+++ b/src/cljam/io/bed.clj
@@ -262,17 +262,19 @@
     (subtract (sort-fields xs) (sort-fields ys))))
 
 (defn complement-fields
-  "Takes a map of chromosome name to its length and a sequence of BED fields,
-  and returns a lazy sequence that is the complement of the sequence.
+  "Takes a sequence of maps containing :name and :len keys (representing
+  chromosome's name and length, resp.) and a sequence of BED fields,
+  and returns a lazy sequence that is the complement of the BED sequence.
 
   The input sequence will first be sorted with sort-fields, which may cause
   an extensive memory use for ones with a large number of elements."
-  [chrom-lengths xs]
-  (let [chrs (sort-by chr/chromosome-order-key (keys chrom-lengths))]
+  [refs xs]
+  (let [chr->len (into {} (map (juxt :name :len)) refs)
+        chrs (sort-by chr/chromosome-order-key (map :name refs))]
     (letfn [(complement [xs chrs pos]
               (lazy-seq
                (if-let [chr (first chrs)]
-                 (let [len (get chrom-lengths chr)
+                 (let [len (get chr->len chr)
                        x (first xs)]
                    (if (and x (= (:chr x) chr))
                      (cond->> (complement (next xs) chrs (inc (:end x)))

--- a/src/cljam/io/bed.clj
+++ b/src/cljam/io/bed.clj
@@ -262,9 +262,7 @@
                        (if (fields-<= r1 y)
                          (cons r1 (subtract (next xs) ys))
                          (subtract (cons r1 (next xs)) (next ys)))
-                       (if (fields-<= x y)
-                         (subtract (next xs) ys)
-                         (subtract xs (next ys))))))
+                       (subtract (next xs) ys))))
                  xs)
                [])))]
     (subtract (sort-fields xs) (merge-fields ys))))

--- a/src/cljam/io/bed.clj
+++ b/src/cljam/io/bed.clj
@@ -208,12 +208,12 @@
    0
    (sort-fields xs)))
 
-(defn- fields-<
+(defn- fields-<=
   "Compare two BED fields on the basis of :chr and :end fields."
   [x y]
-  (< (compare [(chr/chromosome-order-key (:chr x)) (:end x)]
-              [(chr/chromosome-order-key (:chr y)) (:end y)])
-     0))
+  (<= (compare [(chr/chromosome-order-key (:chr x)) (:end x)]
+               [(chr/chromosome-order-key (:chr y)) (:end y)])
+      0))
 
 (defn intersect-fields
   "Returns a lazy sequence that is the intersection of the two BED sequences.
@@ -229,7 +229,7 @@
             (lazy-seq
              (if-let [x (first xs)]
                (if-let [y (first ys)]
-                 (cond->> (if (fields-< x y)
+                 (cond->> (if (fields-<= x y)
                             (intersect (next xs) ys)
                             (intersect xs (next ys)))
                    (region/overlapped-regions? x y)
@@ -238,7 +238,7 @@
                              (update :end min (:end y)))))
                  [])
                [])))]
-    (intersect (sort-fields xs) (sort-fields ys))))
+    (intersect (sort-fields xs) (merge-fields ys))))
 
 (defn subtract-fields
   "Returns a lazy sequence that is the result of subtracting the BED fields
@@ -259,15 +259,15 @@
                    (if r2
                      (cons r1 (subtract (cons r2 (next xs)) (next ys)))
                      (if r1
-                       (if (fields-< r1 y)
+                       (if (fields-<= r1 y)
                          (cons r1 (subtract (next xs) ys))
                          (subtract (cons r1 (next xs)) (next ys)))
-                       (if (fields-< x y)
+                       (if (fields-<= x y)
                          (subtract (next xs) ys)
                          (subtract xs (next ys))))))
                  xs)
                [])))]
-    (subtract (sort-fields xs) (sort-fields ys))))
+    (subtract (sort-fields xs) (merge-fields ys))))
 
 (defn complement-fields
   "Takes a sequence of maps containing :name and :len keys (representing
@@ -298,7 +298,7 @@
                      (cond->> (complement xs (next chrs) 1)
                        (< pos len)
                        (cons {:chr chr :start pos :end len})))))))]
-      (complement (sort-fields xs) chrs 1))))
+      (complement (merge-fields xs) chrs 1))))
 
 (defn write-raw-fields
   "Write sequence of BED fields to writer without converting :start and :thick-start values."

--- a/src/cljam/util/region.clj
+++ b/src/cljam/util/region.clj
@@ -3,6 +3,16 @@
   (:require [clojure.string :as cstr]
             [proton.core :as proton]))
 
+;;; region predicates
+;;; ----------
+
+(defn overlapped-regions?
+  "Returns true iff two regions are overlapped with each other."
+  [x y]
+  (and (= (:chr x) (:chr y))
+       (<= (:start y) (:end x))
+       (<= (:start x) (:end y))))
+
 ;;; region conversion
 ;;; ----------
 

--- a/src/cljam/util/region.clj
+++ b/src/cljam/util/region.clj
@@ -7,7 +7,7 @@
 ;;; ----------
 
 (defn overlapped-regions?
-  "Returns true iff two regions are overlapped with each other."
+  "Returns true if two regions are overlapped with each other."
   [x y]
   (and (= (:chr x) (:chr y))
        (<= (:start y) (:end x))

--- a/test/cljam/io/bed_test.clj
+++ b/test/cljam/io/bed_test.clj
@@ -256,8 +256,8 @@
     [{:chr "chr1" :start 301 :end 899} {:chr "chr2" :start 301 :end 800}])
 
   (is (thrown? IllegalArgumentException
-               (doall (bed/complement-fields [{:name "chr1" :len 1000}]
-                                             [{:chr "chr2" :start 1 :end 100}])))))
+               (bed/complement-fields [{:name "chr1" :len 1000}]
+                                      [{:chr "chr2" :start 1 :end 100}]))))
 
 (deftest bed-reader-and-bam-reader
   (with-open [bam (sam/bam-reader test-sorted-bam-file)]

--- a/test/cljam/io/bed_test.clj
+++ b/test/cljam/io/bed_test.clj
@@ -242,7 +242,10 @@
 
 (deftest bed-complement
   (are [?xs ?result]
-      (= ?result (bed/complement-fields {"chr1" 1000, "chr2" 800} ?xs))
+      (= ?result
+         (bed/complement-fields [{:name "chr1" :len 1000}
+                                 {:name "chr2" :len 800}]
+                                ?xs))
     []
     [{:chr "chr1" :start 1 :end 1000} {:chr "chr2" :start 1 :end 800}]
 
@@ -253,7 +256,8 @@
     [{:chr "chr1" :start 301 :end 899} {:chr "chr2" :start 301 :end 800}])
 
   (is (thrown? IllegalArgumentException
-               (doall (bed/complement-fields {"chr1" 1000} [{:chr "chr2" :start 1 :end 100}])))))
+               (doall (bed/complement-fields [{:name "chr1" :len 1000}]
+                                             [{:chr "chr2" :start 1 :end 100}])))))
 
 (deftest bed-reader-and-bam-reader
   (with-open [bam (sam/bam-reader test-sorted-bam-file)]

--- a/test/cljam/io/bed_test.clj
+++ b/test/cljam/io/bed_test.clj
@@ -204,7 +204,11 @@
 
     [{:chr "chr1" :start 10 :end 40} {:chr "chr1" :start 50 :end 80} {:chr "chr2" :start 10 :end 40}]
     [{:chr "chr1" :start 10 :end 20} {:chr "chr2" :start 30 :end 40}]
-    [{:chr "chr1" :start 10 :end 20} {:chr "chr2" :start 30 :end 40}]))
+    [{:chr "chr1" :start 10 :end 20} {:chr "chr2" :start 30 :end 40}]
+
+    [{:chr "chr1" :start 10 :end 40} {:chr "chr1" :start 10 :end 50}]
+    [{:chr "chr1" :start 10 :end 40} {:chr "chr1" :start 30 :end 50}]
+    [{:chr "chr1" :start 10 :end 40} {:chr "chr1" :start 10 :end 50}]))
 
 (deftest bed-subtract
   (are [?xs ?ys ?result] (= ?result (bed/subtract-fields ?xs ?ys))
@@ -238,7 +242,11 @@
 
     [{:chr "chr1" :start 10 :end 40} {:chr "chr1" :start 50 :end 80} {:chr "chr2" :start 10 :end 40}]
     [{:chr "chr1" :start 10 :end 20} {:chr "chr2" :start 5 :end 30}]
-    [{:chr "chr1" :start 21 :end 40} {:chr "chr1" :start 50 :end 80} {:chr "chr2" :start 31 :end 40}]))
+    [{:chr "chr1" :start 21 :end 40} {:chr "chr1" :start 50 :end 80} {:chr "chr2" :start 31 :end 40}]
+
+    [{:chr "chr1" :start 10 :end 40} {:chr "chr1" :start 10 :end 50}]
+    [{:chr "chr1" :start 10 :end 40} {:chr "chr1" :start 30 :end 50}]
+    []))
 
 (deftest bed-complement
   (are [?xs ?result]
@@ -253,7 +261,10 @@
     [{:chr "chr1" :start 301 :end 1000} {:chr "chr2" :start 1 :end 800}]
 
     [{:chr "chr1" :start 1 :end 300} {:chr "chr1" :start 900 :end 1000} {:chr "chr2" :start 1 :end 300}]
-    [{:chr "chr1" :start 301 :end 899} {:chr "chr2" :start 301 :end 800}])
+    [{:chr "chr1" :start 301 :end 899} {:chr "chr2" :start 301 :end 800}]
+
+    [{:chr "chr1" :start 1 :end 300} {:chr "chr1" :start 200 :end 500}]
+    [{:chr "chr1" :start 501 :end 1000} {:chr "chr2" :start 1 :end 800}])
 
   (is (thrown? IllegalArgumentException
                (bed/complement-fields [{:name "chr1" :len 1000}]

--- a/test/cljam/io/bed_test.clj
+++ b/test/cljam/io/bed_test.clj
@@ -244,16 +244,16 @@
   (are [?xs ?result]
       (= ?result (bed/complement-fields {"chr1" 1000, "chr2" 800} ?xs))
     []
-    [{:chr "chr1" :start 0 :end 1000} {:chr "chr2" :start 0 :end 800}]
+    [{:chr "chr1" :start 1 :end 1000} {:chr "chr2" :start 1 :end 800}]
 
-    [{:chr "chr1" :start 0 :end 300}]
-    [{:chr "chr1" :start 300 :end 1000} {:chr "chr2" :start 0 :end 800}]
+    [{:chr "chr1" :start 1 :end 300}]
+    [{:chr "chr1" :start 301 :end 1000} {:chr "chr2" :start 1 :end 800}]
 
-    [{:chr "chr1" :start 0 :end 300} {:chr "chr1" :start 900 :end 1000} {:chr "chr2" :start 0 :end 300}]
-    [{:chr "chr1" :start 300 :end 900} {:chr "chr2" :start 300 :end 800}])
+    [{:chr "chr1" :start 1 :end 300} {:chr "chr1" :start 900 :end 1000} {:chr "chr2" :start 1 :end 300}]
+    [{:chr "chr1" :start 301 :end 899} {:chr "chr2" :start 301 :end 800}])
 
   (is (thrown? IllegalArgumentException
-               (bed/complement-fields {"chr1" 1000} [{:chr "chr2" :start 0 :end 100}]))))
+               (doall (bed/complement-fields {"chr1" 1000} [{:chr "chr2" :start 1 :end 100}])))))
 
 (deftest bed-reader-and-bam-reader
   (with-open [bam (sam/bam-reader test-sorted-bam-file)]

--- a/test/cljam/io/bed_test.clj
+++ b/test/cljam/io/bed_test.clj
@@ -172,6 +172,89 @@
   (is (= (bed/merge-fields [{:chr "chr1" :start 1 :end 10 :name "chr1:1-10"} {:chr "chr1" :start 4 :end 13 :name "chr1:4-13"}])
          [{:chr "chr1" :start 1 :end 13 :name "chr1:1-10+chr1:4-13"}])))
 
+(deftest bed-intersect
+  (are [?xs ?ys ?result] (= ?result (bed/intersect-fields ?xs ?ys))
+    []
+    []
+    []
+
+    [{:chr "chr1" :start 10 :end 40}]
+    []
+    []
+
+    []
+    [{:chr "chr1" :start 10 :end 40}]
+    []
+
+    [{:chr "chr1" :start 10 :end 40}]
+    [{:chr "chr1" :start 50 :end 60}]
+    []
+
+    [{:chr "chr1" :start 10 :end 40} {:chr "chr1" :start 50 :end 80}]
+    [{:chr "chr1" :start 5 :end 20}]
+    [{:chr "chr1" :start 10 :end 20}]
+
+    [{:chr "chr1" :start 10 :end 40} {:chr "chr1" :start 50 :end 80}]
+    [{:chr "chr1" :start 20 :end 30}]
+    [{:chr "chr1" :start 20 :end 30}]
+
+    [{:chr "chr1" :start 10 :end 40} {:chr "chr1" :start 50 :end 80}]
+    [{:chr "chr1" :start 30 :end 60} {:chr "chr1" :start 70 :end 90}]
+    [{:chr "chr1" :start 30 :end 40} {:chr "chr1" :start 50 :end 60} {:chr "chr1" :start 70 :end 80}]
+
+    [{:chr "chr1" :start 10 :end 40} {:chr "chr1" :start 50 :end 80} {:chr "chr2" :start 10 :end 40}]
+    [{:chr "chr1" :start 10 :end 20} {:chr "chr2" :start 30 :end 40}]
+    [{:chr "chr1" :start 10 :end 20} {:chr "chr2" :start 30 :end 40}]))
+
+(deftest bed-subtract
+  (are [?xs ?ys ?result] (= ?result (bed/subtract-fields ?xs ?ys))
+    []
+    []
+    []
+
+    [{:chr "chr1" :start 10 :end 40}]
+    []
+    [{:chr "chr1" :start 10 :end 40}]
+
+    []
+    [{:chr "chr1" :start 10 :end 40}]
+    []
+
+    [{:chr "chr1" :start 10 :end 40}]
+    [{:chr "chr1" :start 50 :end 60}]
+    [{:chr "chr1" :start 10 :end 40}]
+
+    [{:chr "chr1" :start 10 :end 40} {:chr "chr1" :start 50 :end 80}]
+    [{:chr "chr1" :start 5 :end 20}]
+    [{:chr "chr1" :start 21 :end 40} {:chr "chr1" :start 50 :end 80}]
+
+    [{:chr "chr1" :start 10 :end 40} {:chr "chr1" :start 50 :end 80}]
+    [{:chr "chr1" :start 20 :end 30}]
+    [{:chr "chr1" :start 10 :end 19} {:chr "chr1" :start 31 :end 40} {:chr "chr1" :start 50 :end 80}]
+
+    [{:chr "chr1" :start 10 :end 40} {:chr "chr1" :start 50 :end 80}]
+    [{:chr "chr1" :start 30 :end 60} {:chr "chr1" :start 70 :end 90}]
+    [{:chr "chr1" :start 10 :end 29} {:chr "chr1" :start 61 :end 69}]
+
+    [{:chr "chr1" :start 10 :end 40} {:chr "chr1" :start 50 :end 80} {:chr "chr2" :start 10 :end 40}]
+    [{:chr "chr1" :start 10 :end 20} {:chr "chr2" :start 5 :end 30}]
+    [{:chr "chr1" :start 21 :end 40} {:chr "chr1" :start 50 :end 80} {:chr "chr2" :start 31 :end 40}]))
+
+(deftest bed-complement
+  (are [?xs ?result]
+      (= ?result (bed/complement-fields {"chr1" 1000, "chr2" 800} ?xs))
+    []
+    [{:chr "chr1" :start 0 :end 1000} {:chr "chr2" :start 0 :end 800}]
+
+    [{:chr "chr1" :start 0 :end 300}]
+    [{:chr "chr1" :start 300 :end 1000} {:chr "chr2" :start 0 :end 800}]
+
+    [{:chr "chr1" :start 0 :end 300} {:chr "chr1" :start 900 :end 1000} {:chr "chr2" :start 0 :end 300}]
+    [{:chr "chr1" :start 300 :end 900} {:chr "chr2" :start 300 :end 800}])
+
+  (is (thrown? IllegalArgumentException
+               (bed/complement-fields {"chr1" 1000} [{:chr "chr2" :start 0 :end 100}]))))
+
 (deftest bed-reader-and-bam-reader
   (with-open [bam (sam/bam-reader test-sorted-bam-file)]
     (letfn [(ref-pos-end [m] {:rname (:rname m) :pos (:pos m) :end (sam-util/get-end m)})


### PR DESCRIPTION
This PR adds the following new APIs to `cljam.io.bed`:

- `intersect-fields`
- `subtract-fields`
- `complement-fields`

Each implementation reflects the behavior of `bedtools`' corresponding subcommand. See  the links below for details:

- intersect: http://bedtools.readthedocs.io/en/latest/content/tools/intersect.html
- subtract: http://bedtools.readthedocs.io/en/latest/content/tools/subtract.html
- complement: http://bedtools.readthedocs.io/en/latest/content/tools/complement.html

There is one thing to be confirmed.

`complement-fields` now throws an exception if the map passed as the first argument (`chrom-lengths`) lacks the entry for some chromosome appeared in the sequence of BED fields. However, the exception will be deferred until the resulting sequence is realized because `complement-fields` returns a lazy sequence and the body of `complement-fields` is wrapped with `lazy-seq`.

The design of throwing exceptions from lazy sequences doesn't look very good to me. Is it better to scan the input sequences and check if every chromosome appeared in them can be found in `chrom-lengths` before processing the sequences? Any suggestions?