### PR TITLE
Ignore undeclared keys in INFO and FORMAT when writing BCF files

### DIFF
--- a/src/cljam/io/bcf/writer.clj
+++ b/src/cljam/io/bcf/writer.clj
@@ -236,7 +236,7 @@
 (defn- parsed-variant->bcf-map
   "Converts a parsed variant map to BCF-style map."
   [[fmt-kw & indiv-kws :as kws] contigs filters formats info variant]
-  (let [fmts (map (juxt identity formats) (variant fmt-kw))
+  (let [fmts (keep (fn [f] (when-let [m (formats f)] [f m])) (variant fmt-kw))
         genotype (map
                   (fn [[k {:keys [idx type-kw]}]]
                     (->> indiv-kws
@@ -254,9 +254,9 @@
         (update :chr (comp :idx contigs))
         (update :filter (fn [f] (map (comp :idx filters) f)))
         (update :info (fn [i]
-                        (map (fn [[k v]]
-                               (let [{:keys [idx type-kw]} (info k)]
-                                 [idx type-kw v])) i))))))
+                        (keep (fn [[k v]]
+                                (when-let [{:keys [idx type-kw]} (info k)]
+                                  [idx type-kw v])) i))))))
 
 (defn- meta->map
   "Creates a map for searching meta-info with (f id)."


### PR DESCRIPTION
`cljam.io.bcf.writer/write-variants` fails to encode variants if they contain keys not declared in `meta-info`.
This PR fixes the bug by ignoring such keys.

https://github.com/chrovis/cljam/blob/94ce1f8de25130bc2a28aa5a03e3fec3e34672f9/test/cljam/io/bcf/writer_test.clj#L256-L258
https://travis-ci.org/chrovis/cljam/jobs/552587080#L535-L554