### PR TITLE
Fix options of cljam.algo.pileup/pileup

### DIFF
--- a/src/cljam/algo/pileup.clj
+++ b/src/cljam/algo/pileup.clj
@@ -195,12 +195,22 @@
       (step xs))))
 
 (defn mpileup
-  "Pile up alignments from multiple sources."
+  "Pile up alignments from multiple sources.
+
+  The following `options` are available:
+  - `min-base-quality` Minimum quality of called bases [13]
+  - `min-map-quality` Minimum quality of alignments [0]
+  - `ignore-overlaps?` Disable detecting overlapped bases of PE reads [false]"
   [region options & sam-readers]
   (apply align-pileup-seqs (map #(pileup % region options) sam-readers)))
 
 (defn create-mpileup
-  "Creates a mpileup file from the BAM file."
+  "Creates a mpileup file from the BAM file.
+
+  The following `options` are available:
+  - `min-base-quality` Minimum quality of called bases [13]
+  - `min-map-quality` Minimum quality of alignments [0]
+  - `ignore-overlaps?` Disable detecting overlapped bases of PE reads [false]"
   ([in-sam out-mplp]
    (create-mpileup in-sam nil out-mplp))
   ([in-sam in-ref out-mplp]


### PR DESCRIPTION
#### Summary
- Add an `ignore-overlaps?` option to `cljam.algo.pileup/pileup`
- Skip filtering bases when `min-base-quality` is ~zero~ not positive

#### Tests

- `lein check` 🆗
- `lein test :all` 🆗