### PR TITLE
Add utility functions for manipulating genotypes

### DIFF
--- a/src/cljam/io/vcf/reader.clj
+++ b/src/cljam/io/vcf/reader.clj
@@ -27,7 +27,7 @@
   protocols/IRegionReader
   (read-in-region [this region]
     (protocols/read-in-region this region {}))
-  (read-in-region [this {:keys [chr start end]} {:keys [depth] :as option}]
+  (read-in-region [this {:keys [chr start end]} option]
     (logging/warn "May cause degradation of performance.")
     (filter
      (fn [v] (and (if chr (= (:chr v) chr) true)
@@ -141,7 +141,7 @@
 ;; ------------------
 
 (defn- parse-data-line
-  [line header kws]
+  [line kws]
   ;; When splitting a string with single-character delimiter,
   ;; `java.lang.String#split` is slightly faster than `clojure.string/split`.
   ;; For more details, please refer to https://github.com/chrovis/cljam/pull/29.
@@ -165,7 +165,7 @@
   [^java.io.BufferedReader rdr header kws]
   (when-let [line (.readLine rdr)]
     (if-not (or (meta-line? line) (header-line? line))
-      (cons (parse-data-line line header kws)
+      (cons (parse-data-line line kws)
             (lazy-seq (read-data-lines rdr header kws)))
       (read-data-lines rdr header kws))))
 


### PR DESCRIPTION
#### Summary
This PR adds 4 utility functions related to genotype ordering in VCF.
I've refined the implementation a bit.
Basically, these are useful for working with genotype information values defined as `Number=G` like genotype likelihoods `GL`.
Such values should be provided for all possible genotypes with given ploidy and number of alleles (`REF` + `ALT`).
For more details, please refer to the [spec "VCFv4.3 1.6.2 Genotype fields"](https://github.com/samtools/hts-specs/blob/d962e2fc9e2456c737a91e88cbc40ccf4a732650/VCFv4.3.tex#L442).

- `genotype-seq`: list all genotypes
- `genotype-index`: get an index for a genotype
- `biallelic-genotype`: multiallelic genotype string to biallelic one
- `biallelic-coll`: multiallelic genotype-wise values to biallelic one

#### Tests

- `lein check` 🆗
- `lein test :all` 🆗
- `lein cloverage` 🆗
