### PR TITLE
Improve pileup by chunking alignments

### DIFF
--- a/src/cljam/algo/pileup.clj
+++ b/src/cljam/algo/pileup.clj
@@ -9,6 +9,8 @@
   (:import [cljam.io.protocols SAMAlignment]
            [cljam.io.pileup PileupBase LocusPile]))
 
+(def ^:const base-chunk-size 5000)
+
 (defn- cover-locus? [^long pos ^SAMAlignment aln]
   (<= (.pos aln) pos))
 
@@ -104,35 +106,6 @@
   (when (seq pile)
     (LocusPile. chr pos pile)))
 
-(defn- correct-qual
-  "Correct quality of two overlapped mate reads by setting zero quality for one
-  of the base."
-  [^PileupBase r1 ^PileupBase r2]
-  (let [b1 (.base r1)
-        q1 (.qual r1)
-        b2 (.base r2)
-        q2 (.qual r2)]
-    (if (= b1 b2)
-      [(assoc r1 :qual (min 200 (+ q1 q2))) (assoc r2 :qual 0)]
-      (if (<= q2 q1)
-        [(assoc r1 :qual (int (* 0.8 q1))) (assoc r2 :qual 0)]
-        [(assoc r1 :qual 0) (assoc r2 :qual (int (* 0.8 q2)))]))))
-
-(defn correct-overlapped-bases
-  "Find out overlapped bases and tweak their base quality scores."
-  [xs]
-  (if (<= (count xs) 1)
-    xs
-    (->> xs
-         (group-by (fn [x] (.qname ^PileupBase x)))
-         (into [] (mapcat
-                   (fn [[_ xs]]
-                     (if (<= (count xs) 1) xs (apply correct-qual xs))))))))
-
-(defn- correct-overlaps
-  [pile]
-  (update pile 1 correct-overlapped-bases))
-
 (defn filter-by-base-quality
   "Returns a predicate for filtering piled-up reads by base quality at its
   position."
@@ -141,6 +114,159 @@
     (->> #(<= min-base-quality (.qual ^PileupBase %))
          (partial filterv)
          (update p 1))))
+
+(defn- merge-corrected-quals
+  "Merge corrected quals with the uncorrected part."
+  [^SAMAlignment aln ^long correct-start corrected-quals]
+  (let [quals (:quals-at-ref aln)
+        start (.pos aln)
+        len   (count corrected-quals)]
+    (if (<= start correct-start)
+      (-> quals
+          (subvec 0 (- correct-start start))
+          (into corrected-quals)
+          (into (subvec quals (+ (- correct-start start) len))))
+      (into corrected-quals (subvec quals len)))))
+
+(defn- correct-pair-quals
+  "Correct quals of a pair. Returns a map with corrected quals."
+  [^SAMAlignment a1 ^SAMAlignment a2]
+  (if-not (and (pos? (.pnext a1))
+               (<= (max (.pos a1) (.pos a2)) (.end a1)))
+    nil
+    (let [tlen1 (.tlen a1)
+          tlen2 (.tlen a2)
+          quals1 (:quals-at-ref a1)
+          quals2 (:quals-at-ref a2)
+          seqs1  (:seqs-at-ref a1)
+          seqs2  (:seqs-at-ref a2)
+          correct-start (max (.pos a1) (.pos a2))
+          new-quals (for [pos (range correct-start
+                                     (inc (min (.end a1) (.end a2))))]
+                      (let [relative-pos1 (- pos (.pos a1))
+                            relative-pos2 (- pos (.pos a2))
+                            q1 (quals1 relative-pos1)
+                            q2 (quals2 relative-pos2)
+                            [b1 _] (seqs1 relative-pos1)
+                            [b2 _] (seqs2 relative-pos2)]
+                         (if (= b1 b2)
+                           [(min 200 (+ q1 q2)) 0]
+                           (if (<= q2 q1)
+                             [(int (* 0.8 q1)) 0]
+                             [0 (int (* 0.8 q2))]))))
+          [new1 new2] (apply map vector new-quals)]
+      [(merge-corrected-quals a1 correct-start new1)
+       (merge-corrected-quals a2 correct-start new2)])))
+
+(defn- make-corrected-quals-map
+  "Make a map which has corrected quals of all overlapping pairs."
+  [alns]
+  (->> alns
+       (group-by (fn [x] (.qname ^SAMAlignment x)))
+       (into {} (map
+                 (fn [[qname xs]]
+                   (if (<= (count xs) 1)
+                     {}
+                     {(keyword qname) (apply correct-pair-quals xs)}))))))
+
+(defn- correct-quals-at-ref
+  "Returns an alignment with corrected quals by looking up quals
+  in the corrected quals map."
+  [corrected-map ^SAMAlignment aln]
+  (if-not (= (.rnext aln) "=")
+    aln
+    (if-let [quals-pair ((keyword (.qname aln)) corrected-map)]
+      (let [new-quals (if (flag/r1? (.flag aln))
+                        (first quals-pair)
+                        (second quals-pair))]
+        (assoc aln :quals-at-ref new-quals))
+      aln)))
+
+(defn- get-max-pnext
+  "Get the maximum pnext of alignments."
+  [alns]
+  (->> alns
+       (map (fn [^SAMAlignment aln]
+              (if (= (.rnext aln) "=")
+                (.pnext aln)
+                0)))
+       (apply max)))
+
+(defn- read-chunk
+  "Read a chunk which is specified by the region."
+  [sam-reader min-map-quality region]
+  (->> region
+       (sam/read-alignments sam-reader)
+       (sequence
+         (comp
+           (filter (basic-mpileup-pred min-map-quality))
+           (map index-cigar)))))
+
+(defn- get-chunk
+  "Get a chunk in which all pairs exist.
+  Returns the end position of the chunk and alignments in the chunk.
+  It concatenates chunks when a pair overlap across multiple chunks."
+  [sam-reader min-map-quality last-end {:keys [chr start end] :as region}]
+  (loop [s    start
+         e    end
+         alns (read-chunk sam-reader min-map-quality region)]
+    (if (or (empty? alns)                ;; empty chunk
+            (= e last-end)               ;; this is the last chunk
+            (<= (get-max-pnext alns) e)) ;; all pairs are in this chunk
+      [e alns]
+      (let [next-start (inc e)
+            next-end   (min last-end (+ e (- e s) 1))]
+        (recur
+          next-start
+          next-end
+          (->> (read-chunk sam-reader
+                           min-map-quality
+                           {:chr   chr
+                            :start next-start
+                            :end   next-end})
+               (concat alns)
+               distinct))))))
+
+(defn- pileup-chunk
+  "Piles up alignments in a chunk position-by-position.
+  Returns a lazy sequence of `cljam.io.pileup.LocusPile`s."
+  [^long start ^long end ignore-overlaps? alns]
+  (->> alns
+       (sequence
+         (comp
+           (drop-while #(< (.end ^SAMAlignment %) start))
+           (if ignore-overlaps?
+             identity
+             (keep (partial correct-quals-at-ref
+                            (make-corrected-quals-map alns))))))
+       (pileup-seq start end)))
+
+(defn- pileup-chunks
+  "Piles up alignments in each chunk."
+  [sam-reader {:keys [chr start end]} chunk-size
+   min-base-quality min-map-quality ignore-overlaps?]
+  (loop [chunk-start start
+         total-piles []]
+    (if-not (<= chunk-start end)
+      total-piles
+      (let [tmp-chunk-end (min (+ chunk-start chunk-size) end)
+            [chunk-end alns] (get-chunk sam-reader
+                                        min-map-quality
+                                        end
+                                        {:chr chr
+                                         :start chunk-start
+                                         :end tmp-chunk-end})
+            piles (->> alns
+                       (pileup-chunk chunk-start chunk-end ignore-overlaps?)
+                       (sequence
+                         (comp
+                           (map resolve-bases)
+                           (if (pos? min-base-quality)
+                             (map (filter-by-base-quality min-base-quality))
+                             identity)
+                           (keep (partial ->locus-pile chr)))))]
+        (recur (inc chunk-end)
+               (concat total-piles piles))))))
 
 (defn pileup
   "Piles up alignments in given region and returns a lazy sequence of
@@ -158,23 +284,14 @@
      :or {min-base-quality 13 min-map-quality 0 ignore-overlaps? false}}]
    (when-let [len (:len (refs/ref-by-name (sam/read-refs sam-reader) chr))]
      (let [s (max 1 start)
-           e (min len end)]
-       (->> {:chr chr :start s :end e}
-            (sam/read-alignments sam-reader)
-            (sequence
-             (comp
-              (filter (basic-mpileup-pred min-map-quality))
-              (map index-cigar)))
-            (pileup-seq s e)
-            (sequence
-             (comp (map resolve-bases)
-                   (if ignore-overlaps?
-                     identity
-                     (map correct-overlaps))
-                   (if (pos? min-base-quality)
-                     (map (filter-by-base-quality min-base-quality))
-                     identity)
-                   (keep (partial ->locus-pile chr)))))))))
+           e (min len end)
+           region {:chr chr :start s :end e}]
+       (pileup-chunks sam-reader
+                      region
+                      base-chunk-size
+                      min-base-quality
+                      min-map-quality
+                      ignore-overlaps?)))))
 
 (defn align-pileup-seqs
   "Align multiple piled-up seqs."

--- a/test/cljam/algo/pileup_test.clj
+++ b/test/cljam/algo/pileup_test.clj
@@ -347,11 +347,11 @@
         plps-cont (->> reads-continal-for-pileup
                        (pileup* {:chr "seq1" :start 1 :end 10} {}))
         plps-overlap (->> reads-overlapping-for-pileup
-                       (pileup* {:chr "seq1" :start 1 :end 10} {}))
+                          (pileup* {:chr "seq1" :start 1 :end 10} {}))
         plps-include (->> reads-including-for-pileup
-                       (pileup* {:chr "seq1" :start 1 :end 10} {}))
+                          (pileup* {:chr "seq1" :start 1 :end 10} {}))
         plps-chunk (->> reads-overlapping-for-pileup
-                     (pileup* {:chr "seq1" :start 1 :end 15} {:chunk-size 2}))]
+                        (pileup* {:chr "seq1" :start 1 :end 15} {:chunk-size 2}))]
     (is (= (filter pos? [0 0 1 1 1 1 1 1 1 1])
            (map (comp count :pile) plps)))
     (is (= (filter seq [[] [] [\T] [\T] [\G] [\G] [\C] [\C] [\A] [\A]])


### PR DESCRIPTION
#### Summary
Pileup alignments per chunk to improve the performance

#### Benchmark
##### Pileup many alignments in a short region
```clojure
(time (with-open [r (sam/reader "/path/to/bam/SRP006438.chr1.bam")]
  (dorun (pileup/pileup r {:chr "chr1", :start 152210000, :end 152214999}))))
```

- master: 8523 ms
- PR: 6013 ms (-29.4%)

##### Pileup-bench
- master: `time: 56.355322 sec, sd: 4.858070 ms`
- PR: `time: 55.349883 sec, sd: 7.576505 ms` (-1.8%)

#### Changes
- Read and make chunks which have all pairs
- Correct `quals-at-ref` of an overlapping pair by looking up `quals` in the corrected quals map
- Pileup alignments in each chunk
- Add pileup tests

#### Tests
- `lein check` 🆗
- `lein test :all` 🆗
- `lein eastwood` 🆗