### PR TITLE
Fix minor typos

### DIFF
--- a/src/cljam/algo/depth.clj
+++ b/src/cljam/algo/depth.clj
@@ -48,7 +48,7 @@
   "Calculate depth of coverage lazily. Returns a lazy seq of depth for range [start, end].
   Requires a `cljam.io.bam.reader.BAMReader` instance and region.
   If start and end are not supplied, piles whole range up.
-  Note that CIGAR code in alignemnts are ignored and only start/end positions are used."
+  Note that CIGAR code in alignments are ignored and only start/end positions are used."
   [bam-reader {:keys [chr start end] :or {start 1 end Long/MAX_VALUE}}
    & [{:keys [step n-threads] :or {step default-step n-threads 1}}]]
   {:pre [chr start end (pos? start) (pos? end) (<= start end)]}
@@ -119,7 +119,7 @@
   "Calculate depth of coverage eagerly. Returns a seq of depth for range [start, end].
   Requires a `cljam.io.bam.reader.BAMReader` instance and region.
   If start and end are not supplied, piles whole range up.
-  Note that CIGAR code in alignemnts are ignored and only start/end positions are used."
+  Note that CIGAR code in alignments are ignored and only start/end positions are used."
   [bam-reader {:keys [chr start end] :or {start 1 end Long/MAX_VALUE}}
    & [{:keys [step unchecked? n-threads] :or {step default-step unchecked? false n-threads 1}}]]
   {:pre [chr start end (pos? start) (pos? end) (<= start end)]}

--- a/src/cljam/io/bam_index/writer.clj
+++ b/src/cljam/io/bam_index/writer.clj
@@ -29,7 +29,7 @@
   [^long pos]
   (bit-shift-right (if (<= pos 0) 0 (dec pos)) linear-index-shift))
 
-;; ### Intermidate data definitions
+;; ### Intermediate data definitions
 ;;
 ;; Use record for performance.
 ;; Record is faster than map for retrieving elements.
@@ -41,14 +41,14 @@
 ;; ### Initializing
 
 (defn- init-index-status
-  "Returns initialized index status. This data structure is intermidate. Must
+  "Returns initialized index status. This data structure is intermediate. Must
   be passed `finalize-index` in the final stage."
   []
   (IndexStatus. (MetaData. -1 0 0 0)
-                ;; Intermidiate bin-index -> {bin1 chunks1, bin2 chunks2, ...}
+                ;; Intermediate bin-index -> {bin1 chunks1, bin2 chunks2, ...}
                 ;; e.g. {4681 [{:beg 97, :end 555} ...], 37450 [...] ...}
                 {}
-                ;; Intermidate linear-index -> {pos1 value1, pos2 value2, ...}
+                ;; Intermediate linear-index -> {pos1 value1, pos2 value2, ...}
                 ;; e.g. {5415 4474732776, 14827 5955073327, ...}
                 {}))
 
@@ -117,7 +117,7 @@
 
 (defn- make-index*
   "Calculates index from the references and alignments, returning it as a map.
-  Returned index is still intermidate. It must be passed to finalize function
+  Returned index is still intermediate. It must be passed to finalize function
   in the final stage."
   [alns]
   (loop [[^BAMPointerBlock aln & rest] alns
@@ -177,7 +177,7 @@
   (merge-with min lidx1 lidx2))
 
 (defn- merge-index
-  "Merges two intermidate indices, returning the merged intermidate index."
+  "Merges two intermediate indices, returning the merged intermediate index."
   [idx1 idx2]
   (let [no-coordinate-alns (+ (:no-coordinate-alns idx1) (:no-coordinate-alns idx2))
         idx1 (dissoc idx1 :no-coordinate-alns)
@@ -221,7 +221,7 @@
        (map second)))
 
 (defn- finalize-index
-  "Converts intermidate BAM index data structure into final one. Must be called
+  "Converts intermediate BAM index data structure into final one. Must be called
   in the final stage."
   [^long nrefs index]
   (loop [i 0

--- a/src/cljam/io/bigwig.clj
+++ b/src/cljam/io/bigwig.clj
@@ -40,7 +40,7 @@
                     root-offset])
 
 ; Currently, max number of zoom levels (i.e. max number of zoom headers) is 10,
-; the numberais small. Therefore, we choose a record containing vector of zoom
+; the number is small. Therefore, we choose a record containing vector of zoom
 ; header instead of a flat record.
 ; Cf. https://github.com/ucscGenomeBrowser/kent/blob/3a0198acd1f859a603f5aad90188bee2d82efe0c/src/inc/bbiFile.h#L384
 (defrecord BigWigHeaders [^FixedWidthHeader fixed-width-header

--- a/src/cljam/io/sam/util/header.clj
+++ b/src/cljam/io/sam/util/header.clj
@@ -50,7 +50,7 @@
 
 (defn- group-by-rf
   "Returns a reducing function acts like `group-by`.
-  Second argument `rf` is a reducing function appliede to each group. Default is (into-rf [])."
+  Second argument `rf` is a reducing function applied to each group. Default is (into-rf [])."
   ([keyfn] (group-by-rf keyfn (into-rf [])))
   ([keyfn rf]
    (fn group-by-rf-inner

--- a/src/cljam/io/vcf/util.clj
+++ b/src/cljam/io/vcf/util.clj
@@ -11,7 +11,7 @@
             (= \. (.charAt ~s 0)))))
 
 (defn- value-parser
-  "Returns a parser function for given type idenfier."
+  "Returns a parser function for given type identifier."
   [type]
   (case type
     "Flag" (constantly :exists)
@@ -200,7 +200,7 @@
            (map vector ks vs)))))))
 
 (defn stringify-sample
-  "Converts sample map into string. formats must be a seqeunce of keys in sample-map."
+  "Converts sample map into string. formats must be a sequence of keys in sample-map."
   [formats sample-map]
   (->> formats
        (map (fn [k] [k (get sample-map k)]))


### PR DESCRIPTION
This PR fixes minor typos. It's mainly misspelling, so maybe there are still some grammatical errors that involve misunderstanding.