### PR TITLE
Improvement for pileup memory usage

### DIFF
--- a/src/cljam/algo/pileup.clj
+++ b/src/cljam/algo/pileup.clj
@@ -40,7 +40,7 @@
   (let [empty-qual? (and (= (.length qual) 1)
                          (= (.charAt qual 0) \*))]
     (if empty-qual?
-      (short-array (repeat (count idx) 93)) ;; \~
+      (short-array (count idx) (short 93)) ;; \~
       (->> idx
            (map (fn [[_ x]]
                   (if (number? x)

--- a/src/cljam/algo/pileup.clj
+++ b/src/cljam/algo/pileup.clj
@@ -103,7 +103,7 @@
      (when-not deletion? indel)
      (when deletion? indel)
      (.qname aln)
-     aln)))
+     (dissoc aln :seqs-at-ref :quals-at-ref))))
 
 (defn- resolve-bases
   [[ref-pos alns]]

--- a/src/cljam/algo/pileup.clj
+++ b/src/cljam/algo/pileup.clj
@@ -40,21 +40,26 @@
   (let [empty-qual? (and (= (.length qual) 1)
                          (= (.charAt qual 0) \*))]
     (if empty-qual?
-      (vec (repeat (count idx) 93)) ;; \~
-      (mapv (fn [[_ x]]
-              (if (number? x)
-                (qual/fastq-char->phred-byte (.charAt qual x))
-                93))
-            idx))))
+      (short-array (repeat (count idx) 93)) ;; \~
+      (->> idx
+           (map (fn [[_ x]]
+                  (if (number? x)
+                    (qual/fastq-char->phred-byte (.charAt qual x))
+                    93)))
+           short-array))))
+
+(deftype PosBase [^char base indel])
 
 (defn- seqs-at-ref
   [idx ^String s]
-  (mapv (fn [[op x xs]]
-          (let [c (if (number? x) (.charAt s x) x)]
-            (case op
-              :m [c]
-              :d [c xs]
-              :i [c (subs s (first xs) (last xs))]))) idx))
+  (->> idx
+       (map (fn [[op x xs]]
+              (let [c (if (number? x) (.charAt s x) x)]
+                (case op
+                  :m (->PosBase c nil)
+                  :d (->PosBase c xs)
+                  :i (->PosBase c (subs s (first xs) (last xs)))))))
+       object-array))
 
 (defn index-cigar
   "Align bases and base quality scores with the reference coordinate."
@@ -83,8 +88,10 @@
   "Find a piled-up base and an indel from an alignment."
   [^long ref-pos ^SAMAlignment aln]
   (let [relative-pos (- ref-pos (.pos aln))
-        qual ((:quals-at-ref aln) relative-pos)
-        [base indel] ((:seqs-at-ref aln) relative-pos)
+        qual (aget ^shorts (:quals-at-ref aln) relative-pos)
+        ^PosBase pb (aget ^objects (:seqs-at-ref aln) relative-pos)
+        base (.base pb)
+        indel (.indel pb)
         deletion? (number? indel)]
     (plpio/->PileupBase
      (zero? relative-pos)
@@ -106,7 +113,7 @@
   "Convert a pile into `cljam.io.pileup.LocusPile`."
   [chr [pos pile]]
   (when (seq pile)
-    (LocusPile. chr pos pile)))
+    (LocusPile. chr pos (object-array pile))))
 
 (defn filter-by-base-quality
   "Returns a predicate for filtering piled-up reads by base quality at its
@@ -114,7 +121,7 @@
   [^long min-base-quality]
   (fn [p]
     (->> #(<= min-base-quality (.qual ^PileupBase %))
-         (partial filterv)
+         (partial filter)
          (update p 1))))
 
 (defn- unzip-2
@@ -138,31 +145,30 @@
 (defn- merge-corrected-quals
   "Merge corrected quals with the uncorrected part."
   [^SAMAlignment aln ^long correct-start corrected-quals]
-  (let [quals (:quals-at-ref aln)
+  (let [^shorts quals (:quals-at-ref aln)
         start (.pos aln)
-        len   (count corrected-quals)]
-    (if (< start correct-start)
-      (-> quals
-          (subvec 0 (- correct-start start))
-          (into corrected-quals)
-          (into (subvec quals (+ (- correct-start start) len))))
-      (into corrected-quals (subvec quals len)))))
+        len   (count corrected-quals)
+        quals' (java.util.Arrays/copyOf quals (alength quals))
+        start' (if (< start correct-start) (- correct-start start) 0)]
+    (dotimes [i len]
+      (aset quals' (+ start' i) (short (corrected-quals i))))
+    quals'))
 
 (defn- correct-pair-qual
   [^SAMAlignment a1 ^SAMAlignment a2]
   (let [pos1 (.pos a1)
         pos2 (.pos a2)
-        quals1 (:quals-at-ref a1)
-        quals2 (:quals-at-ref a2)
-        seqs1  (:seqs-at-ref a1)
-        seqs2  (:seqs-at-ref a2)]
+        ^shorts quals1 (:quals-at-ref a1)
+        ^shorts quals2 (:quals-at-ref a2)
+        ^objects seqs1 (:seqs-at-ref a1)
+        ^objects seqs2 (:seqs-at-ref a2)]
     (fn [^long pos]
       (let [relative-pos1 (- pos pos1)
             relative-pos2 (- pos pos2)
-            ^int q1 (quals1 relative-pos1)
-            ^int q2 (quals2 relative-pos2)
-            [b1] (seqs1 relative-pos1)
-            [b2] (seqs2 relative-pos2)]
+            q1 (aget quals1 relative-pos1)
+            q2 (aget quals2 relative-pos2)
+            b1 (-> seqs1 ^PosBase (aget relative-pos1) .-base)
+            b2 (-> seqs2 ^PosBase (aget relative-pos2) .-base)]
         (if (= b1 b2)
           [(min 200 (+ q1 q2)) 0]
           (if (<= q2 q1)


### PR DESCRIPTION
`cljam.algo.pileup` tends to consume a very large amount of memory and in the worst case it ends up with OOME.

This PR mitigates the situation by improving memory efficiency for the pileup data structure. The primary changes are as follows:

- Use more space-efficient data structures (eg. primitive arrays, dedicated deftypes) to represent a pileup result
- Drop unnecessary intermediate data (`:seqs-at-ref` / `:quals-at-ref` ) from the pileup result
- Unchunk a pileup result (which was a chunked sequence) and return a lazy sequence instead to make each element easier to consume and deallocate one by one

In my small examination, the changes reduced the memory usage by ~45% at peak time with almost no impact on time efficiency:

<img width="300" alt="Memory usage (before change)" src="https://user-images.githubusercontent.com/27441/72877985-6e3cd000-3d3d-11ea-9157-88ae881363b5.png"> <img width="300" alt="Memory usage (after change)" src="https://user-images.githubusercontent.com/27441/72877999-71d05700-3d3d-11ea-826d-d814f45277d4.png">

See [here](https://docs.google.com/spreadsheets/d/1HiCzozDYk5iFR_nglC43JB9x1EzjUKzOGIj1Vua2Odc/edit?usp=sharing) for the detailed raw profiling data for the above result.