### PR TITLE
Add support for breakends in VCF

### DIFF
--- a/src/cljam/io/vcf/util.clj
+++ b/src/cljam/io/vcf/util.clj
@@ -275,7 +275,8 @@
         {:bases bases, :join (if pre-dot :before :after)}))))
 
 (defn stringify-breakend
-  "Returns a string representation of a breakend."
+  "Returns a string representation of a breakend. If the input is malformed,
+  returns `nil`. See the docstring of `parse-breakend` for the format."
   [{:keys [chr pos strand join] s :bases}]
   (when (and (not-empty s) (#{:before :after} join))
     (if (and chr pos (#{:forward :reverse} strand))

--- a/src/cljam/io/vcf/util.clj
+++ b/src/cljam/io/vcf/util.clj
@@ -235,11 +235,11 @@
           (update fmt-kw stringify-format)
           (merge (into {} (for [k sample-kws] [k (stringify-sample (v fmt-kw) (v k))])))))))
 
-(def ^:private long-breakend-regexp
+(def ^:private ^:const long-breakend-regexp
   ;;   pre-seq    [ or ]  chr    pos     [ or ]    post-seq
   #"([ACGTN]*|\.)([\[\]])(.+?)(?::(\d+))([\[\]])([ACGTN]*|\.)")
 
-(def ^:private short-breakend-regexp
+(def ^:private ^:const short-breakend-regexp
   #"(\.?)([ATGCN]+)(\.?)")
 
 (defn parse-breakend

--- a/src/cljam/io/vcf/util.clj
+++ b/src/cljam/io/vcf/util.clj
@@ -236,8 +236,8 @@
           (merge (into {} (for [k sample-kws] [k (stringify-sample (v fmt-kw) (v k))])))))))
 
 (def ^:private long-breakend-regexp
-  ;;     pre-seq      [ or ]  chr      pos   [ or ]    post-seq
-  #"((?:[ACGTN]*|\.))([\[\]])(.+?)(?::(\d+))([\[\]])((?:[ACGTN]*|\.))")
+  ;;   pre-seq    [ or ]  chr    pos     [ or ]    post-seq
+  #"([ACGTN]*|\.)([\[\]])(.+?)(?::(\d+))([\[\]])([ACGTN]*|\.)")
 
 (def ^:private short-breakend-regexp
   #"(\.?)([ATGCN]+)(\.?)")


### PR DESCRIPTION
#### Summary

This PR adds basic support for breakends in VCF.
Breakends are variant records which have `SVTYPE=BND` in the `INFO` field.
They have a dedicated format of string representation for `ALT` field.
For more details, please refer to the [spec "5.4 Specifying complex rearrangements with breakends"](https://github.com/samtools/hts-specs/blob/d962e2fc9e2456c737a91e88cbc40ccf4a732650/VCFv4.3.tex#L859)

#### Tests

- `lein check` 🆗
- `lein test :all` 🆗
- `lein cloverage` 🆗