### PR TITLE
Fix nonintentional paths

### DIFF
--- a/test/cljam/io/fastq_test.clj
+++ b/test/cljam/io/fastq_test.clj
@@ -136,7 +136,7 @@
         (cio/as-url (str (:uri server) "/fastq/test.fq")))))
 
   (testing "writer"
-    (let [temp-file (str temp-dir "test.fq")]
+    (let [temp-file (.getPath (cio/file temp-dir "test.fq"))]
       (are [x] (with-before-after {:before (prepare-cache!)
                                    :after (clean-cache!)}
                  (with-open [wtr (fq/writer x)]

--- a/test/cljam/io/sequence_test.clj
+++ b/test/cljam/io/sequence_test.clj
@@ -341,7 +341,7 @@
         (cio/as-url (str (:uri server) "/twobit/test.2bit")))))
 
   (testing "writer"
-    (let [temp-test-twobit-file (str temp-dir "test.2bit")]
+    (let [temp-test-twobit-file (.getPath (cio/file temp-dir "test.2bit"))]
       (are [x] (with-before-after {:before (prepare-cache!)
                                    :after (clean-cache!)}
                  (with-open [rdr (cseq/reader test-fa-file)

--- a/test/cljam/io/util/lsb_test.clj
+++ b/test/cljam/io/util/lsb_test.clj
@@ -85,7 +85,7 @@
 (deftest about-random-access-file
   (common/with-before-after {:before (common/prepare-cache!)
                              :after (common/clean-cache!)}
-    (let [filename (str common/temp-dir "raf.bin")]
+    (let [filename (cio/file common/temp-dir "raf.bin")]
       (with-open [raf (RandomAccessFile. filename "rw")]
         (let [bb (lsb/gen-byte-buffer 24)]
           (.putLong bb 0x789ABCDEF0123456)
@@ -160,7 +160,7 @@
 (deftest about-data-input-stream
   (common/with-before-after {:before (common/prepare-cache!)
                              :after (common/clean-cache!)}
-    (let [filename (str common/temp-dir "raf.bin")]
+    (let [filename (cio/file common/temp-dir "raf.bin")]
       (with-open [raf (RandomAccessFile. filename "rw")]
         (let [bb (lsb/gen-byte-buffer 24)]
           (.putLong bb 0x789ABCDEF0123456)
@@ -247,7 +247,7 @@
 (deftest about-bgzf-input-stream
   (common/with-before-after {:before (common/prepare-cache!)
                              :after (common/clean-cache!)}
-    (let [filename (str common/temp-dir "raf.bin.gz")]
+    (let [filename (cio/file common/temp-dir "raf.bin.gz")]
       (with-open [bgzfos (BGZFOutputStream. (cio/file filename))]
         (let [bb (lsb/gen-byte-buffer 24)]
           (.putLong bb 0x789ABCDEF0123456)


### PR DESCRIPTION
`temp-dir` has a type of `java.lang.String` and the end is not `"/"`, so `"/"` is needed when concatenating `temp-dir` with files.
This PR fixes nonintentional paths that do not contain `"/"`, does not change the test results.