### PR TITLE
Provide a default file format version for BCF

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,10 +4,9 @@ cache:
   directories:
     - $HOME/.m2
 jdk:
+  - openjdk-ea
   - openjdk12
   - openjdk11
-  - openjdk10
-  - openjdk9
   - openjdk8
 env:
 before_install:

--- a/src/cljam/io/bcf/writer.clj
+++ b/src/cljam/io/bcf/writer.clj
@@ -22,6 +22,7 @@
   (write-variants [this variants]
     (write-variants this variants)))
 
+(def ^:private ^:const default-fileformat "VCFv4.3")
 (def ^:private ^:const bcf-meta-keys
   [:fileformat :file-date :source :reference :contig :phasing :info :filter
    :format :alt :sample :pedigree])
@@ -86,8 +87,11 @@
        (WRITING-BCF))"
   [f meta-info header]
   (let [bos (bgzf/bgzf-output-stream f)
-        dos (DataOutputStream. bos)]
-    (doto (BCFWriter. (util/as-url f) (index-meta meta-info) header dos)
+        dos (DataOutputStream. bos)
+        indexed-meta (->> meta-info
+                          (merge {:fileformat default-fileformat})
+                          index-meta)]
+    (doto (BCFWriter. (util/as-url f) indexed-meta header dos)
       (write-file-header))))
 
 (defn- value-type

--- a/test/cljam/io/bcf/writer_test.clj
+++ b/test/cljam/io/bcf/writer_test.clj
@@ -275,7 +275,7 @@
                 "##FILTER=<ID=PASS,Description=\"All filters passed\",IDX=0>"
                 (str "#" (cstr/join \tab header) \newline (char 0))]
                (cstr/join \newline))
-        _ (with-open [w (bcf-writer/writer tmp {} header)])
+        _ (with-open [_ (bcf-writer/writer tmp {} header)])
         bytes (bb->seq (bgzf->bb tmp))]
     (is (= (concat (.getBytes "BCF\2\2") [(.length s) 0 0 0] (.getBytes s))
            bytes))

--- a/test/cljam/io/bcf/writer_test.clj
+++ b/test/cljam/io/bcf/writer_test.clj
@@ -267,3 +267,16 @@
          0x17 0x43
          0x00]
         []]])))
+
+(deftest default-meta-info
+  (let [tmp (File/createTempFile "default-meta-info" ".bcf")
+        header ["CHROM" "POS" "ID" "REF" "ALT" "QUAL" "FILTER" "INFO"]
+        s (->> ["##fileformat=VCFv4.3"
+                "##FILTER=<ID=PASS,Description=\"All filters passed\",IDX=0>"
+                (str "#" (cstr/join \tab header) \newline (char 0))]
+               (cstr/join \newline))
+        _ (with-open [w (bcf-writer/writer tmp {} header)])
+        bytes (bb->seq (bgzf->bb tmp))]
+    (is (= (concat (.getBytes "BCF\2\2") [(.length s) 0 0 0] (.getBytes s))
+           bytes))
+    (.delete tmp)))


### PR DESCRIPTION
~~**This PR depends on #169**
The actual diff is [94ce1f8...581438a](https://github.com/chrovis/cljam/pull/170/files/94ce1f8de25130bc2a28aa5a03e3fec3e34672f9..581438a1502bf4ab1af0d4b1ea74970b3d876320)~~

Like VCFWriter, this PR provides a default file format version `"VCFv4.3"` for meta-info of BCF.
Though BCF has its version in the magic number `BCF\2\2`, the header string should start with `##fileformat=`.