### PR TITLE
Skip INFO value parsing if it's empty

### DIFF
--- a/src/cljam/io/vcf/util.clj
+++ b/src/cljam/io/vcf/util.clj
@@ -6,6 +6,7 @@
   "Checks if given string is equal to \".\" or nil."
   [^String s]
   `(or (nil? ~s)
+       (empty? ~s)
        (and (= 1 (.length ~s))
             (= \. (.charAt ~s 0)))))
 

--- a/test/cljam/io/vcf/util_test.clj
+++ b/test/cljam/io/vcf/util_test.clj
@@ -30,7 +30,8 @@
       "NS=3;DP=9;AA=G" {:NS 3, :DP 9, :AA "G"}
       "NS=3;DP=14;AF=0.5;DB;H2" {:NS 3, :DP 14, :AF [0.5], :DB :exists :H2 :exists}
       "NS=3;DP=11;AF=0.017" {:NS 3, :DP 11, :AF [(float 0.017)]}
-      "NS=2;DP=10;AF=0.333,0.667;AA=T;DB" {:NS 2, :DP 10, :AF [(float 0.333) (float 0.667)] :AA "T", :DB :exists})))
+      "NS=2;DP=10;AF=0.333,0.667;AA=T;DB" {:NS 2, :DP 10, :AF [(float 0.333) (float 0.667)] :AA "T", :DB :exists}
+      "NS;DP=12" {:NS nil, :DP 12})))
 
 (deftest about-parse-filter
   (are [?filter-str ?expected]

--- a/test/cljam/io/vcf/util_test.clj
+++ b/test/cljam/io/vcf/util_test.clj
@@ -31,7 +31,8 @@
       "NS=3;DP=14;AF=0.5;DB;H2" {:NS 3, :DP 14, :AF [0.5], :DB :exists :H2 :exists}
       "NS=3;DP=11;AF=0.017" {:NS 3, :DP 11, :AF [(float 0.017)]}
       "NS=2;DP=10;AF=0.333,0.667;AA=T;DB" {:NS 2, :DP 10, :AF [(float 0.333) (float 0.667)] :AA "T", :DB :exists}
-      "NS;DP=12" {:NS nil, :DP 12})))
+      "NS;DP=12" {:NS nil, :DP 12} ;; Not VCF standard. "NS=.;DP=12" is correct. However, some variant caller outputs such form.
+      )))
 
 (deftest about-parse-filter
   (are [?filter-str ?expected]


### PR DESCRIPTION
#### Summary

This PR fixes VCF INFO parsing errors when empty values pass.

#### Cause

If `nil` comes to the line below,

https://github.com/chrovis/cljam/blob/773eb527a09b2d206ee567c8a93eeee27162f065/src/cljam/io/vcf/util.clj#L27

it transforms to an empty string.
So `NumberFormatException` in `Integer/parseInt` and `Float/parseFloat` occurs, because `dot-or-nil?` doesn't catch empty strings.

#### Changes

- Add empty check into `dot-or-nil?`

#### Affects

- VCF reader
- BCF reader

#### Tests

- `lein check` 🆗 
- `lein test :all` 🆗 
- `lein eastwood` 🆗 
