### PR TITLE
Replace memoizing cache for parsed CIGARs with core.memoize's LU cache

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -3,7 +3,8 @@
   :url "https://github.com/chrovis/cljam"
   :license {:name "Apache License, Version 2.0"
             :url "https://www.apache.org/licenses/LICENSE-2.0"}
-  :dependencies [[org.clojure/tools.logging "0.5.0"]
+  :dependencies [[org.clojure/core.memoize "0.8.2"]
+                 [org.clojure/tools.logging "0.5.0"]
                  [org.clojure/tools.cli "0.4.2"]
                  [org.apache.commons/commons-compress "1.19"]
                  [clj-sub-command "0.5.1"]

--- a/src/cljam/io/sam/util/cigar.clj
+++ b/src/cljam/io/sam/util/cigar.clj
@@ -1,5 +1,7 @@
 (ns cljam.io.sam.util.cigar
   "Parser of CIGAR strings."
+  (:require [clojure.core.memoize :as memoize]
+            [proton.core :as proton])
   (:import [java.nio ByteBuffer ByteOrder]))
 
 (defn parse
@@ -45,7 +47,10 @@
           #{\I} (recur xs r (+ s l) (update-last! idx (fn [x] [:i x [s (+ l s)]]))))
         (persistent! idx)))))
 
-(def to-index (memoize to-index*))
+(def to-index
+  (memoize/lu to-index* :lu/threshold
+              (or (proton/as-int (System/getProperty "cljam.sam.cigar.cache-size"))
+                  1024)))
 
 (defn count-op
   "Returns length of CIGAR operations."


### PR DESCRIPTION
cljam has [a memoizing cache for parsed CIGAR strings](https://github.com/chrovis/cljam/blob/c320af1a4a17ac0af06a7da438fac1d6ec909825/src/cljam/io/sam/util/cigar.clj#L48), and it tends to limitlessly increase in size after a long-term process such as pileup. The following chart shows how large the whole memory usage got during a certain run of variant call using cljam's pileup. Note that the bottom line of the used heap size is steadily getting higher as time goes along:

<img alt="Memory usage (using memoize)" src="https://user-images.githubusercontent.com/27441/74316917-c48db380-4dbd-11ea-9d30-068060a214d3.png" width="500">

This PR replaces the memoizing cache with [core.memoize](https://github.com/clojure/core.memoize)'s LU cache, limiting the cache size to an appropriate upper bound. Also, it defines a new system property named `cljam.sam.cigar.cache-size` to specify the upper bound of cache size when launching the JVM.

After applying the change, memory usage would grow as follows. In this case, the bottom line keeps as low as the beginning throughout the whole run.

<img alt="Memory usage (using core memoize with threshold = 4096)" src="https://user-images.githubusercontent.com/27441/74318537-cc9b2280-4dc0-11ea-9d9e-b309b37cefba.png" width="500">

See [here](https://docs.google.com/spreadsheets/d/1hEWQw8skqDX5Ija_8g24zYYPYbkuvPXGPSuMX4nWSMc/edit?usp=sharing) for the detailed data for the above charts.