### PR TITLE
Fix some fields of cljam.io.pileup LocusPile and PileupBase

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,6 @@ cache:
   directories:
     - $HOME/.m2
 jdk:
-  - oraclejdk10
   - oraclejdk9
   - oraclejdk8
   - openjdk11

--- a/project.clj
+++ b/project.clj
@@ -4,7 +4,7 @@
   :license {:name "Apache License, Version 2.0"
             :url "https://www.apache.org/licenses/LICENSE-2.0"}
   :dependencies [[org.clojure/tools.logging "0.4.1"]
-                 [org.clojure/tools.cli "0.3.7"]
+                 [org.clojure/tools.cli "0.4.1"]
                  [org.apache.commons/commons-compress "1.18"]
                  [clj-sub-command "0.4.1"]
                  [digest "1.4.8"]

--- a/project.clj
+++ b/project.clj
@@ -6,7 +6,7 @@
   :dependencies [[org.clojure/tools.logging "0.4.1"]
                  [org.clojure/tools.cli "0.4.1"]
                  [org.apache.commons/commons-compress "1.18"]
-                 [clj-sub-command "0.4.1"]
+                 [clj-sub-command "0.5.0"]
                  [digest "1.4.8"]
                  [bgzf4j "0.1.0"]
                  [com.climate/claypoole "1.1.4"]

--- a/project.clj
+++ b/project.clj
@@ -31,7 +31,7 @@
              :1.7 {:dependencies [[org.clojure/clojure "1.7.0"]]}
              :1.8 {:dependencies [[org.clojure/clojure "1.8.0"]]}
              :1.9 {:dependencies [[org.clojure/clojure "1.9.0"]]}
-             :1.10 {:dependencies [[org.clojure/clojure "1.10.0-alpha6"]]}
+             :1.10 {:dependencies [[org.clojure/clojure "1.10.0-beta4"]]}
              :uberjar {:dependencies [[org.clojure/clojure "1.9.0"]
                                       [org.apache.logging.log4j/log4j-api "2.11.1"]
                                       [org.apache.logging.log4j/log4j-core "2.11.1"]]

--- a/project.clj
+++ b/project.clj
@@ -18,7 +18,7 @@
                                   [net.totakke/libra "0.1.1"]
                                   [se.haleby/stub-http "0.2.5"]]
                    :plugins [[lein-binplus "0.6.4" :exclusions [org.clojure/clojure]]
-                             [lein-codox "0.10.4"]
+                             [lein-codox "0.10.5"]
                              [lein-marginalia "0.9.1" :exclusions [org.clojure/clojure]]
                              [lein-cloverage "1.0.13"]
                              [net.totakke/lein-libra "0.1.2"]]

--- a/src/cljam/algo/pileup.clj
+++ b/src/cljam/algo/pileup.clj
@@ -84,7 +84,7 @@
         [base indel] ((:seqs-at-ref aln) relative-pos)]
     (-> (PileupBase.
          (zero? relative-pos)
-         (when (zero? relative-pos) (.mapq aln))
+         (.mapq aln)
          base
          qual
          (flag/reversed? (.flag aln))
@@ -101,9 +101,8 @@
 (defn ->locus-pile
   "Convert a pile into `cljam.io.pileup.LocusPile`."
   [chr [pos pile]]
-  (let [c (count pile)]
-    (when (pos? c)
-      (LocusPile. chr pos \N c pile))))
+  (when (seq pile)
+    (LocusPile. chr pos pile)))
 
 (defn- correct-qual
   "Correct quality of two overlapped mate reads by setting zero quality for one

--- a/src/cljam/io/pileup.clj
+++ b/src/cljam/io/pileup.clj
@@ -21,8 +21,6 @@
 
 (defrecord LocusPile [rname
                       ^int pos
-                      ^char ref
-                      ^long count
                       pile])
 
 ;; Reader
@@ -103,7 +101,8 @@
         pile (mapv (fn [b q] (assoc b :qual q))
                    (some->> bases (parse-bases-col upper-ref-base))
                    (some-> quals qual/fastq->phred))]
-    (LocusPile. rname (p/as-int pos) ref-base (p/as-long cnt) pile)))
+    (-> (LocusPile. rname (p/as-long pos) pile)
+        (assoc :count (p/as-int cnt) :ref ref-base))))
 
 (defn read-piles
   "Reads piled-up bases of the pileup file, returning them as a lazy sequence of


### PR DESCRIPTION
#### Summary
For clarification and better performance,
- Remove `count` and `ref` fields from `defrecord` of `cljam.io.pileup.LocusPile`
    - optional for `cljam.io.pileup.PileupReader`
- Always fill `mapq` of `cljam.io.pileup.PileupBase` when available

#### Tests

- `lein check` 🆗
- `lein test :all` 🆗