### PR TITLE
Fix creating temp directory to support multiple users

### DIFF
--- a/test/cljam/io/pileup_test.clj
+++ b/test/cljam/io/pileup_test.clj
@@ -281,9 +281,10 @@
   (testing "with-ref"
     (are [?input]
          (= ?input
-            (let [tmp (File/createTempFile "pileup-regression" ".fa")
-                  idx (File/createTempFile "pileup-regression" ".fai")]
-              (try
+            (with-before-after {:before (prepare-cache!)
+                                :after (clean-cache!)}
+              (let [tmp (cio/file temp-dir "pileup-regression.fa")
+                    idx (cio/file temp-dir "pileup-regression.fai")]
                 (with-open [w (cseq/writer (.getCanonicalPath tmp))]
                   (cseq/write-sequences w [{:name "chr1" :sequence "NNNNNNNNNATGC"}]))
                 (fai/create-index tmp idx)
@@ -291,10 +292,7 @@
                             sw (StringWriter.)
                             w (plpio/writer sw tmp)]
                   (plpio/write-piles w (plpio/read-piles r))
-                  (str sw))
-                (finally
-                  (when (.isFile (cio/file tmp))
-                    (cio/delete-file (cio/file tmp)))))))
+                  (str sw)))))
       "chr1\t10\tA\t1\t.\tI\n"
       "chr1\t10\tA\t4\t.,Tt\tIABC\n"
       "chr1\t10\tA\t4\t^].+3TTT,-2tg$Tt\tIABC\n")))

--- a/test/cljam/io/sam_test.clj
+++ b/test/cljam/io/sam_test.clj
@@ -3,8 +3,7 @@
             [clojure.java.io :as cio]
             [cljam.test-common :refer :all]
             [cljam.io.sam :as sam]
-            [cljam.io.protocols :as protocols]
-            [cljam.util :as util]))
+            [cljam.io.protocols :as protocols]))
 
 (def temp-sam-file (str temp-dir "/test.sam"))
 (def temp-bam-file (str temp-dir "/test.bam"))
@@ -260,15 +259,21 @@
 
 (deftest writer-test
   (testing "sam"
-    (with-open [wtr (sam/writer (.getAbsolutePath (cio/file util/temp-dir "temp.sam")))]
-      (is (instance? cljam.io.sam.writer.SAMWriter wtr))))
+    (with-before-after {:before (prepare-cache!)
+                        :after (clean-cache!)}
+      (with-open [wtr (sam/writer (.getAbsolutePath (cio/file temp-dir "temp.sam")))]
+        (is (instance? cljam.io.sam.writer.SAMWriter wtr)))))
   (testing "bam"
-    (with-open [wtr (sam/writer (.getAbsolutePath (cio/file util/temp-dir "temp.bam")))]
-      (is (instance? cljam.io.bam.writer.BAMWriter wtr))))
+    (with-before-after {:before (prepare-cache!)
+                        :after (clean-cache!)}
+      (with-open [wtr (sam/writer (.getAbsolutePath (cio/file temp-dir "temp.bam")))]
+        (is (instance? cljam.io.bam.writer.BAMWriter wtr)))))
   (testing "throws Exception"
-    (are [f] (thrown? Exception (sam/writer (.getAbsolutePath (cio/file util/temp-dir f))))
-      "temp.baam"
-      "temp.bai")))
+    (with-before-after {:before (prepare-cache!)
+                        :after (clean-cache!)}
+      (are [f] (thrown? Exception (sam/writer (.getAbsolutePath (cio/file temp-dir f))))
+        "temp.baam"
+        "temp.bai"))))
 
 (def test-options
   [{:Xa {:type "A", :value \p}}

--- a/test/cljam/io/sequence_test.clj
+++ b/test/cljam/io/sequence_test.clj
@@ -5,8 +5,7 @@
             [cljam.test-common :refer :all]
             [cljam.io.fasta.core :as fa-core]
             [cljam.io.sequence :as cseq]
-            [cljam.io.protocols :as protocols]
-            [cljam.util :as util]))
+            [cljam.io.protocols :as protocols]))
 
 (def temp-test-fa-file (str temp-dir "/test.fa"))
 (def temp-medium-fa-file (str temp-dir "/medium.fa"))
@@ -219,15 +218,21 @@
 
 (deftest writer-test
   (testing "fasta"
-    (with-open [wtr (cseq/writer (.getAbsolutePath (cio/file util/temp-dir "temp.fa")))]
-      (is (instance? cljam.io.fasta.writer.FASTAWriter wtr))))
+    (with-before-after {:before (prepare-cache!)
+                        :after (clean-cache!)}
+      (with-open [wtr (cseq/writer (.getAbsolutePath (cio/file temp-dir "temp.fa")))]
+        (is (instance? cljam.io.fasta.writer.FASTAWriter wtr)))))
   (testing "twobit"
-    (with-open [wtr (cseq/writer (.getAbsolutePath (cio/file util/temp-dir "temp.2bit")))]
-      (is (instance? cljam.io.twobit.writer.TwoBitWriter wtr))))
+    (with-before-after {:before (prepare-cache!)
+                        :after (clean-cache!)}
+      (with-open [wtr (cseq/writer (.getAbsolutePath (cio/file temp-dir "temp.2bit")))]
+        (is (instance? cljam.io.twobit.writer.TwoBitWriter wtr)))))
   (testing "throws Exception"
-    (are [f] (thrown? Exception (cseq/writer (.getAbsolutePath (cio/file util/temp-dir f))))
-      "temp.fsta"
-      "temp.fa.fai")))
+    (with-before-after {:before (prepare-cache!)
+                        :after (clean-cache!)}
+      (are [f] (thrown? Exception (cseq/writer (.getAbsolutePath (cio/file temp-dir f))))
+        "temp.fsta"
+        "temp.fa.fai"))))
 
 (deftest write-sequences-fasta-test
   (with-before-after {:before (prepare-cache!)

--- a/test/cljam/io/util_test.clj
+++ b/test/cljam/io/util_test.clj
@@ -2,7 +2,6 @@
   (:require [clojure.test :refer :all]
             [clojure.java.io :as cio]
             [cljam.test-common :refer :all]
-            [cljam.util :as util]
             [cljam.io.bed :as bed]
             [cljam.io.fastq :as fastq]
             [cljam.io.sam :as sam]
@@ -303,137 +302,155 @@
 
 (deftest writer-predicates-test
   (testing "sam writer"
-    (with-open [r (sam/writer (.getAbsolutePath (cio/file util/temp-dir "temp.sam")))]
-      (are [?pred ?expected] (= (?pred r) ?expected)
-        io-util/alignment-writer? true
-        io-util/sam-writer? true
-        io-util/bam-writer? false
-        io-util/sequence-writer? false
-        io-util/fasta-writer? false
-        io-util/twobit-writer? false
-        io-util/variant-writer? false
-        io-util/vcf-writer? false
-        io-util/bcf-writer? false
-        io-util/fastq-writer? false
-        io-util/bed-writer? false
-        io-util/wig-writer? false)))
+    (with-before-after {:before (prepare-cache!)
+                        :after (clean-cache!)}
+      (with-open [r (sam/writer (.getAbsolutePath (cio/file temp-dir "temp.sam")))]
+        (are [?pred ?expected] (= (?pred r) ?expected)
+          io-util/alignment-writer? true
+          io-util/sam-writer? true
+          io-util/bam-writer? false
+          io-util/sequence-writer? false
+          io-util/fasta-writer? false
+          io-util/twobit-writer? false
+          io-util/variant-writer? false
+          io-util/vcf-writer? false
+          io-util/bcf-writer? false
+          io-util/fastq-writer? false
+          io-util/bed-writer? false
+          io-util/wig-writer? false))))
   (testing "bam writer"
-    (with-open [r (sam/writer (.getAbsolutePath (cio/file util/temp-dir "temp.bam")))]
-      (are [?pred ?expected] (= (?pred r) ?expected)
-        io-util/alignment-writer? true
-        io-util/sam-writer? false
-        io-util/bam-writer? true
-        io-util/sequence-writer? false
-        io-util/fasta-writer? false
-        io-util/twobit-writer? false
-        io-util/variant-writer? false
-        io-util/vcf-writer? false
-        io-util/bcf-writer? false
-        io-util/fastq-writer? false
-        io-util/bed-writer? false
-        io-util/wig-writer? false)))
+    (with-before-after {:before (prepare-cache!)
+                        :after (clean-cache!)}
+      (with-open [r (sam/writer (.getAbsolutePath (cio/file temp-dir "temp.bam")))]
+        (are [?pred ?expected] (= (?pred r) ?expected)
+          io-util/alignment-writer? true
+          io-util/sam-writer? false
+          io-util/bam-writer? true
+          io-util/sequence-writer? false
+          io-util/fasta-writer? false
+          io-util/twobit-writer? false
+          io-util/variant-writer? false
+          io-util/vcf-writer? false
+          io-util/bcf-writer? false
+          io-util/fastq-writer? false
+          io-util/bed-writer? false
+          io-util/wig-writer? false))))
   (testing "fasta writer"
-    (with-open [r (cseq/writer (.getAbsolutePath (cio/file util/temp-dir "temp.fa")))]
-      (are [?pred ?expected] (= (?pred r) ?expected)
-        io-util/alignment-writer? false
-        io-util/sam-writer? false
-        io-util/bam-writer? false
-        io-util/sequence-writer? true
-        io-util/fasta-writer? true
-        io-util/twobit-writer? false
-        io-util/variant-writer? false
-        io-util/vcf-writer? false
-        io-util/bcf-writer? false
-        io-util/fastq-writer? false
-        io-util/bed-writer? false
-        io-util/wig-writer? false)))
+    (with-before-after {:before (prepare-cache!)
+                        :after (clean-cache!)}
+      (with-open [r (cseq/writer (.getAbsolutePath (cio/file temp-dir "temp.fa")))]
+        (are [?pred ?expected] (= (?pred r) ?expected)
+          io-util/alignment-writer? false
+          io-util/sam-writer? false
+          io-util/bam-writer? false
+          io-util/sequence-writer? true
+          io-util/fasta-writer? true
+          io-util/twobit-writer? false
+          io-util/variant-writer? false
+          io-util/vcf-writer? false
+          io-util/bcf-writer? false
+          io-util/fastq-writer? false
+          io-util/bed-writer? false
+          io-util/wig-writer? false))))
   (testing "twobit writer"
-    (with-open [r (cseq/writer (.getAbsolutePath (cio/file util/temp-dir "temp.2bit")))]
-      (are [?pred ?expected] (= (?pred r) ?expected)
-        io-util/alignment-writer? false
-        io-util/sam-writer? false
-        io-util/bam-writer? false
-        io-util/sequence-writer? true
-        io-util/fasta-writer? false
-        io-util/twobit-writer? true
-        io-util/variant-writer? false
-        io-util/vcf-writer? false
-        io-util/bcf-writer? false
-        io-util/fastq-writer? false
-        io-util/bed-writer? false
-        io-util/wig-writer? false)))
+    (with-before-after {:before (prepare-cache!)
+                        :after (clean-cache!)}
+      (with-open [r (cseq/writer (.getAbsolutePath (cio/file temp-dir "temp.2bit")))]
+        (are [?pred ?expected] (= (?pred r) ?expected)
+          io-util/alignment-writer? false
+          io-util/sam-writer? false
+          io-util/bam-writer? false
+          io-util/sequence-writer? true
+          io-util/fasta-writer? false
+          io-util/twobit-writer? true
+          io-util/variant-writer? false
+          io-util/vcf-writer? false
+          io-util/bcf-writer? false
+          io-util/fastq-writer? false
+          io-util/bed-writer? false
+          io-util/wig-writer? false))))
   (testing "vcf writer"
-    (with-open [r (vcf/writer (.getAbsolutePath (cio/file util/temp-dir "temp.vcf")) {} [])]
-      (are [?pred ?expected] (= (?pred r) ?expected)
-        io-util/alignment-writer? false
-        io-util/sam-writer? false
-        io-util/bam-writer? false
-        io-util/sequence-writer? false
-        io-util/fasta-writer? false
-        io-util/twobit-writer? false
-        io-util/variant-writer?  true
-        io-util/vcf-writer? true
-        io-util/bcf-writer? false
-        io-util/fastq-writer? false
-        io-util/bed-writer? false
-        io-util/wig-writer? false)))
+    (with-before-after {:before (prepare-cache!)
+                        :after (clean-cache!)}
+      (with-open [r (vcf/writer (.getAbsolutePath (cio/file temp-dir "temp.vcf")) {} [])]
+        (are [?pred ?expected] (= (?pred r) ?expected)
+          io-util/alignment-writer? false
+          io-util/sam-writer? false
+          io-util/bam-writer? false
+          io-util/sequence-writer? false
+          io-util/fasta-writer? false
+          io-util/twobit-writer? false
+          io-util/variant-writer?  true
+          io-util/vcf-writer? true
+          io-util/bcf-writer? false
+          io-util/fastq-writer? false
+          io-util/bed-writer? false
+          io-util/wig-writer? false))))
   (testing "bcf writer"
-    (with-open [r (vcf/writer (.getAbsolutePath (cio/file util/temp-dir "temp.bcf")) {} [])]
-      (are [?pred ?expected] (= (?pred r) ?expected)
-        io-util/alignment-writer? false
-        io-util/sam-writer? false
-        io-util/bam-writer? false
-        io-util/sequence-writer? false
-        io-util/fasta-writer? false
-        io-util/twobit-writer? false
-        io-util/variant-writer?  true
-        io-util/vcf-writer? false
-        io-util/bcf-writer? true
-        io-util/fastq-writer? false
-        io-util/bed-writer? false
-        io-util/wig-writer? false)))
+    (with-before-after {:before (prepare-cache!)
+                        :after (clean-cache!)}
+      (with-open [r (vcf/writer (.getAbsolutePath (cio/file temp-dir "temp.bcf")) {} [])]
+        (are [?pred ?expected] (= (?pred r) ?expected)
+          io-util/alignment-writer? false
+          io-util/sam-writer? false
+          io-util/bam-writer? false
+          io-util/sequence-writer? false
+          io-util/fasta-writer? false
+          io-util/twobit-writer? false
+          io-util/variant-writer?  true
+          io-util/vcf-writer? false
+          io-util/bcf-writer? true
+          io-util/fastq-writer? false
+          io-util/bed-writer? false
+          io-util/wig-writer? false))))
   (testing "fastq writer"
-    (with-open [r (fastq/writer (.getAbsolutePath (cio/file util/temp-dir "temp.fq")))]
-      (are [?pred ?expected] (= (?pred r) ?expected)
-        io-util/alignment-writer? false
-        io-util/sam-writer? false
-        io-util/bam-writer? false
-        io-util/sequence-writer? false
-        io-util/fasta-writer? false
-        io-util/twobit-writer? false
-        io-util/variant-writer?  false
-        io-util/vcf-writer? false
-        io-util/bcf-writer? false
-        io-util/fastq-writer? true
-        io-util/bed-writer? false
-        io-util/wig-writer? false)))
+    (with-before-after {:before (prepare-cache!)
+                        :after (clean-cache!)}
+      (with-open [r (fastq/writer (.getAbsolutePath (cio/file temp-dir "temp.fq")))]
+        (are [?pred ?expected] (= (?pred r) ?expected)
+          io-util/alignment-writer? false
+          io-util/sam-writer? false
+          io-util/bam-writer? false
+          io-util/sequence-writer? false
+          io-util/fasta-writer? false
+          io-util/twobit-writer? false
+          io-util/variant-writer?  false
+          io-util/vcf-writer? false
+          io-util/bcf-writer? false
+          io-util/fastq-writer? true
+          io-util/bed-writer? false
+          io-util/wig-writer? false))))
   (testing "bed writer"
-    (with-open [r (bed/writer (.getAbsolutePath (cio/file util/temp-dir "temp.bed")))]
-      (are [?pred ?expected] (= (?pred r) ?expected)
-        io-util/alignment-writer? false
-        io-util/sam-writer? false
-        io-util/bam-writer? false
-        io-util/sequence-writer? false
-        io-util/fasta-writer? false
-        io-util/twobit-writer? false
-        io-util/variant-writer?  false
-        io-util/vcf-writer? false
-        io-util/bcf-writer? false
-        io-util/fastq-writer? false
-        io-util/bed-writer? true
-        io-util/wig-writer? false)))
+    (with-before-after {:before (prepare-cache!)
+                        :after (clean-cache!)}
+      (with-open [r (bed/writer (.getAbsolutePath (cio/file temp-dir "temp.bed")))]
+        (are [?pred ?expected] (= (?pred r) ?expected)
+          io-util/alignment-writer? false
+          io-util/sam-writer? false
+          io-util/bam-writer? false
+          io-util/sequence-writer? false
+          io-util/fasta-writer? false
+          io-util/twobit-writer? false
+          io-util/variant-writer?  false
+          io-util/vcf-writer? false
+          io-util/bcf-writer? false
+          io-util/fastq-writer? false
+          io-util/bed-writer? true
+          io-util/wig-writer? false))))
   (testing "wig writer"
-    (with-open [r (wig/writer (.getAbsolutePath (cio/file util/temp-dir "temp.wig")))]
-      (are [?pred ?expected] (= (?pred r) ?expected)
-        io-util/alignment-writer? false
-        io-util/sam-writer? false
-        io-util/bam-writer? false
-        io-util/sequence-writer? false
-        io-util/fasta-writer? false
-        io-util/twobit-writer? false
-        io-util/variant-writer?  false
-        io-util/vcf-writer? false
-        io-util/bcf-writer? false
-        io-util/fastq-writer? false
-        io-util/bed-writer? false
-        io-util/wig-writer? true))))
+    (with-before-after {:before (prepare-cache!)
+                        :after (clean-cache!)}
+      (with-open [r (wig/writer (.getAbsolutePath (cio/file temp-dir "temp.wig")))]
+        (are [?pred ?expected] (= (?pred r) ?expected)
+          io-util/alignment-writer? false
+          io-util/sam-writer? false
+          io-util/bam-writer? false
+          io-util/sequence-writer? false
+          io-util/fasta-writer? false
+          io-util/twobit-writer? false
+          io-util/variant-writer?  false
+          io-util/vcf-writer? false
+          io-util/bcf-writer? false
+          io-util/fastq-writer? false
+          io-util/bed-writer? false
+          io-util/wig-writer? true)))))

--- a/test/cljam/io/vcf_test.clj
+++ b/test/cljam/io/vcf_test.clj
@@ -2,8 +2,7 @@
   (:require [clojure.test :refer :all]
             [clojure.java.io :as cio]
             [cljam.test-common :refer :all]
-            [cljam.io.vcf :as vcf]
-            [cljam.util :as util])
+            [cljam.io.vcf :as vcf])
   (:import bgzf4j.BGZFException))
 
 (def ^:private temp-file (str temp-dir "/test.vcf"))
@@ -124,17 +123,25 @@
 
 (deftest writer-test
   (testing "vcf"
-    (with-open [wtr (vcf/writer (.getAbsolutePath (cio/file util/temp-dir "temp.vcf")) {} [])]
-      (is (instance? cljam.io.vcf.writer.VCFWriter wtr))))
+    (with-before-after {:before (prepare-cache!)
+                        :after (clean-cache!)}
+      (with-open [wtr (vcf/writer (.getAbsolutePath (cio/file temp-dir "temp.vcf")) {} [])]
+        (is (instance? cljam.io.vcf.writer.VCFWriter wtr)))))
   (testing "bcf"
-    (with-open [wtr (vcf/writer (.getAbsolutePath (cio/file util/temp-dir "temp.bcf")) {} [])]
-      (is (instance? cljam.io.bcf.writer.BCFWriter wtr)))
-    (with-open [wtr (vcf/writer (.getAbsolutePath (cio/file util/temp-dir "temp.bcf"))
-                                {:filter [{:id "PASS", :description "All filters passed"}]} [])]
-      (is (instance? cljam.io.bcf.writer.BCFWriter wtr))))
+    (with-before-after {:before (prepare-cache!)
+                        :after (clean-cache!)}
+      (with-open [wtr (vcf/writer (.getAbsolutePath (cio/file temp-dir "temp.bcf")) {} [])]
+        (is (instance? cljam.io.bcf.writer.BCFWriter wtr))))
+    (with-before-after {:before (prepare-cache!)
+                        :after (clean-cache!)}
+      (with-open [wtr (vcf/writer (.getAbsolutePath (cio/file temp-dir "temp.bcf"))
+                                  {:filter [{:id "PASS", :description "All filters passed"}]} [])]
+        (is (instance? cljam.io.bcf.writer.BCFWriter wtr)))))
   (testing "throws Exception"
-    (is (thrown? Exception
-                 (vcf/writer (.getAbsolutePath (cio/file util/temp-dir "temp.vccf")) {} [])))))
+    (with-before-after {:before (prepare-cache!)
+                        :after (clean-cache!)}
+      (is (thrown? Exception
+                   (vcf/writer (.getAbsolutePath (cio/file temp-dir "temp.vccf")) {} []))))))
 
 (deftest about-writing-vcf-v4_0-deep
   (with-before-after {:before (prepare-cache!)

--- a/test/cljam/io/wig_test.clj
+++ b/test/cljam/io/wig_test.clj
@@ -3,8 +3,7 @@
             [clojure.java.io :as cio]
             [clojure.string :as cstr]
             [cljam.test-common :refer :all]
-            [cljam.io.wig :as wig]
-            [cljam.util :as util])
+            [cljam.io.wig :as wig])
   (:import [java.io BufferedReader InputStreamReader ByteArrayInputStream
             ByteArrayOutputStream OutputStreamWriter BufferedWriter]
            [cljam.io.wig WIGReader WIGWriter]))
@@ -189,8 +188,10 @@
 
 (deftest writer
   (testing "make writer instance"
-    (with-open [wtr (wig/writer (.getAbsolutePath (cio/file util/temp-dir "temp.wig")))]
-      (is (instance? cljam.io.wig.WIGWriter wtr))))
+    (with-before-after {:before (prepare-cache!)
+                        :after (clean-cache!)}
+      (with-open [wtr (wig/writer (.getAbsolutePath (cio/file temp-dir "temp.wig")))]
+        (is (instance? cljam.io.wig.WIGWriter wtr)))))
 
   (testing "write wig"
     (is (= (-> "variableStep chrom=chr1 span=10\n1 1\n101 2" str->wig wig->str)

--- a/test/cljam/util_test.clj
+++ b/test/cljam/util_test.clj
@@ -1,9 +1,54 @@
 (ns cljam.util-test
   "Tests for cljam.util."
   (:require [clojure.java.io :as cio]
+            [clojure.string :as cstr]
             [clojure.test :refer :all]
+            [cljam.test-common :refer :all]
             [cljam.util :as util])
-  (:import [java.net URL]))
+  (:import [java.io File]
+           [java.net URL]
+           [java.nio.file Files]
+           [java.nio.file.attribute FileAttribute]))
+
+(deftest with-temp-dir-test
+  (testing "name with given prefixes"
+    (let [x "foo", y "bar"]
+      (util/with-temp-dir [d x, e y]
+        (let [has-prefix? (fn [name' prefix]
+                            (and (> (count name') (count prefix))
+                                 (cstr/starts-with? name' prefix)))]
+          (is (has-prefix? (.getName ^File d) x))
+          (is (has-prefix? (.getName ^File e) y))))))
+  (testing "no temp items outside of the macro's scope"
+    (let [[d e] (util/with-temp-dir [d "foo", e "bar"] [d e])
+          deleted? (fn [dir] (not (.exists (cio/file dir))))]
+      (is (deleted? d))
+      (is (deleted? e))))
+  (testing "users can delete temp directories before entering a finally clause"
+    (try
+      (util/with-temp-dir [d "foo", e "bar"]
+        (cio/delete-file d true)
+        (cio/delete-file e true))
+      (catch Exception e (is false e))
+      (finally (is true))))
+  (testing "automatically deletes subdirectories created by users"
+    (let [sub-dirs (util/with-temp-dir [d "foo"]
+                     (let [sub-dirs [(cio/file d "bar") (cio/file d "qux")]]
+                       (run! (fn [^File dir] (.mkdir dir)) sub-dirs)
+                       sub-dirs))
+          deleted? (fn [dir] (not (.exists (cio/file dir))))]
+      (is (every? deleted? sub-dirs))))
+  (testing "keeps original nodes if symbolic links are deleted"
+    (let [orig (cio/file temp-dir "orig")]
+      (with-before-after {:before (prepare-cache!)
+                          :after (clean-cache!)}
+        (.mkdir orig)
+        (util/with-temp-dir [d "foo"]
+          (Files/createSymbolicLink
+           (.toPath (cio/file d "orig-link"))
+           (.toPath orig)
+           (make-array FileAttribute 0)))
+        (is (.exists orig))))))
 
 (deftest ubyte
   (are [?n ?expected] (= (util/ubyte ?n) ?expected)


### PR DESCRIPTION
In the current implementation of creating temporary user's directory, there are two problems: always creates the directory of the same name `cljam`, and doesn't delete it after all is done. That might cause `Permission denied` if multiple users run cljam on the same machine.

This PR fixes the behavior; `with-temp-dir` macro creates an unique directory, and finally deletes it. Also, fixes a path to temporary directory such that the test code creates user's directory instead of test's directory.