### PR TITLE
Add some util functions for manipulating VCF variants

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -31,7 +31,7 @@
              :1.7 {:dependencies [[org.clojure/clojure "1.7.0"]]}
              :1.8 {:dependencies [[org.clojure/clojure "1.8.0"]]}
              :1.9 {:dependencies [[org.clojure/clojure "1.9.0"]]}
-             :1.10 {:dependencies [[org.clojure/clojure "1.10.0-beta4"]]}
+             :1.10 {:dependencies [[org.clojure/clojure "1.10.0-beta8"]]}
              :uberjar {:dependencies [[org.clojure/clojure "1.9.0"]
                                       [org.apache.logging.log4j/log4j-api "2.11.1"]
                                       [org.apache.logging.log4j/log4j-core "2.11.1"]]

--- a/project.clj
+++ b/project.clj
@@ -11,7 +11,7 @@
                  [bgzf4j "0.1.0"]
                  [com.climate/claypoole "1.1.4"]
                  [camel-snake-kebab "0.4.0"]
-                 [proton "0.1.6"]]
+                 [proton "0.1.7"]]
   :profiles {:dev {:dependencies [[org.clojure/clojure "1.9.0"]
                                   [cavia "0.5.1"]
                                   [criterium "0.4.4"]

--- a/src/cljam/io/vcf/util.clj
+++ b/src/cljam/io/vcf/util.clj
@@ -1,6 +1,5 @@
 (ns cljam.io.vcf.util
-  (:require [clojure.string :as cstr]
-            [cljam.util :as util]))
+  (:require [clojure.string :as cstr]))
 
 (definline dot-or-nil?
   "Checks if given string is equal to \".\" or nil."
@@ -89,9 +88,9 @@
   [^String gt]
   (when-not (dot-or-nil? gt)
     (->> gt
-         (re-seq #"([\||/])?(\d+)")
-         (map (fn [[_ phase allele]]
-                [(Integer/parseInt allele)
+         (re-seq #"([\||/])?(.|\d+)")
+         (map (fn [[_ phase ^String allele]]
+                [(when-not (dot-or-nil? allele) (Integer/parseInt allele))
                  (if phase
                    (= phase "|")
                    (neg? (.indexOf ^String gt "/")))])))))
@@ -100,7 +99,63 @@
   "Stringifies genotype map into VCF-style GT string."
   [gt-seq]
   (when-not (or (nil? gt-seq) (empty? gt-seq))
-    (apply str (rest (mapcat (fn [[allele phase]] [(if phase "|" "/") allele]) gt-seq)))))
+    (->> gt-seq
+         (mapcat
+          (fn [[allele phase]]
+            [(if phase "|" "/") (or allele \.)]))
+         rest
+         (apply str))))
+
+(defn genotype-seq
+  "Produces a sequence of genotypes represented as sequences of integers."
+  ([^long ploidy ^long n-alt-alleles]
+   (genotype-seq ploidy n-alt-alleles []))
+  ([^long ploidy ^long n-alt-alleles s]
+   (mapcat
+    (fn [i]
+      (if (= 1 ploidy)
+        [(cons i s)]
+        (genotype-seq (dec ploidy) i (cons i s))))
+    (range (inc n-alt-alleles)))))
+
+(defn genotype-index
+  "Returns an index for given genotype."
+  ^long [genotype]
+  (letfn [(c [^long n ^long k]
+            (cond
+              (< n k) 0
+              (or (zero? k) (= k n)) 1
+              (or (= k 1) (= k (dec n))) n
+              (< (quot n 2) k) (recur n (- n k))
+              :else (loop [i (inc (- n k)) j 1 r 1]
+                      (if (<= j k)
+                        (recur (inc i) (inc j) (quot (* r i) j))
+                        r))))]
+    (->> genotype
+         sort
+         (map-indexed (fn [^long m ^long k] (c (+ k m) (inc m))))
+         (apply +))))
+
+(defn biallelic-genotype
+  "Converts a multiallelic `genotype` string into a biallelic one. Ignores all
+  alleles other than the reference allele and the `target-allele`."
+  [genotype ^long target-allele]
+  (->> genotype
+       parse-genotype
+       (map (fn [[allele phased?]]
+              [(if (nil? allele) nil (if (= target-allele allele) 1 0))
+               phased?]))
+       stringify-genotype))
+
+(defn biallelic-coll
+  "Picks up elements in multiallelic `coll` and make a biallelic one. Ignores
+  all alleles other than the reference allele and the `target-allele`."
+  [^long ploidy ^long n-alt-alleles ^long target-allele coll]
+  (keep-indexed
+   (fn [i gt]
+     (when (every? (fn [^long a] (or (= a 0) (= a target-allele))) gt)
+       (nth coll i)))
+   (genotype-seq ploidy n-alt-alleles)))
 
 (defn genotype->ints
   "Convert genotype to a sequence of integers."
@@ -139,8 +194,8 @@
   (->> formats
        (map (fn [k] [k (sample-map k)]))
        reverse
-       (drop-while (fn [[k v]] (or (nil? v) (= [nil] v))))
-       (map (fn [[k v]]
+       (drop-while (fn [[_ v]] (or (nil? v) (= [nil] v))))
+       (map (fn [[_ v]]
               (cond
                 (sequential? v) (cstr/join "," (map (fn [i] (if (nil? i) "." i)) v))
                 (nil? v) "."
@@ -176,3 +231,145 @@
           (update :info stringify-info)
           (update fmt-kw stringify-format)
           (merge (into {} (for [k sample-kws] [k (stringify-sample (v fmt-kw) (v k))])))))))
+
+(defmacro ^:private ->breakend [^String alt p1 p2 t1 t2 strand join]
+  `(let [p1# ~p1
+         p2# ~p2
+         t1# ~t1
+         t2# ~t2
+         k# (.lastIndexOf ~alt (int 58) p2#)
+         k'# (inc k#)] ;; \:
+     (when (and (< p1# k#) (< k'# p2#) (< t1# t2#))
+       (when-let [pos# (try
+                         (Long/parseLong (.substring ~alt k'# p2#))
+                         (catch NumberFormatException _# nil))]
+         {:chr (.substring ~alt p1# k#),
+          :pos pos#,
+          :bases (.substring ~alt t1# t2#),
+          :strand ~strand,
+          :join ~join}))))
+
+(defn parse-breakend
+  "Parses an ALT allele string of SVTYPE=BND.
+  Returns a map with mandatory keys:
+  - `:bases` bases that replaces the reference place
+  - `:join` `:before` or `:after`
+  and optional keys for a mate:
+  - `:chr` chromosome name of the mate sequence
+  - `:pos` genomic position of the mate sequence
+  - `:strand` strand of the mate sequence
+  Returns `nil` if input `alt` is not a breakend."
+  [^String alt]
+  (let [left-bracket (int 91) ;; \[
+        right-bracket (int 93) ;; \]
+        l1 (.indexOf alt left-bracket)
+        r1 (.indexOf alt right-bracket)]
+    (if-not (neg? l1)
+      (let [l2 (.indexOf alt left-bracket (inc l1))
+            l2' (inc l2)]
+        (when-not (or (neg? l2)
+                      (not (neg? (.indexOf alt left-bracket l2')))
+                      (not (neg? r1)))
+          (if (zero? l1)
+            (->breakend alt 1 l2 l2' (.length alt) :reverse :before)
+            (->breakend alt (inc l1) l2 0 l1 :forward :after))))
+      (if-not (neg? r1)
+        (let [r2 (.indexOf alt right-bracket (inc r1))
+              r2' (inc r2)]
+          (when-not (or (neg? r2)
+                        (not (neg? (.indexOf alt right-bracket r2'))))
+            (if (zero? r1)
+              (->breakend alt 1 r2 r2' (.length alt) :forward :before)
+              (->breakend alt (inc r1) r2 0 r1 :reverse :after))))
+        (let [dot (int 46) ;; \.
+              d (.indexOf alt dot)] ;; single breakends
+          (when-not (or (neg? d)
+                        (= 1 (.length alt))
+                        (not (neg? (.indexOf alt dot (inc d)))))
+            (if (zero? d)
+              {:bases (.substring alt 1), :join :before}
+              {:bases (.substring alt 0 d), :join :after})))))))
+
+(defn- parse-alt'
+  [^String ref ^String alt]
+  (let [r-len (.length ref)
+        a-len (.length alt)
+        eq (fn [^long r ^long a]
+             (= (Character/toUpperCase (.charAt ref r))
+                (Character/toUpperCase (.charAt alt a))))
+        [^long r ^long a] (loop [r 0 a 0]
+                            (if (and (< r r-len) (< a a-len) (eq r a))
+                              (recur (inc r) (inc a))
+                              [r a]))]
+    (if (and (< a a-len) (= r r-len))
+      {:type :insertion, :n-bases (- a-len r),
+       :offset (dec a), :inserted (.substring alt a)}
+      (if (and (= a a-len) (< r r-len))
+        {:type :deletion, :n-bases (- a r-len),
+         :offset (dec r), :deleted (.substring ref r)}
+        (if (= r r-len a a-len)
+          {:type :ref}
+          (let [[^long re ^long ae] (loop [re (dec r-len)
+                                           ae (dec a-len)]
+                                      (if (and (< r re) (< a ae) (eq re ae))
+                                        (recur (dec re) (dec ae))
+                                        [re ae]))]
+            (if (= ae a)
+              (if (= re r)
+                {:type :snp, :ref (.charAt ref a),
+                 :alt (.charAt alt a), :offset a}
+                (let [n (- r re)]
+                  (if (eq re ae)
+                    {:type :deletion, :n-bases n,
+                     :offset (dec r), :deleted (.substring ref r re)}
+                    {:type :other, :n-bases n})))
+              (if (= re r)
+                (let [n (- ae a)]
+                  (if (eq re ae)
+                    {:type :insertion, :n-bases n,
+                     :offset (dec a), :inserted (.substring alt a ae)}
+                    {:type :other, :n-bases n}))
+                (let [n (if (< (- ae a) (- re r))
+                          (- r re 1)
+                          (- ae a -1))]
+                  (if (= (- re r) (- ae a))
+                    {:type :mnp, :ref (.substring ref r (inc re)),
+                     :alt (.substring alt a (inc ae)), :offset a}
+                    {:type :other, :n-bases n}))))))))))
+
+(defn parse-alt
+  "Parses an alt allele string and returns a map containing its details."
+  [^String ref ^String alt]
+  (let [r-len (.length ref)
+        a-len (.length alt)
+        fa (.charAt alt (int 0))]
+    (if (= 1 r-len a-len)
+      (if (or (= fa \.)
+              (= fa \*)
+              (= fa \X)
+              (= (Character/toUpperCase fa)
+                 (Character/toUpperCase (.charAt ref (int 0)))))
+        {:type :ref}
+        {:type :snp, :ref (.charAt ref (int 0)), :alt fa, :offset 0})
+      (if (= fa \<)
+        (let [la (.charAt alt (dec a-len))]
+          (if (= la \>)
+            (if (and (= 3 a-len)
+                     (or (= (.charAt alt (int 1)) \*)   ;; <*>
+                         (= (.charAt alt (int 1)) \X))) ;; <X>
+              {:type :ref}
+              {:type :id, :id (.substring alt (int 1) (dec a-len))})
+            (if (and (<= 4 a-len) ;; <id>N, SVTYPE=INS
+                     (= (.charAt alt (dec (dec a-len))) \>))
+              {:type :complete-insertion, :join :before, :base la,
+               :id (.substring alt 1 (dec (dec a-len)))}
+              {:type :other})))
+        (let [la (.charAt alt (dec a-len))]
+          (if (and (<= 4 a-len) ;; N<id>, SVTYPE=INS
+                   (= la \>)
+                   (= \< (.charAt alt (int 1))))
+            {:type :complete-insertion, :join :after, :base fa,
+             :id (.substring alt 2 (dec a-len))}
+            (if-let [bnd (parse-breakend alt)]
+              (assoc bnd :type :breakend)
+              (parse-alt' ref alt))))))))

--- a/src/cljam/io/vcf/util.clj
+++ b/src/cljam/io/vcf/util.clj
@@ -297,44 +297,50 @@
         eq (fn [^long r ^long a]
              (= (Character/toUpperCase (.charAt ref r))
                 (Character/toUpperCase (.charAt alt a))))
-        [^long r ^long a] (loop [r 0 a 0]
-                            (if (and (< r r-len) (< a a-len) (eq r a))
-                              (recur (inc r) (inc a))
-                              [r a]))]
-    (if (and (< a a-len) (= r r-len))
-      {:type :insertion, :n-bases (- a-len r),
-       :offset (dec a), :inserted (.substring alt a)}
-      (if (and (= a a-len) (< r r-len))
-        {:type :deletion, :n-bases (- a r-len),
-         :offset (dec r), :deleted (.substring ref r)}
-        (if (= r r-len a a-len)
+        left-match (long
+                    (loop [i 0]
+                      (if (and (< i r-len) (< i a-len) (eq i i))
+                        (recur (inc i))
+                        i)))]
+    (if (and (< left-match a-len) (= left-match r-len))
+      {:type :insertion, :n-bases (- a-len left-match),
+       :offset (dec left-match), :inserted (.substring alt left-match)}
+      (if (and (= left-match a-len) (< left-match r-len))
+        {:type :deletion, :n-bases (- left-match r-len),
+         :offset (dec left-match), :deleted (.substring ref left-match)}
+        (if (= left-match r-len a-len)
           {:type :ref}
           (let [[^long re ^long ae] (loop [re (dec r-len)
                                            ae (dec a-len)]
-                                      (if (and (< r re) (< a ae) (eq re ae))
+                                      (if (and (< left-match re)
+                                               (< left-match ae)
+                                               (eq re ae))
                                         (recur (dec re) (dec ae))
                                         [re ae]))]
-            (if (= ae a)
-              (if (= re r)
-                {:type :snp, :ref (.charAt ref a),
-                 :alt (.charAt alt a), :offset a}
-                (let [n (- r re)]
+            (if (= ae left-match)
+              (if (= re left-match)
+                {:type :snp, :ref (.charAt ref left-match),
+                 :alt (.charAt alt left-match), :offset left-match}
+                (let [n (- left-match re)]
                   (if (eq re ae)
                     {:type :deletion, :n-bases n,
-                     :offset (dec r), :deleted (.substring ref r re)}
+                     :offset (dec left-match),
+                     :deleted (.substring ref left-match re)}
                     {:type :other, :n-bases n})))
-              (if (= re r)
-                (let [n (- ae a)]
+              (if (= re left-match)
+                (let [n (- ae left-match)]
                   (if (eq re ae)
                     {:type :insertion, :n-bases n,
-                     :offset (dec a), :inserted (.substring alt a ae)}
+                     :offset (dec left-match),
+                     :inserted (.substring alt left-match ae)}
                     {:type :other, :n-bases n}))
-                (let [n (if (< (- ae a) (- re r))
-                          (- r re 1)
-                          (- ae a -1))]
-                  (if (= (- re r) (- ae a))
-                    {:type :mnp, :ref (.substring ref r (inc re)),
-                     :alt (.substring alt a (inc ae)), :offset a}
+                (let [n (if (< (- ae left-match) (- re left-match))
+                          (- left-match re 1)
+                          (- ae left-match -1))]
+                  (if (= (- re left-match) (- ae left-match))
+                    {:type :mnp, :ref (.substring ref left-match (inc re)),
+                     :alt (.substring alt left-match (inc ae)),
+                     :offset left-match}
                     {:type :other, :n-bases n}))))))))))
 
 (defn parse-alt

--- a/src/cljam/io/vcf/util/normalize.clj
+++ b/src/cljam/io/vcf/util/normalize.clj
@@ -1,0 +1,200 @@
+(ns cljam.io.vcf.util.normalize
+  "Functions related to variant normalization"
+  (:require [clojure.string :as cstr]
+            [cljam.io.vcf.util :as vcf-util]
+            [cljam.io.sequence :as io-seq]
+            [cljam.util.sequence :as util-seq]))
+
+(defn- biallelic-kv
+  [id->number i n-allele ploidy [k v]]
+  (let [i (long i)
+        n (id->number k)]
+    [k (cond
+         (= k :GT) (vcf-util/biallelic-genotype v (inc i))
+         (= n "A") [(nth v i)]
+         (= n "R") [(first v) (nth v (inc i))]
+         (= n "G") (vcf-util/biallelic-coll ploidy n-allele (inc i) v)
+         :else v)]))
+
+(defn- biallelic-map
+  [m id->number ^long i ^long n-allele]
+  (let [ploidy (or (some-> m :GT vcf-util/parse-genotype count) 2)]
+    (into {} (map (partial biallelic-kv id->number i n-allele ploidy) m))))
+
+(defn splitter
+  "Returns a function that splits a multiallelic variant into a sequence of
+  biallelic variants."
+  [meta-info header]
+  (let [f #(->> meta-info % (map (juxt (comp keyword :id) :number)) (into {}))
+        info-id->number (f :info)
+        format-id->number (f :format)
+        samples (map keyword (drop 9 header))]
+    (fn [{:keys [alt] :as v}]
+      (let [n (count alt)]
+        (if (<= n 1)
+          [v]
+          (->> n
+               range
+               (map
+                (fn [i]
+                  (-> v
+                      (update :alt nth i)
+                      (update :alt vector)
+                      (update :info biallelic-map info-id->number i n)
+                      (into
+                       (map
+                        (fn [k]
+                          [k (biallelic-map (k v) format-id->number i n)]))
+                       samples))))))))))
+
+(defn same-ref?
+  "Checks if a REF allele matches the reference sequence."
+  [seq-reader {:keys [chr ^long pos ^String ref]}]
+  (let [ref-len (.length ref)
+        ref-region {:chr chr :start pos :end (dec (+ pos ref-len))}
+        ref-seq (-> seq-reader
+                    (io-seq/read-sequence ref-region {:mask? false})
+                    util-seq/->atgcn)]
+    (and ref-seq (.equalsIgnoreCase ^String ref-seq ref))))
+
+(defn- trim-right-m
+  "trim-right implementation for general veriants."
+  [seq-reader {:keys [chr pos ^String ref alt] :as v} ^long window]
+  (let [n (inc (count alt))
+        a (->> alt
+               (cons ref)
+               (map #(StringBuilder. ^String %))
+               ^"[Ljava.lang.StringBuilder;" (into-array StringBuilder))
+        r ^StringBuilder (aget a 0)]
+    (loop [p (long pos)]
+      (let [rl (.length r)
+            rc (Character/toUpperCase (.charAt r (dec rl)))
+            min-len (long (loop [min-len rl
+                                 i 1]
+                            (if (< i n)
+                              (let [sb ^StringBuilder (aget a i)
+                                    l (long (.length sb))]
+                                (if (= (Character/toUpperCase
+                                        (.charAt sb (dec l)))
+                                       rc)
+                                  (recur (Math/min min-len l) (inc i))
+                                  -1))
+                              min-len)))]
+        (if (and (not (neg? min-len))
+                 (or (< 1 min-len) (< 1 p)))
+          (do
+            (dotimes [i n]
+              (let [sb ^StringBuilder (aget a i)]
+                (.setLength sb (dec (.length sb)))))
+            (if (= min-len 1)
+              (let [n-pad (min p window)
+                    region {:chr chr, :start (inc (- p n-pad)), :end (dec p)}
+                    s (io-seq/read-sequence seq-reader region {:mask? false})]
+                (dotimes [i n]
+                  (.insert ^StringBuilder (aget a i) 0 s))
+                (recur (inc (- p n-pad))))
+              (recur p)))
+          (assoc v :pos p :ref (.toString r) :alt (map str (rest a))))))))
+
+(defn- trim-right-2
+  "trim-right specialized for biallelic variants."
+  [rdr {:keys [chr pos ^String ref alt] :as v} ^long window]
+  (let [r (StringBuilder. ref)
+        a (StringBuilder. ^String (first alt))]
+    (loop [p (long pos)]
+      (let [rl (.length r)
+            rc (.charAt r (unchecked-dec-int rl))
+            al (.length a)
+            ac (.charAt a (unchecked-dec-int al))
+            min-len (unchecked-long (Math/min rl al))]
+        (if (and (or (< 1 min-len) (< 1 p))
+                 (= (Character/toUpperCase rc) (Character/toUpperCase ac)))
+          (do
+            (.setLength r (unchecked-dec-int rl))
+            (.setLength a (unchecked-dec-int al))
+            (if (= min-len 1)
+              (let [n-pad (Math/min p window)
+                    start (unchecked-inc (unchecked-subtract p n-pad))
+                    region {:chr chr, :start start, :end (dec p)}
+                    s (io-seq/read-sequence rdr region {:mask? false})]
+                (.insert r (unchecked-int 0) s)
+                (.insert a (unchecked-int 0) s)
+                (recur start))
+              (recur p)))
+          (assoc v :pos p :ref (.toString r) :alt [(.toString a)]))))))
+
+(defn trim-right
+  "Trims all duplicated allele sequences from right. If reached the start,
+  reference sequences of length `window` will be read from `seq-reader` and
+  prepended to the alleles."
+  [seq-reader {:keys [alt] :as v} ^long window]
+  (if (<= 2 (count alt))
+    (trim-right-m seq-reader v window)
+    (trim-right-2 seq-reader v window)))
+
+(defn- trim-left-m
+  "trim-left implementation for general variants."
+  [alt {:keys [^String ref] :as v}]
+  (let [alleles (cons ref alt)
+        n-trim-left (->> alleles
+                         (map cstr/upper-case)
+                         (apply map =)
+                         (take-while true?)
+                         count)
+        min-len (long (apply min (map count alleles)))
+        n-trim-left (min (dec min-len) n-trim-left)]
+    (if (pos? n-trim-left)
+      (-> v
+          (update :pos + n-trim-left)
+          (update :ref subs n-trim-left)
+          (assoc :alt (map #(subs % n-trim-left) alt)))
+      v)))
+
+(defn- trim-left-2
+  "trim-left specialized for biallelic variants."
+  [alt {:keys [^String ref] :as v}]
+  (let [rl (.length ref)
+        a ^String (first alt)
+        al (.length a)
+        min-len (unchecked-dec (Math/min rl al))]
+    (loop [i 0]
+      (if (and (= (Character/toUpperCase (.charAt ref i))
+                  (Character/toUpperCase (.charAt a i)))
+               (< i min-len))
+        (recur (unchecked-inc i))
+        (if (pos? i)
+          (-> v
+              (update :pos + i)
+              (assoc :ref (.substring ref i))
+              (assoc :alt [(.substring a i)]))
+          v)))))
+
+(defn trim-left
+  "Trims all duplicated allele sequences from left."
+  [{:keys [alt] :as v}]
+  (if (<= 2 (count alt))
+    (trim-left-m alt v)
+    (trim-left-2 alt v)))
+
+(defn realign
+  "Left-align and trim REF/ALT alleles."
+  ([seq-reader variant]
+   (realign seq-reader variant {}))
+  ([seq-reader
+    {:keys [^String ref alt] :as variant}
+    {:keys [window] :or {window 100}}]
+   (if (and
+        ref (seq alt) (util-seq/atgcn? ref)
+        (every?
+         (fn [^String a]
+           (let [c (.charAt a (unchecked-int 0))]
+             (and
+              (not= c \<)
+              (not= c \*)
+              (util-seq/atgcn? a)
+              (not (.equalsIgnoreCase ref a)))))
+         alt))
+     (trim-left (trim-right seq-reader variant window))
+     (if (and ref (nil? (seq alt)))
+       (update variant :ref subs 0 1)
+       variant))))

--- a/src/cljam/io/vcf/util/normalize.clj
+++ b/src/cljam/io/vcf/util/normalize.clj
@@ -58,7 +58,7 @@
     (and ref-seq (.equalsIgnoreCase ^String ref-seq ref))))
 
 (defn- trim-right-m
-  "trim-right implementation for general veriants."
+  "trim-right implementation for general variants."
   [seq-reader {:keys [chr pos ^String ref alt] :as v} ^long window]
   (let [n (inc (count alt))
         a (->> alt

--- a/src/cljam/util/sequence.clj
+++ b/src/cljam/util/sequence.clj
@@ -26,3 +26,32 @@
            (.put cb)))
     (.flip cb)
     (.toString cb)))
+
+(defn atgcn?
+  "Checks if a given string contains only [ATGCNatgcn]."
+  [^String s]
+  (let [l (.length s)]
+    (loop [i 0]
+      (if (< i l)
+        (let [c' (unchecked-long (unchecked-int (.charAt s (unchecked-int i))))
+              c (if (<= 97 c') (- c' 32) c')]
+          (if (or (= c 65) (= c 67) (= c 71) (= c 78) (= c 84))
+            (recur (unchecked-inc i))
+            false))
+        true))))
+
+(defn ^String ->atgcn
+  "Replaces all characters other than [ATGCatgc] with N."
+  [^String s]
+  (when s
+    (let [l (.length s)
+          cb (CharBuffer/allocate l)]
+      (dotimes [i l]
+        (let [c'' (.charAt s i)
+              c' (unchecked-long (unchecked-int c''))
+              c (if (<= 97 c') (- c' 32) c')]
+          (if (or (= c 65) (= c 67) (= c 71) (= c 78) (= c 84))
+            (.put cb c'')
+            (.put cb \N))))
+      (.rewind cb)
+      (.toString cb))))

--- a/test/cljam/io/vcf/util/normalize_test.clj
+++ b/test/cljam/io/vcf/util/normalize_test.clj
@@ -1,0 +1,186 @@
+(ns cljam.io.vcf.util.normalize-test
+  (:require [clojure.test :refer :all]
+            [cljam.io.vcf.util.normalize :as norm]
+            [cljam.io.protocols :as protocols]))
+
+(deftest splitter
+  (let [meta-info {:info [{:id "XF" :number 0}
+                          {:id "DP" :number 1}
+                          {:id "XT" :number 2}
+                          {:id "AC" :number "A"}
+                          {:id "XR" :number "R"}
+                          {:id "XG" :number "G"}]
+                   :format [{:id "XF" :number 0}
+                            {:id "DP" :number 1}
+                            {:id "XT" :number 2}
+                            {:id "GT" :number 1}
+                            {:id "AC" :number "A"}
+                            {:id "XR" :number "R"}
+                            {:id "XG" :number "G"}]}
+        header ["CHROM" "POS" "ID" "REF" "ALT" "QUAL" "FILTER" "INFO" "FORMAT" "SAMPLE01" "SAMPLE02"]]
+    (are [?variant ?expected]
+        (= ?expected ((norm/splitter meta-info header) ?variant))
+
+      {:chr "1", :pos 1, :ref "T", :alt ["A"], :id nil, :qual 100.0, :filter [:PASS],
+       :info {:XF :exists, :DP 10, :XT [1 2], :AC [2], :XR [100.0 200.0], :XG [0 1 2]}
+       :FORMAT [:XF :DP :XT :GT :AC :XR :XG],
+       :SAMPLE01 {:XF :exists, :DP 20, :XT [10 20], :GT "0/1", :AC [40], :XR [2 3], :XG [10 11 12]},
+       :SAMPLE02 {:XF :exists, :DP 300, :XT [30 40], :GT "0/0/1", :AC [80], :XR [1 7], :XG [0 1 2]}}
+
+      [{:chr "1", :pos 1, :ref "T", :alt ["A"], :id nil, :qual 100.0, :filter [:PASS],
+        :info {:XF :exists, :DP 10, :XT [1 2], :AC [2], :XR [100.0 200.0], :XG [0 1 2]}
+        :FORMAT [:XF :DP :XT :GT :AC :XR :XG],
+        :SAMPLE01 {:XF :exists, :DP 20, :XT [10 20], :GT "0/1", :AC [40], :XR [2 3], :XG [10 11 12]},
+        :SAMPLE02 {:XF :exists, :DP 300, :XT [30 40], :GT "0/0/1", :AC [80], :XR [1 7], :XG [0 1 2]}}]
+
+      ;; -----
+
+      {:chr "2", :pos 20, :ref "T", :alt ["A", "C"], :id nil, :qual 100.0, :filter [:PASS],
+       :info {:XF :exists, :DP 10, :XT [1 2], :AC [2 4], :XR [100.0 200.0 300.0], :XG [0 1 2 3 4 5]}
+       :FORMAT [:XF :DP :XT :GT :AC :XR :XG],
+       :SAMPLE01 {:XF :exists, :DP 20, :XT [10 20], :GT "0/2", :AC [40 50], :XR [2 3 4], :XG [10 11 12 13 14 15]},
+       :SAMPLE02 {:XF :exists, :DP 300, :XT [30 40], :GT "0/1/2", :AC [80 90], :XR [1 7 9], :XG [0 1 2 3 4 5 6 7 8 9]}}
+
+      [{:chr "2", :pos 20, :ref "T", :alt ["A"], :id nil, :qual 100.0, :filter [:PASS],
+        :info {:XF :exists, :DP 10, :XT [1 2], :AC [2], :XR [100.0 200.0], :XG [0 1 2]}
+        :FORMAT [:XF :DP :XT :GT :AC :XR :XG],
+        :SAMPLE01 {:XF :exists, :DP 20, :XT [10 20], :GT "0/0", :AC [40], :XR [2 3], :XG [10 11 12]},
+        :SAMPLE02 {:XF :exists, :DP 300, :XT [30 40], :GT "0/1/0", :AC [80], :XR [1 7], :XG [0 1 2 3]}}
+       {:chr "2", :pos 20, :ref "T", :alt ["C"], :id nil, :qual 100.0, :filter [:PASS],
+        :info {:XF :exists, :DP 10, :XT [1 2], :AC [4], :XR [100.0 300.0], :XG [0 3 5]}
+        :FORMAT [:XF :DP :XT :GT :AC :XR :XG],
+        :SAMPLE01 {:XF :exists, :DP 20, :XT [10 20], :GT "0/1", :AC [50], :XR [2 4], :XG [10 13 15]},
+        :SAMPLE02 {:XF :exists, :DP 300, :XT [30 40], :GT "0/0/1", :AC [90], :XR [1 9], :XG [0 4 7 9]}}]
+
+      ;; -----
+
+      {:chr "3", :pos 300, :ref "T", :alt ["A", "C"], :id nil, :qual 100.0, :filter [:PASS],
+       :info {}
+       :FORMAT [:XF :DP :XT:AC :XR :XG],
+       :SAMPLE01 {:XF :exists, :DP 20, :XT [10 20], :AC [40 50], :XR [2 3 4], :XG [10 11 12 13 14 15]},
+       :SAMPLE02 {:XF :exists, :DP 20, :XT [10 20], :AC [40 50], :XR [2 3 4], :XG [10 11 12 13 14 15]}}
+      [{:chr "3", :pos 300, :ref "T", :alt ["A"], :id nil, :qual 100.0, :filter [:PASS],
+        :info {}
+        :FORMAT [:XF :DP :XT:AC :XR :XG],
+        :SAMPLE01 {:XF :exists, :DP 20, :XT [10 20], :AC [40], :XR [2 3], :XG [10 11 12]},
+        :SAMPLE02 {:XF :exists, :DP 20, :XT [10 20], :AC [40], :XR [2 3], :XG [10 11 12]}}
+       {:chr "3", :pos 300, :ref "T", :alt ["C"], :id nil, :qual 100.0, :filter [:PASS],
+        :info {}
+        :FORMAT [:XF :DP :XT:AC :XR :XG],
+        :SAMPLE01 {:XF :exists, :DP 20, :XT [10 20], :AC [50], :XR [2 4], :XG [10 13 15]},
+        :SAMPLE02 {:XF :exists, :DP 20, :XT [10 20], :AC [50], :XR [2 4], :XG [10 13 15]}}])))
+
+(defn- seq-reader [s]
+  (reify protocols/ISequenceReader
+    (read-sequence [_ {:keys [^long start ^long end]} _]
+      (subs s (dec start) end))))
+
+(deftest same-ref?
+  (are [?seq ?variant ?expected]
+      (= ?expected (norm/same-ref? (seq-reader ?seq) ?variant))
+    "A" {:pos 1, :ref "A"} true
+    "ATT" {:pos 2, :ref "tt"} true
+    "TTT" {:pos 3, :ref "A"} false
+    "ATGC" {:pos 4, :ref "N"} false))
+
+(deftest realign
+  (testing "not affected"
+    (are [?seq ?variant ?expected]
+        (= ?expected (norm/realign (seq-reader ?seq) ?variant))
+      "G" ;; ref
+      {:pos 1, :ref "G", :alt ["G"]}
+      {:pos 1, :ref "G", :alt ["G"]}
+
+      "G"
+      {:pos 1, :ref "G", :alt ["T"]}
+      {:pos 1, :ref "G", :alt ["T"]}
+
+      "G" ;; deleted
+      {:pos 1, :ref "G", :alt ["*"]}
+      {:pos 1, :ref "G", :alt ["*"]}
+
+      "TGGG"
+      {:pos 1, :ref "TGGG", :alt ["TAC" "TG" "TGGGG", "AC"]}
+      {:pos 1, :ref "TGGG", :alt ["TAC" "TG" "TGGGG", "AC"]}
+
+      ""
+      {}
+      {}
+
+      ""
+      {:pos 1, :ref "A", :alt nil}
+      {:pos 1, :ref "A", :alt nil}
+
+      "NNNNNNAC"
+      {:pos 7, :ref "A", :alt ["a", "AT"]}
+      {:pos 7, :ref "A", :alt ["a", "AT"]}
+
+      "CAT"
+      {:pos 1, :ref "C", :alt ["CC"]}
+      {:pos 1, :ref "C", :alt ["CC"]}))
+
+  (testing "realigned"
+    (are [?seq ?variant ?expected]
+        (= ?expected (norm/realign (seq-reader ?seq) ?variant))
+      "AT"
+      {:pos 1, :ref "AT", :alt nil}
+      {:pos 1, :ref "A", :alt nil}
+
+      "AT"
+      {:pos 1, :ref "AT", :alt ["TT"]}
+      {:pos 1, :ref "A", :alt ["T"]}
+
+      "AT"
+      {:pos 1, :ref "AT", :alt ["AA"]}
+      {:pos 2, :ref "T", :alt ["A"]}
+
+      "ATTTTTTTTTTTTT"
+      {:pos 1, :ref "ATTTTTTTTTTTTT", :alt ["ATTTTTTTTTTTTTTT"]}
+      {:pos 1, :ref "A", :alt ["ATT"]}
+
+      "GATG"
+      {:pos 1, :ref "GATG", :alt ["GACT"]}
+      {:pos 3, :ref "TG", :alt ["CT"]}
+
+      "TAAACCCTAAA"
+      {:pos 1, :ref "TAAACCCTAAA", :alt ["TAA" "TAACCCTAAA"]}
+      {:pos 1, :ref "TAAACCCTA", :alt ["T" "TAACCCTA"]}
+
+      "CACA"
+      {:pos 1, :ref "CACA", :alt ["CAC"]}
+      {:pos 3, :ref "CA", :alt ["C"]}
+
+      "CAT"
+      {:pos 1, :ref "CAT", :alt ["AT"]}
+      {:pos 1, :ref "CA", :alt ["A"]}
+
+      "CAC"
+      {:pos 1, :ref "CAC", :alt ["CC", "CTC"]}
+      {:pos 1, :ref "CA", :alt ["C", "CT"]}
+
+      "GTTTTTTTTTTTTT"
+      {:pos 1, :ref "GTTTTTTTTTTTTT", :alt ["GTTTTTTTTTTTTTTC", "GTTTTTTTTTTTTTT"]}
+      {:pos 14, :ref "T", :alt ["TTC", "TT"]}
+
+      "ACTCTGGGGGGGGGGGGGGGGGGGGAGGGGA"
+      {:pos 22, :ref "G", :alt ["GAG"]}
+      {:pos 21, :ref "G", :alt ["GGA"]}
+
+      "ACTCTGGGGGGGGGGGGGGGGGGGGAGGGGA"
+      {:pos 22, :ref "G", :alt ["GAG", "GCG"]}
+      {:pos 21, :ref "G", :alt ["GGA", "GGC"]}))
+
+  (testing "skipped"
+    (are [?seq ?variant ?expected]
+        (= ?expected (norm/realign (seq-reader ?seq) ?variant))
+      "C" ;; INS
+      {:pos 1, :ref "C", :alt ["C<ctg1>"]}
+      {:pos 1, :ref "C", :alt ["C<ctg1>"]}
+
+      "NC" ;; BND
+      {:pos 2, :ref "C", :alt ["CTT[1:123["]}
+      {:pos 2, :ref "C", :alt ["CTT[1:123["]}
+
+      "NNC" ;; Symbolic
+      {:pos 3, :ref "C", :alt ["<DUP>"]}
+      {:pos 3, :ref "C", :alt ["<DUP>"]})))

--- a/test/cljam/util/sequence_test.clj
+++ b/test/cljam/util/sequence_test.clj
@@ -18,3 +18,34 @@
     "ACGTGT" "ACACGT"
     "GAANTGGN" "NCCANTTC"
     "aacacacnnnnacacTTTAGAGCNNacacnttg" "caangtgtNNGCTCTAAAgtgtnnnngtgtgtt"))
+
+(deftest atgcn?
+  (are [?seq ?expected]
+      (= ?expected (util-seq/atgcn? ?seq))
+    "" true
+    "A" true
+    "t" true
+    "n" true
+    "N" true
+    "U" false
+    "*" false
+    "AT" true
+    "At" true
+    "AtN" true
+    "ACM" false
+    "AoT" false
+    "aacacacnnnnacacTTTAGAGCNNacacnttg" true))
+
+(deftest ->atgcn
+  (are [?seq ?expected]
+      (= ?expected (util-seq/->atgcn ?seq))
+    nil nil
+    "" ""
+    "A" "A"
+    "a" "a"
+    "N" "N"
+    "n" "n"
+    "U" "N"
+    "u" "N"
+    "ATGCNatgcn" "ATGCNatgcn"
+    "*AT>gc" "NATNgc"))


### PR DESCRIPTION
#### Summary
This PR adds some utility functions to normalize variants.

- genotype ordering
    - `genotype-seq`: list all genotypes
    - `genotype-index`: get an index for a genotype
    - `biallelic-genotype`: multiallelic genotype to biallelic
    - `biallelic-coll`: multiallelic genotype-wise values to biallelic
- sequence
    - `atgcn?`: check nucleotides
    - `->atgcn`: replace with N
- variant
    - `parse-alt`: classify and parse complex variants
    - `splitter`: split multiallelic variants into multiple biallelic ones
    - `realign`: left-align variants

#### Tests

- `lein check` 🆗
- `lein test :all` 🆗
- `lein eastwood` 🆗