### PR TITLE
Upgrade dependencies

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,16 +4,24 @@ cache:
   directories:
     - $HOME/.m2
 jdk:
+  - oraclejdk10
   - oraclejdk9
   - oraclejdk8
+  - openjdk11
+  - openjdk10
+  - openjdk9
   - openjdk8
-  - openjdk7
 env:
   matrix:
     - VERSION='1.8'
     - VERSION='1.9'
     - VERSION='1.10'
-script: lein with-profile dev,$VERSION test
+before_install:
+  - if [ -f "${JAVA_HOME}/lib/security/cacerts" -a -w  "${JAVA_HOME}/lib/security/cacerts" ]; then rm "${JAVA_HOME}/lib/security/cacerts" && ln -s /etc/ssl/certs/java/cacerts "${JAVA_HOME}/lib/security/cacerts"; fi;
+script:
+    - lein with-profile dev,$VERSION test
+    - lein with-profile dev,1.9 bin
+    - target/cljam version
 jobs:
   include:
     - stage: coverage

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,9 +10,9 @@ jdk:
   - openjdk7
 env:
   matrix:
-    - VERSION='1.7'
     - VERSION='1.8'
     - VERSION='1.9'
+    - VERSION='1.10'
 script: lein with-profile dev,$VERSION test
 jobs:
   include:

--- a/deploy-snapshot.sh
+++ b/deploy-snapshot.sh
@@ -3,5 +3,5 @@
 set -e
 
 if head -n 1 project.clj | grep -e '-SNAPSHOT' >/dev/null; then
-    lein with-profile +1.8 deploy snapshots
+    lein with-profile +1.9 deploy snapshots
 fi

--- a/project.clj
+++ b/project.clj
@@ -5,7 +5,7 @@
             :url "https://www.apache.org/licenses/LICENSE-2.0"}
   :dependencies [[org.clojure/tools.logging "0.4.1"]
                  [org.clojure/tools.cli "0.3.7"]
-                 [org.apache.commons/commons-compress "1.16.1"]
+                 [org.apache.commons/commons-compress "1.17"]
                  [clj-sub-command "0.4.1"]
                  [digest "1.4.8"]
                  [bgzf4j "0.1.0"]

--- a/project.clj
+++ b/project.clj
@@ -4,9 +4,9 @@
   :license {:name "Apache License, Version 2.0"
             :url "https://www.apache.org/licenses/LICENSE-2.0"}
   :dependencies [[org.clojure/tools.logging "0.4.1"]
-                 [org.clojure/tools.cli "0.3.5"]
+                 [org.clojure/tools.cli "0.3.7"]
                  [org.apache.commons/commons-compress "1.16.1"]
-                 [clj-sub-command "0.4.0"]
+                 [clj-sub-command "0.4.1"]
                  [digest "1.4.8"]
                  [bgzf4j "0.1.0"]
                  [com.climate/claypoole "1.1.4"]

--- a/project.clj
+++ b/project.clj
@@ -3,7 +3,7 @@
   :url "https://github.com/chrovis/cljam"
   :license {:name "Apache License, Version 2.0"
             :url "https://www.apache.org/licenses/LICENSE-2.0"}
-  :dependencies [[org.clojure/tools.logging "0.4.0"]
+  :dependencies [[org.clojure/tools.logging "0.4.1"]
                  [org.clojure/tools.cli "0.3.5"]
                  [org.apache.commons/commons-compress "1.16.1"]
                  [clj-sub-command "0.4.0"]

--- a/project.clj
+++ b/project.clj
@@ -12,7 +12,7 @@
                  [com.climate/claypoole "1.1.4"]
                  [camel-snake-kebab "0.4.0"]
                  [proton "0.1.6"]]
-  :profiles {:dev {:dependencies [[org.clojure/clojure "1.8.0"]
+  :profiles {:dev {:dependencies [[org.clojure/clojure "1.9.0"]
                                   [cavia "0.5.1"]
                                   [criterium "0.4.4"]
                                   [net.totakke/libra "0.1.1"]
@@ -32,7 +32,7 @@
              :1.7 {:dependencies [[org.clojure/clojure "1.7.0"]]}
              :1.8 {:dependencies [[org.clojure/clojure "1.8.0"]]}
              :1.9 {:dependencies [[org.clojure/clojure "1.9.0"]]}
-             :uberjar {:dependencies [[org.clojure/clojure "1.8.0"]
+             :uberjar {:dependencies [[org.clojure/clojure "1.9.0"]
                                       [org.apache.logging.log4j/log4j-api "2.11.0"]
                                       [org.apache.logging.log4j/log4j-core "2.11.0"]]
                        :resource-paths ["bin-resources"]

--- a/project.clj
+++ b/project.clj
@@ -19,7 +19,7 @@
                                   [org.tcrawley/dynapath "1.0.0"]
                                   [se.haleby/stub-http "0.2.5"]]
                    :plugins [[lein-binplus "0.6.4" :exclusions [org.clojure/clojure]]
-                             [lein-codox "0.10.3"]
+                             [lein-codox "0.10.4"]
                              [lein-marginalia "0.9.1" :exclusions [org.clojure/clojure]]
                              [lein-cloverage "1.0.10" :exclusions [org.clojure/clojure org.tcrawley/dynapath]]
                              [net.totakke/lein-libra "0.1.2"]]

--- a/project.clj
+++ b/project.clj
@@ -13,7 +13,7 @@
                  [camel-snake-kebab "0.4.0"]
                  [proton "0.1.6"]]
   :profiles {:dev {:dependencies [[org.clojure/clojure "1.8.0"]
-                                  [cavia "0.5.0"]
+                                  [cavia "0.5.1"]
                                   [criterium "0.4.4"]
                                   [net.totakke/libra "0.1.1"]
                                   [org.tcrawley/dynapath "1.0.0"]

--- a/project.clj
+++ b/project.clj
@@ -22,7 +22,7 @@
                              [lein-codox "0.10.3"]
                              [lein-marginalia "0.9.1" :exclusions [org.clojure/clojure]]
                              [lein-cloverage "1.0.10" :exclusions [org.clojure/clojure org.tcrawley/dynapath]]
-                             [net.totakke/lein-libra "0.1.0"]]
+                             [net.totakke/lein-libra "0.1.2"]]
                    :test-selectors {:default #(not-any? % [:slow :remote])
                                     :slow :slow ; Slow tests with local resources
                                     :remote :remote ; Tests with remote resources

--- a/project.clj
+++ b/project.clj
@@ -18,7 +18,7 @@
                                   [net.totakke/libra "0.1.1"]
                                   [org.tcrawley/dynapath "1.0.0"]
                                   [se.haleby/stub-http "0.2.5"]]
-                   :plugins [[lein-binplus "0.6.2" :exclusions [org.clojure/clojure]]
+                   :plugins [[lein-binplus "0.6.4" :exclusions [org.clojure/clojure]]
                              [lein-codox "0.10.3"]
                              [lein-marginalia "0.9.1" :exclusions [org.clojure/clojure]]
                              [lein-cloverage "1.0.10" :exclusions [org.clojure/clojure org.tcrawley/dynapath]]

--- a/project.clj
+++ b/project.clj
@@ -32,6 +32,7 @@
              :1.7 {:dependencies [[org.clojure/clojure "1.7.0"]]}
              :1.8 {:dependencies [[org.clojure/clojure "1.8.0"]]}
              :1.9 {:dependencies [[org.clojure/clojure "1.9.0"]]}
+             :1.10 {:dependencies [[org.clojure/clojure "1.10.0-alpha4"]]}
              :uberjar {:dependencies [[org.clojure/clojure "1.9.0"]
                                       [org.apache.logging.log4j/log4j-api "2.11.0"]
                                       [org.apache.logging.log4j/log4j-core "2.11.0"]]


### PR DESCRIPTION
#### Summary
- Upgrade outdated dependencies
- Use Clojure 1.9 for `:dev` and `:uberjar` profiles (#133)
- Add some more JDK versions for CI
    - Some installed certificates in JDKs need to be overwritten to connect to clojars. https://stackoverflow.com/questions/50712164/clojure-build-failed-on-travis-ci-with-openjdk-9-during-lein-deps