### PR TITLE
Detect the latest build number of OpenJDK EA

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -36,12 +36,14 @@ jobs:
     steps:
     - uses: actions/checkout@v1
     - name: Download Early-Access Builds
-      run: curl -O https://download.java.net/java/early_access/jdk14/25/GPL/openjdk-14-ea+25_linux-x64_bin.tar.gz
+      run: curl -sSL https://jdk.java.net/14 | grep -m1 -Eo 'https.*linux-x64_bin.tar.gz' | xargs curl -O
+    - name: Get name of the downloaded jdkFile
+      run: echo -e "::set-env name=JDKFILE::$(find . -name '*linux-x64_bin.tar.gz' | head -n1)"
     - name: Setup Java
       uses: actions/setup-java@v1
       with:
         java-version: ea
-        jdkFile: ./openjdk-14-ea+25_linux-x64_bin.tar.gz
+        jdkFile: ${{ env.JDKFILE }}
         architecture: x64
     - name: Cache m2 repository
       uses: actions/cache@v1


### PR DESCRIPTION
The build 14 of OpenJDK EA has been deleted after build 25 is published.
We need to get the latest build number automatically to adapt to future releases.
This PR picks up a tarball URL from the HTML of jdk.java.net then [`set-env`](https://help.github.com/en/actions/automating-your-workflow-with-github-actions/development-tools-for-github-actions#set-an-environment-variable-set-env) it to use it from `actions/setup-java`.