### PR TITLE
Fix a bug in reading bgzipped VCF files

### DIFF
--- a/src/cljam/io/vcf.clj
+++ b/src/cljam/io/vcf.clj
@@ -31,7 +31,6 @@
         header (with-open [r (cio/reader (util/compressor-input-stream f))]
                  (vcf-reader/load-header r))]
     (VCFReader. (util/as-url f) meta-info header
-
                 (if (bgzf/bgzip? f)
                   (bgzf/bgzf-input-stream f)
                   (cio/reader (util/compressor-input-stream f)))

--- a/test/cljam/io/vcf_test.clj
+++ b/test/cljam/io/vcf_test.clj
@@ -292,6 +292,17 @@
             (with-open [b (vcf/writer temp-file m h)]
               (vcf/write-variants b xs))
             (with-open [b (vcf/reader temp-file)]
+              (is (= xs (vcf/read-variants b))))))))
+    (testing "v4.3 complex bgzip"
+      (let [temp-file (.getAbsolutePath
+                       (cio/file temp-dir "test_v4_3_complex_bgzip.bcf"))]
+        (with-open [v (vcf/reader test-vcf-complex-gz-file)]
+          (let [xs (vcf/read-variants v)
+                m (vcf/meta-info v)
+                h (vcf/header v)]
+            (with-open [b (vcf/writer temp-file m h)]
+              (vcf/write-variants b xs))
+            (with-open [b (vcf/reader temp-file)]
               (is (= xs (vcf/read-variants b))))))))))
 
 (deftest bcf->vcf-conversion-test

--- a/test/cljam/io/vcf_test.clj
+++ b/test/cljam/io/vcf_test.clj
@@ -116,9 +116,11 @@
       (is (= (vcf/read-variants rdr) test-vcf-no-samples-variants-deep)))))
 
 (deftest read-variants-complex-test
-  (with-open [v (vcf/reader test-vcf-complex-file)
-              b (vcf/reader test-bcf-complex-file)]
+  (with-open [v (vcf/reader test-vcf-complex-file)    ;; uncompressed VCF
+              z (vcf/reader test-vcf-complex-gz-file) ;; bgzipped VCF
+              b (vcf/reader test-bcf-complex-file)]   ;; bgzipped BCF
     (is (= (vcf/read-variants v)
+           (vcf/read-variants z)
            (vcf/read-variants b)))))
 
 (deftest-remote bin-index-is-done-without-errors-with-a-large-file


### PR DESCRIPTION
## Problem
`cljam.io.vcf/read-variants` throws `java.lang.ClassCastException` for bgzipped VCF files.

#### Cause
#180 introduced switching of reader type between `java.io.BufferedReader` and `bgzf4j.BGZFInputStream` but did not modify the existing code.

#### Changes
Switch methods based on the type of reader instance.

#### Tests

- `lein check` ✅
- `lein test :all` ✅
- `lein cloverage` ✅