### PR TITLE
Add a function to inspect an ALT allele of VCF

### DIFF
--- a/src/cljam/io/vcf/util.clj
+++ b/src/cljam/io/vcf/util.clj
@@ -312,7 +312,7 @@
 
       (and (< left-match ref-length) (= left-match alt-length))
       {:type :deletion, :offset (dec left-match),
-       :n-bases (- left-match ref-length), :deleted (subs ref left-match)}
+       :n-bases (- ref-length left-match), :deleted (subs ref left-match)}
 
       (= (inc matched-length) ref-length alt-length)
       {:type :snv, :ref (nth ref left-match),
@@ -320,7 +320,7 @@
 
       (= matched-length alt-length)
       {:type :deletion, :offset (dec left-match),
-       :n-bases (- left-match (- ref-length right-match)),
+       :n-bases (- ref-length right-match left-match),
        :deleted (subs ref left-match (- ref-length right-match))}
 
       (= matched-length ref-length)

--- a/src/cljam/io/vcf/util.clj
+++ b/src/cljam/io/vcf/util.clj
@@ -329,7 +329,7 @@
        :ref (subs ref left-match (- ref-length right-match)),
        :alt (subs alt left-match (- alt-length right-match))}
 
-      :else {:type :other})))
+      :else {:type :complex})))
 
 (defn inspect-allele
   "Inspects an `alt` allele by comparing to a `ref` allele string.
@@ -343,7 +343,8 @@
   - `:deletion` Deletion of a short base sequence
   - `:complete-insertion` Complete insertion of a long sequence
   - `:breakend` Breakend of a complex rearrangement
-  - `:other` The variant is too complex or malformed"
+  - `:complex` Complex nucleotide variants other than snv/mnv/indel
+  - `:other` Can't categorize the allele, might be malformed"
   [ref alt]
   (let [alt-length (count alt)]
     (cond

--- a/src/cljam/io/vcf/util.clj
+++ b/src/cljam/io/vcf/util.clj
@@ -291,14 +291,18 @@
   [ref alt]
   (let [ref-length (count ref)
         alt-length (count alt)
-        u-ref (cstr/upper-case ref)
-        u-alt (cstr/upper-case alt)
-        left-match (->> (map vector u-ref u-alt)
-                        (take-while #(apply = %))
+        upper-ref (cstr/upper-case ref)
+        upper-alt (cstr/upper-case alt)
+        left-match (->> (map = upper-ref upper-alt)
+                        (take-while true?)
                         count)
-        right-match (->> (map vector (cstr/reverse u-ref) (cstr/reverse u-alt))
-                         (take-while #(apply = %))
-                         count)
+        right-match (->> (cstr/reverse upper-alt)
+                         (map = (cstr/reverse upper-ref))
+                         (take-while true?)
+                         count
+                         long
+                         (Math/min (- (Math/min ref-length alt-length)
+                                      left-match)))
         matched-length (+ left-match right-match)]
     ;; Note that `{:type :ref}` is handled in the caller
     (cond

--- a/test/cljam/io/vcf/util_test.clj
+++ b/test/cljam/io/vcf/util_test.clj
@@ -368,6 +368,7 @@
     "TGGTA" "TCcAA" {:type :mnv, :ref "GGT", :alt "CcA", :offset 1}
 
     "TC"  "T"     {:type :deletion, :n-bases -1, :offset 0, :deleted "C"}
+    "TTC" "TC"    {:type :deletion, :n-bases -1, :offset 0, :deleted "T"}
     "GTC" "G"     {:type :deletion, :n-bases -2, :offset 0, :deleted "TC"}
     "TCG" "TG"    {:type :deletion, :n-bases -1, :offset 0, :deleted "C"}
     "TGCA" "TGC"  {:type :deletion, :n-bases -1, :offset 2, :deleted "A"}
@@ -378,6 +379,7 @@
                          :offset 2, :deleted "ACCCTAAA"}
 
     "C"   "CTAG"  {:type :insertion, :n-bases 3, :offset 0, :inserted "TAG"}
+    "TC"  "TTC"   {:type :insertion, :n-bases 1, :offset 0, :inserted "T"}
     "GTC" "GTCT"  {:type :insertion, :n-bases 1, :offset 2, :inserted "T"}
     "TCG" "TCAG"  {:type :insertion, :n-bases 1, :offset 1, :inserted "A"}
     ;; ambiguous

--- a/test/cljam/io/vcf/util_test.clj
+++ b/test/cljam/io/vcf/util_test.clj
@@ -341,19 +341,24 @@
   (are [?ref ?alt ?expected]
       (= ?expected (vcf-util/inspect-allele ?ref ?alt))
 
-    "A" "."   {:type :ref}
-    "A" "*"   {:type :ref}
-    "A" "X"   {:type :ref}
+    "A" ""    {:type :no-call} ;; malformed
+    "A" "."   {:type :no-call}
+    "A" nil   {:type :no-call}
+
+    "A" "*"   {:type :spanning-deletion}
+
+    "A" "X"   {:type :unspecified}
+    "A" "<*>" {:type :unspecified}
+    "A" "<X>" {:type :unspecified}
+
     "A" "A"   {:type :ref}
     "A" "a"   {:type :ref}
     "AA" "AA" {:type :ref}
     "AA" "Aa" {:type :ref}
-    "A" "<*>" {:type :ref} ;; conventional
-    "A" "<X>" {:type :ref} ;; conventional
 
     "A" "<DUP>"     {:type :id, :id "DUP"}
     "A" "<INV>"     {:type :id, :id "INV"}
-    "A" "<NON_REF>" {:type :id, :id "NON_REF"} ;; not :ref
+    "A" "<NON_REF>" {:type :id, :id "NON_REF"} ;; not :unspecified
 
     "A"  "T"      {:type :snv, :ref \A, :alt \T, :offset 0}
     "TC" "TG"     {:type :snv, :ref \C, :alt \G, :offset 1}
@@ -400,9 +405,14 @@
     "T" "]13:123456]T" {:type :breakend, :join :before,
                         :strand :forward, :chr "13", :pos 123456, :bases "T"}
 
-    "T" "<ctg1>CT" {:type :other} ;; invalid
-    "T" "<CT" {:type :other} ;; invalid
-    "." "A" {:type :other}
+    "T" "<ctg1>CT" {:type :other} ;; malformed
+    "T" "<CT"      {:type :other} ;; malformed
+    "T" "C,A"      {:type :other}
+    "." "A"        {:type :other} ;; malformed
+    "" "A"         {:type :other} ;; malformed
+    nil "A"        {:type :other} ;; malformed
+    nil nil        {:type :other} ;; malformed
+    "R" "A"        {:type :other} ;; malformed
 
     "TAC" "GC" {:type :complex}
     "TG" "TAC" {:type :complex}

--- a/test/cljam/io/vcf/util_test.clj
+++ b/test/cljam/io/vcf/util_test.clj
@@ -400,9 +400,9 @@
 
     "T" "<ctg1>CT" {:type :other} ;; invalid
     "T" "<CT" {:type :other} ;; invalid
-
     "." "A" {:type :other}
-    "TAC" "GC" {:type :other}
-    "TG" "TAC" {:type :other}
-    "TCA" "GGGG" {:type :other}
-    "AAAA" "CAC" {:type :other}))
+
+    "TAC" "GC" {:type :complex}
+    "TG" "TAC" {:type :complex}
+    "TCA" "GGGG" {:type :complex}
+    "AAAA" "CAC" {:type :complex}))

--- a/test/cljam/io/vcf/util_test.clj
+++ b/test/cljam/io/vcf/util_test.clj
@@ -367,15 +367,15 @@
     "TGCA" "TCCC" {:type :mnv, :ref "GCA", :alt "CCC", :offset 1} ;; two snvs?
     "TGGTA" "TCcAA" {:type :mnv, :ref "GGT", :alt "CcA", :offset 1}
 
-    "TC"  "T"     {:type :deletion, :n-bases -1, :offset 0, :deleted "C"}
-    "TTC" "TC"    {:type :deletion, :n-bases -1, :offset 0, :deleted "T"}
-    "GTC" "G"     {:type :deletion, :n-bases -2, :offset 0, :deleted "TC"}
-    "TCG" "TG"    {:type :deletion, :n-bases -1, :offset 0, :deleted "C"}
-    "TGCA" "TGC"  {:type :deletion, :n-bases -1, :offset 2, :deleted "A"}
+    "TC"  "T"     {:type :deletion, :n-bases 1, :offset 0, :deleted "C"}
+    "TTC" "TC"    {:type :deletion, :n-bases 1, :offset 0, :deleted "T"}
+    "GTC" "G"     {:type :deletion, :n-bases 2, :offset 0, :deleted "TC"}
+    "TCG" "TG"    {:type :deletion, :n-bases 1, :offset 0, :deleted "C"}
+    "TGCA" "TGC"  {:type :deletion, :n-bases 1, :offset 2, :deleted "A"}
     ;; ambiguous
-    "TCGCG" "TCG" {:type :deletion, :n-bases -2, :offset 2, :deleted "CG"}
+    "TCGCG" "TCG" {:type :deletion, :n-bases 2, :offset 2, :deleted "CG"}
     ;; ambiguous
-    "TAAACCCTAAA" "TAA" {:type :deletion, :n-bases -8,
+    "TAAACCCTAAA" "TAA" {:type :deletion, :n-bases 8,
                          :offset 2, :deleted "ACCCTAAA"}
 
     "C"   "CTAG"  {:type :insertion, :n-bases 3, :offset 0, :inserted "TAG"}


### PR DESCRIPTION
~~**This PR is depending on #163**~~

#### Summary
This PR adds a function to inspect an `ALT` allele of a variant in VCF.
The `ALT` field of VCF is so expressive that it is not so straightforward to know what they mean.
`cljam.io.vcf.util/inspect-allele` provides a way to classify `ALT` alleles into ~~9~~ ~~10~~ 13 types.
With this feature, we can easily transform VCF variants based on their types. (e.g. filtering only SNPs)

#### Tests

- `lein check` 🆗
- `lein test :all` 🆗
- `lein cloverage` 🆗