### PR TITLE
Fix grammar

### DIFF
--- a/src/cljam/algo/sorter.clj
+++ b/src/cljam/algo/sorter.clj
@@ -51,7 +51,7 @@
 
 (defn- split**
   "Splits SAM/BAM file into multiple files each containing alignments up to chunk-size.
-  name-fn must be a function taking a int value i and returning a path string for i-th output.
+  name-fn must be a function taking an int value i and returning a path string for i-th output.
   read-fn must produce a sequence of alignments and write-fn must consume the splitted sequence."
   [rdr mode chunk-size name-fn read-fn write-fn]
   (let [hdr (header/sorted-by mode (header/update-version (sam/read-header rdr)))]
@@ -86,7 +86,7 @@
     (split** rdr mode chunk-size name-fn read-fn write-fn)))
 
 (defn- head-pq
-  "Take a smallest element from sequences in priority queue."
+  "Take the smallest element from sequences in priority queue."
   [^PriorityQueue q]
   (when-not (.isEmpty q)
     (let [x (.poll q)]

--- a/src/cljam/io/bcf/reader.clj
+++ b/src/cljam/io/bcf/reader.clj
@@ -241,7 +241,7 @@
 (defn read-variants
   "Returns data lines of the BCF from rdr as a lazy sequence of maps.
    rdr must implement cljam.bcf.BCFReader.
-   Can take a option :depth to specify parsing level. Default is :deep.
+   Can take an option :depth to specify parsing level. Default is :deep.
 
      :deep    Fully parsed variant map. FORMAT, FILTER, INFO and samples columns are parsed.
      :vcf     VCF-style map. FORMAT, FILTER, INFO and samples columns are strings.

--- a/src/cljam/io/bed.clj
+++ b/src/cljam/io/bed.clj
@@ -70,7 +70,8 @@
     (cstr/join "," xs)))
 
 (defn- update-some
-  "Same as update if map 'm' contains key 'k'. Otherwise returns the original map 'm'."
+  "Same as update if map 'm' contains key 'k'. Otherwise, returns the original
+  map 'm'."
   [m k f & args]
   (if (get m k)
     (apply update m k f args)

--- a/src/cljam/io/sam/util/flag.clj
+++ b/src/cljam/io/sam/util/flag.clj
@@ -34,7 +34,7 @@
   (reduce + (map flags flag-set)))
 
 (defmacro encoded
-  "Macro to provide a encoded flag with set of keywords."
+  "Macro to provide an encoded flag with set of keywords."
   [flag-set-literal]
   (let [f (encode flag-set-literal)]
     f))

--- a/src/cljam/io/util/lsb.clj
+++ b/src/cljam/io/util/lsb.clj
@@ -192,7 +192,7 @@
   (write-ushort [this n] "Writes a 2-byte unsigned short value.")
   (write-int [this n] "Writes a 4-byte integer value.")
   (write-uint [this n] "Writes a 4-byte unsigned integer value.")
-  (write-long [this n] "Writes a 8-byte long value.")
+  (write-long [this n] "Writes an 8-byte long value.")
   (write-float [this n] "Writes a 4-byte float value.")
   (write-bytes [this b] "Writes a byte-array.")
   (write-string [this s] "Writes a string as a sequence of ascii characters."))

--- a/src/cljam/io/vcf.clj
+++ b/src/cljam/io/vcf.clj
@@ -60,7 +60,7 @@
 
 (defn read-variants
   "Reads variants of the VCF/BCF file, returning them as a lazy sequence. rdr
-  must implement cljam.io.protocols/IVariantReader. Can take a option :depth to
+  must implement cljam.io.protocols/IVariantReader. Can take an option :depth to
   specify parsing level, default :deep. <:deep|:vcf|:bcf|:shallow|:raw>
     :deep - Fully parsed variant map. FORMAT, FILTER, INFO and samples columns are parsed.
     :vcf - VCF-style map. FORMAT, FILTER, INFO and samples columns are strings.

--- a/src/cljam/util.clj
+++ b/src/cljam/util.clj
@@ -64,7 +64,7 @@
    :bzip2 CompressorStreamFactory/BZIP2})
 
 (defn ^java.io.InputStream compressor-input-stream
-  "Returns an compressor input stream from f, autodetecting the compressor type
+  "Returns a compressor input stream from f, autodetecting the compressor type
   from the first few bytes of f. Returns java.io.BufferedInputStream if the
   compressor type is not known. Should be used inside with-open to ensure the
   InputStream is properly closed."
@@ -77,7 +77,7 @@
         is))))
 
 (defn ^java.io.OutputStream compressor-output-stream
-  "Returns an compressor output stream from f and a compressor type k. k must be
+  "Returns a compressor output stream from f and a compressor type k. k must be
   selected from :gzip or :bzip2. Autodetects the compressor type from the
   extension of f if k is not passed. Returns java.io.BufferedOutputStream if the
   compressor type is not known. Should be used inside with-open to ensure the


### PR DESCRIPTION
This PR fixes minor grammar mistakes:

- `an` follows the word starts with a vowel sound.
- `a` follows the word doesn't start with a vowel sound.
- Superlative takes `the`.
- It needs a comma after a conjunctive adverb.