### PR TITLE
Avoid an ArityException on creating an index for BAM files without alignments

### DIFF
--- a/src/cljam/io/bam_index/writer.clj
+++ b/src/cljam/io/bam_index/writer.clj
@@ -138,7 +138,7 @@
                        indices)]
         (recur rest rid' idx-status' no-coordinate-alns' indices'))
       (assoc indices rid idx-status
-                     :no-coordinate-alns no-coordinate-alns))))
+             :no-coordinate-alns no-coordinate-alns))))
 
 ;; Merging indices
 ;; -------------
@@ -148,9 +148,9 @@
   (MetaData. (let [f1 (.first-offset meta1)
                    f2 (.first-offset meta2)]
                (cond
-                (= f1 -1) f2
-                (= f2 -1) f1
-                :else (min f1 f2)))
+                 (= f1 -1) f2
+                 (= f2 -1) f1
+                 :else (min f1 f2)))
              (max (.last-offset meta1) (.last-offset meta2))
              (+ (.aligned-alns meta1) (.aligned-alns meta2))
              (+ (.unaligned-alns meta1) (.unaligned-alns meta2))))

--- a/src/cljam/io/bam_index/writer.clj
+++ b/src/cljam/io/bam_index/writer.clj
@@ -307,7 +307,7 @@
                                                   (->> sub-blocks
                                                        (eduction (map bam-decoder/decode-pointer-block))
                                                        make-index*)))
-                                 (reduce merge-index)))))]
+                                 (reduce merge-index {:no-coordinate-alns 0})))))]
     (->> blocks
          make-index-fn
          (finalize-index nrefs))))

--- a/test/cljam/algo/bam_indexer_test.clj
+++ b/test/cljam/algo/bam_indexer_test.clj
@@ -106,3 +106,14 @@
     (is (not-throw? (bai/create-index temp-file-sorted
                                       (str temp-file-sorted ".bai"))))
     (is (.isFile (cio/file (str temp-file-sorted ".bai"))))))
+
+(deftest bam-without-alignments-test
+  (with-before-after {:before (prepare-cache!)
+                      :after (clean-cache!)}
+    (let [header {:SQ [{:SN "chr1", :LN 100}]}
+          target (cio/file temp-dir "no_aln.bam")
+          target-bai (cio/file temp-dir "no_aln.bam.bai")]
+      (with-open [w (sam/writer target)]
+        (sam/write-header w header)
+        (sam/write-refs w header))
+      (is (not-throw? (bai/create-index target target-bai))))))


### PR DESCRIPTION
#### Problem
`cljam.algo.bam-indexer/create-index` throws an `clojure.lang.ArityException` when the target BAM contains no alignments

#### Cause
An initial value is not provided for `(reduce merge-index [])` in `cljam.io.bam-index.writer/make-index-from-blocks`
https://github.com/chrovis/cljam/blob/2db7fe739047e2284e93e9d211be74cfdd6cc09b/src/cljam/io/bam_index/writer.clj#L310

#### Changes
Add a default value for `make-index-from-blocks`

#### Affects
- `cljam.algo.bam-indexer`
- `cljam.io.bam-index.writer`

#### Tests

- `lein check` ✅
- `lein test :all` ✅