### PR TITLE
Fix ByteBuffer/CharBuffer methods incompatibility

### DIFF
--- a/src/cljam/io/bam/decoder.clj
+++ b/src/cljam/io/bam/decoder.clj
@@ -10,7 +10,7 @@
             [cljam.io.bam.common :as common]
             [cljam.io.util.lsb :as lsb])
   (:import [java.util Arrays]
-           [java.nio ByteBuffer ByteOrder CharBuffer]
+           [java.nio Buffer ByteBuffer ByteOrder CharBuffer]
            [cljam.io.protocols SAMAlignment SAMRegionBlock SAMCoordinateBlock SAMQuerynameBlock]))
 
 (definline validate-tag-type
@@ -57,10 +57,10 @@
   (lazy-seq
    (when (.hasRemaining bb)
      (cons
-      (let [cb (doto (CharBuffer/allocate 2)
-                 (.put (unchecked-char (.get bb)))
-                 (.put (unchecked-char (.get bb)))
-                 (.flip))
+      (let [cb (as-> (CharBuffer/allocate 2) cb
+                 (.put cb (unchecked-char (.get bb)))
+                 (.put cb (unchecked-char (.get bb)))
+                 (.flip ^Buffer cb))
             typ (.get bb)]
         {(keyword (.toString cb))
          {:type  (str (validate-tag-type typ))

--- a/src/cljam/io/bcf/reader.clj
+++ b/src/cljam/io/bcf/reader.clj
@@ -10,7 +10,7 @@
             [cljam.util :as util])
   (:import [java.io Closeable IOException]
            [java.net URL]
-           [java.nio ByteBuffer]
+           [java.nio Buffer ByteBuffer]
            [bgzf4j BGZFInputStream]))
 
 (declare read-variants meta-info)
@@ -146,7 +146,7 @@
   (let [chrom-id (lsb/read-int shared)
         pos (inc (lsb/read-int shared))
         rlen (lsb/read-int shared)]
-    (.position shared 0)
+    (.position ^Buffer shared 0)
     (assoc m :chr (:id (contigs chrom-id)) :pos pos :rlen rlen)))
 
 (defn- parse-data-line-deep

--- a/src/cljam/io/fasta/reader.clj
+++ b/src/cljam/io/fasta/reader.clj
@@ -4,7 +4,7 @@
             [cljam.io.fasta.util :refer [header-line? parse-header-line]]
             [cljam.io.fasta-index.core :as fasta-index])
   (:import [java.io RandomAccessFile InputStream]
-           [java.nio ByteBuffer CharBuffer]
+           [java.nio Buffer ByteBuffer CharBuffer]
            [java.nio.channels FileChannel$MapMode]))
 
 ;; FASTAReader
@@ -94,7 +94,7 @@
                       (when-not (or (= 10 c) (= 13 c))
                         ;; toUpperCase works only for ASCII chars.
                         (.put buf (unchecked-char (bit-and c 0x5f))))))))
-              (.flip buf)
+              (.flip ^Buffer buf)
               (.toString buf))))))))
 
 (defn read
@@ -111,9 +111,9 @@
 (definline create-ba [^ByteBuffer buffer]
   `(when (pos? (.position ~buffer))
        (let [ba# (byte-array (.position ~buffer))]
-         (.clear ~buffer)
+         (.clear ~(with-meta buffer {:tag `Buffer}))
          (.get ~buffer ba#)
-         (.clear ~buffer)
+         (.clear ~(with-meta buffer {:tag `Buffer}))
          ba#)))
 
 (def ^:private ^:const gt-byte (byte \>))

--- a/src/cljam/io/fastq.clj
+++ b/src/cljam/io/fastq.clj
@@ -5,7 +5,7 @@
             [cljam.io.protocols :as protocols]
             [cljam.util :as util])
   (:import [java.io Closeable]
-           [java.nio CharBuffer]))
+           [java.nio Buffer CharBuffer]))
 
 (declare read-sequences write-sequences)
 
@@ -110,7 +110,7 @@
                          :phred64 (+ q 64)
                          q)))))
     (.put cb \newline)
-    (.flip cb)
+    (.flip ^Buffer cb)
     (.toString cb)))
 
 (defn write-sequences

--- a/src/cljam/io/sam/util/quality.clj
+++ b/src/cljam/io/sam/util/quality.clj
@@ -1,6 +1,6 @@
 (ns cljam.io.sam.util.quality
   "Utility functions for phred quality strings."
-  (:import [java.nio ByteBuffer CharBuffer]))
+  (:import [java.nio Buffer ByteBuffer CharBuffer]))
 
 (definline fastq-char->phred-byte [ch]
   `(byte (- (int ~ch) 33)))
@@ -27,7 +27,7 @@
         (when (.hasRemaining bb)
           (.put cb (phred-byte->fastq-char (.get bb)))
           (recur)))
-      (.flip cb)
+      (.flip ^Buffer cb)
       (.toString cb))))
 
 (defmethod phred->fastq (class (byte-array nil))

--- a/src/cljam/io/sam/util/sequence.clj
+++ b/src/cljam/io/sam/util/sequence.clj
@@ -1,7 +1,7 @@
 (ns cljam.io.sam.util.sequence
   "Utility functions for base sequences."
   (:require [clojure.string :as cstr])
-  (:import [java.nio ByteBuffer CharBuffer]))
+  (:import [java.nio Buffer ByteBuffer CharBuffer]))
 
 (def ^:private ^:const nibble-to-base-table
   ;; Index: nibble of a compressed base.
@@ -55,13 +55,13 @@
   [^long length ^bytes compressed-bases ^long compressed-offset]
   (let [cb (CharBuffer/allocate (inc length))
         bb (ByteBuffer/wrap compressed-bases)]
-    (.position bb compressed-offset)
+    (.position ^Buffer bb compressed-offset)
     (dotimes [_ (quot (inc length) 2)]
       (let [i (-> (.get bb) (bit-and 0xff) (* 2))]
         (.put cb (.charAt compressed-bases-to-bases-table i))
         (.put cb (.charAt compressed-bases-to-bases-table (inc i)))))
-    (.limit cb length)
-    (.flip cb)
+    (.limit ^Buffer cb length)
+    (.flip ^Buffer cb)
     (.toString cb)))
 
 (defn normalize-bases

--- a/src/cljam/io/util/lsb.clj
+++ b/src/cljam/io/util/lsb.clj
@@ -3,7 +3,7 @@
   (:refer-clojure :exclude [read-string])
   (:require [cljam.util :refer [string->bytes bytes->string]])
   (:import [java.io DataInput InputStream DataOutputStream EOFException ByteArrayOutputStream]
-           [java.nio ByteBuffer ByteOrder]))
+           [java.nio Buffer ByteBuffer ByteOrder]))
 
 (defn ^ByteBuffer gen-byte-buffer
   "Generates a new `java.nio.ByteBuffer` instance with little-endian byte order.
@@ -36,7 +36,7 @@
 (extend-type ByteBuffer
   LSBReadable
   (skip [this ^long length]
-    (.position this (+ (.position this) length)))
+    (.position ^Buffer this (+ (.position this) length)))
   (read-byte [this]
     (.get this))
   (read-ubyte [this]
@@ -269,36 +269,36 @@
 (extend-type java.nio.channels.FileChannel
   LSBWritable
   (write-ubyte [w b]
-    (let [bb (gen-byte-buffer 1)]
-      (.. bb (put (unchecked-byte b)) clear)
+    (let [bb (-> (gen-byte-buffer 1) (.put (unchecked-byte b)))]
+      (.clear ^Buffer bb)
       (.write w bb)))
   (write-char [w b]
-    (let [bb (gen-byte-buffer 1)]
-      (.. bb (putChar b) clear)
+    (let [bb (-> (gen-byte-buffer 1) (.putChar b))]
+      (.clear ^Buffer bb)
       (.write w bb)))
   (write-short [w n]
-    (let [bb (gen-byte-buffer 2)]
-      (.. bb (putShort n) clear)
+    (let [bb (-> (gen-byte-buffer 2) (.putShort n))]
+      (.clear ^Buffer bb)
       (.write w bb)))
   (write-ushort [w n]
-    (let [bb (gen-byte-buffer 2)]
-      (.. bb (putShort (unchecked-short n)) clear)
+    (let [bb (-> (gen-byte-buffer 2) (.putShort (unchecked-short n)))]
+      (.clear ^Buffer bb)
       (.write w bb)))
   (write-int [w n]
-    (let [bb (gen-byte-buffer 4)]
-      (.. bb (putInt n) clear)
+    (let [bb (-> (gen-byte-buffer 4) (.putInt n))]
+      (.clear ^Buffer bb)
       (.write w bb)))
   (write-uint [w n]
-    (let [bb (gen-byte-buffer 4)]
-      (.. bb (putInt (unchecked-int n)) clear)
+    (let [bb (-> (gen-byte-buffer 4) (.putInt (unchecked-int n)))]
+      (.clear ^Buffer bb)
       (.write w bb)))
   (write-long [w n]
-    (let [bb (gen-byte-buffer 8)]
-      (.. bb (putLong n) clear)
+    (let [bb (-> (gen-byte-buffer 8) (.putLong n))]
+      (.clear ^Buffer bb)
       (.write w bb)))
   (write-float [w n]
-    (let [bb (gen-byte-buffer 4)]
-      (.. bb (putFloat n) clear)
+    (let [bb (-> (gen-byte-buffer 4) (.putFloat n))]
+      (.clear ^Buffer bb)
       (.write w bb)))
   (write-bytes [w ^bytes b]
     (.write w (ByteBuffer/wrap b)))

--- a/src/cljam/util/sequence.clj
+++ b/src/cljam/util/sequence.clj
@@ -1,6 +1,6 @@
 (ns cljam.util.sequence
   (:require [clojure.string :as cstr])
-  (:import [java.nio CharBuffer]))
+  (:import [java.nio Buffer CharBuffer]))
 
 (def ^:private revcomp-table
   (let [ba (byte-array 128)]
@@ -24,5 +24,5 @@
            (aget ^bytes revcomp-table)
            unchecked-char
            (.put cb)))
-    (.flip cb)
+    (.flip ^Buffer cb)
     (.toString cb)))


### PR DESCRIPTION
This PR fixes #158.

Basically, it's just type-hinting with `Buffer` the receiver of each call to the following `ByteBuffer`/`CharBuffer` methods (some of the changes might look somewhat tricky, though):
- `clear()`
- `flip()`
- `limit(int)`
- `mark()`
- `position(int)`
- `reset()`
- `rewind()`

All the problematic call sites are listed [here](https://gist.github.com/athos/bc8d6e2ff28318f1ec61a4baf73588dd).

I've tested an uberjar built on Java 11, running `lein check` and `lein test :all` on Java 8 and Java 11.