### PR TITLE
Fix warnings and errors reported by clj-kondo

### DIFF
--- a/.clj-kondo/config.edn
+++ b/.clj-kondo/config.edn
@@ -1,0 +1,23 @@
+{:linters
+ {:type-mismatch
+  {:namespaces
+   {clojure.core
+    {long {:arities {1 {:args [#{:byte :number :char}],
+                        :ret :int}}}},
+    cljam.algo.pileup
+    {unzip-2 {:arities {1 {:args [:fn],
+                           :ret :transducer}}}}}},
+  :unresolved-symbol
+  {:exclude [(cljam.io.pileup-test/with-string-writer [w])
+             ;; cljam.algo.depth
+             (com.climate.claypoole/pdoseq [s e])
+             ;; cljam.algo.level
+             (com.climate.claypoole/pfor [i])]}},
+ :lint-as {cljam.test-common/deftest-slow clojure.test/deftest,
+           cljam.test-common/deftest-remote clojure.test/deftest,
+           cljam.util/with-temp-dir clojure.core/with-open,
+           cavia.core/defprofile clojure.core/def,
+           libra.bench/defbench clojure.test/deftest,
+           libra.bench/is clojure.test/is,
+           libra.bench/are clojure.test/are,
+           com.climate.claypoole/with-shutdown! clojure.core/with-open}}

--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,4 @@ pom.xml.asc
 .nrepl-port
 /.cavia
 /docs
+.clj-kondo/.cache

--- a/bench/cljam/algo/bam_indexer_bench.clj
+++ b/bench/cljam/algo/bam_indexer_bench.clj
@@ -1,5 +1,5 @@
 (ns cljam.algo.bam-indexer-bench
-  (:require [libra.bench :refer :all]
+  (:require [libra.bench :refer [defbench are dur]]
             [libra.criterium :as c]
             [cljam.test-common :as tcommon]
             [cljam.algo.bam-indexer :as bai]))

--- a/bench/cljam/algo/convert_bench.clj
+++ b/bench/cljam/algo/convert_bench.clj
@@ -1,5 +1,5 @@
 (ns cljam.algo.convert-bench
-  (:require [libra.bench :refer :all]
+  (:require [libra.bench :refer [defbench are]]
             [libra.criterium :as c]
             [cljam.test-common :as tcommon]
             [cljam.algo.convert :as convert]))

--- a/bench/cljam/algo/depth_bench.clj
+++ b/bench/cljam/algo/depth_bench.clj
@@ -1,5 +1,5 @@
 (ns cljam.algo.depth-bench
-  (:require [libra.bench :refer :all]
+  (:require [libra.bench :refer [defbench are dur]]
             [libra.criterium :as c]
             [cljam.test-common :as tcommon]
             [cljam.algo.depth :as depth]

--- a/bench/cljam/algo/pileup_bench.clj
+++ b/bench/cljam/algo/pileup_bench.clj
@@ -1,5 +1,5 @@
 (ns cljam.algo.pileup-bench
-  (:require [libra.bench :refer :all]
+  (:require [libra.bench :refer [defbench is]]
             [libra.criterium :as c]
             [criterium.core :as criterium]
             [cljam.test-common :as tcommon]
@@ -15,4 +15,3 @@
           (is
            (c/quick-bench
             (dorun (pileup/pileup r region)))))))))
-

--- a/bench/cljam/io/sequence_bench.clj
+++ b/bench/cljam/io/sequence_bench.clj
@@ -1,5 +1,5 @@
 (ns cljam.io.sequence-bench
-  (:require [libra.bench :refer :all]
+  (:require [libra.bench :refer [defbench are]]
             [libra.criterium :as c]
             [cljam.test-common :as tcommon]
             [cljam.io.sequence :as cseq]))

--- a/src/cljam/algo/sorter.clj
+++ b/src/cljam/algo/sorter.clj
@@ -1,15 +1,14 @@
 (ns cljam.algo.sorter
   "Sorter of the SAM/BAM format alignments."
   (:refer-clojure :exclude [sorted?])
-  (:require [clojure.java.io :as cio]
-            [clojure.tools.logging :as logging]
+  (:require [clojure.tools.logging :as logging]
             [com.climate.claypoole :as cp]
             [cljam.io.protocols :as protocols]
             [cljam.io.sam :as sam]
             [cljam.io.util :as io-util]
             [cljam.util :as util]
             [cljam.io.sam.util.header :as header])
-  (:import [java.io Closeable File]
+  (:import [java.io Closeable]
            [java.util PriorityQueue]))
 
 (def ^:const default-chunk-size 1500000)

--- a/src/cljam/io/bam/reader.clj
+++ b/src/cljam/io/bam/reader.clj
@@ -6,9 +6,8 @@
             [cljam.io.bam-index.core :as bai]
             [cljam.io.bam.decoder :as decoder]
             [cljam.io.util.lsb :as lsb])
-  (:import [java.io Closeable EOFException IOException FileNotFoundException]
+  (:import [java.io Closeable FileNotFoundException]
            [cljam.io.bam.decoder BAMRawBlock]
-           [java.nio ByteBuffer]
            [bgzf4j BGZFInputStream]))
 
 (declare read-blocks-sequentially*

--- a/src/cljam/io/bam_index/core.clj
+++ b/src/cljam/io/bam_index/core.clj
@@ -70,7 +70,7 @@
   (with-open [w (writer f refs)]
     (try
       (writer/write-index! w alns)
-      (catch Exception e (do
-                           (cio/delete-file (.url w))
-                           (logging/error "Failed to create BAM index")
-                           (throw e))))))
+      (catch Exception e
+        (cio/delete-file (.url w))
+        (logging/error "Failed to create BAM index")
+        (throw e)))))

--- a/src/cljam/io/bam_index/writer.clj
+++ b/src/cljam/io/bam_index/writer.clj
@@ -4,11 +4,13 @@
             [cljam.io.util.bgzf :as bgzf]
             [cljam.io.util.lsb :as lsb]
             [cljam.io.util.bin :as util-bin]
-            [cljam.io.bam-index.common :refer :all]
+            [cljam.io.bam-index.common :refer [linear-index-shift
+                                               linear-index-depth
+                                               max-bins
+                                               bai-magic]]
             [cljam.io.util.chunk :as chunk]
             [cljam.io.bam.decoder :as bam-decoder])
   (:import [java.io DataOutputStream Closeable]
-           [java.nio ByteBuffer ByteOrder]
            [cljam.io.bam.decoder BAMPointerBlock]
            [cljam.io.util.chunk Chunk]))
 

--- a/src/cljam/io/bcf/writer.clj
+++ b/src/cljam/io/bcf/writer.clj
@@ -6,7 +6,7 @@
             [cljam.io.vcf.writer :as vw]
             [cljam.io.vcf.util :as vcf-util]
             [cljam.util :as util])
-  (:import [java.io Closeable IOException DataOutputStream]
+  (:import [java.io Closeable DataOutputStream]
            [java.net URL]
            [java.nio ByteBuffer ByteOrder]))
 
@@ -27,7 +27,6 @@
   [:fileformat :file-date :source :reference :contig :phasing :info :filter
    :format :alt :sample :pedigree])
 (def ^:private ^:const meta-info-prefix "##")
-(def ^:private ^:const header-prefix "#")
 (def ^:private ^:const type-kws
   {"String" :str, "Character" :char,
    "Integer" :int, "Float" :float, "Flag" :flag})

--- a/src/cljam/io/bed.clj
+++ b/src/cljam/io/bed.clj
@@ -3,7 +3,7 @@
   http://genome.ucsc.edu/FAQ/FAQformat#format1 for the detail BED specifications."
   (:require [clojure.java.io :as cio]
             [clojure.string :as cstr]
-            [proton.core :refer [as-int as-long]]
+            [proton.core :refer [as-long]]
             [cljam.io.protocols :as protocols]
             [cljam.util :as util]
             [cljam.util.chromosome :as chr]

--- a/src/cljam/io/bigwig.clj
+++ b/src/cljam/io/bigwig.clj
@@ -301,8 +301,9 @@
                            end-base (lsb/read-uint r)
                            offset (lsb/read-long r)
                            size (lsb/read-long r)]
-                       (if (cir-tree-overlaps? id start end start-chrom-ix
-                                               start-base end-chrom-ix end-base)
+                       (when (cir-tree-overlaps?
+                              id start end start-chrom-ix
+                              start-base end-chrom-ix end-base)
                          {:offset offset, :size size}))))
        (remove nil?)))
 

--- a/src/cljam/io/dict/core.clj
+++ b/src/cljam/io/dict/core.clj
@@ -28,7 +28,7 @@
   (with-open [w (writer f)]
     (try
       (writer/write-dict! w headers sequences ur)
-      (catch Exception e (do
-                           (cio/delete-file (.url w))
-                           (logging/error "Failed to create dictionary")
-                           (throw e))))))
+      (catch Exception e
+        (cio/delete-file (.url w))
+        (logging/error "Failed to create dictionary")
+        (throw e)))))

--- a/src/cljam/io/dict/writer.clj
+++ b/src/cljam/io/dict/writer.clj
@@ -47,7 +47,7 @@
 (defn make-dict
   "Calculates sequence dictionary from the headers and sequences, returning it
   as a map."
-  [headers sequences ur]
+  [_headers sequences ur]
   (loop [[seq* & rest] sequences
          name (:name seq*)
          dict-status (init-dict-status)

--- a/src/cljam/io/fasta_index/core.clj
+++ b/src/cljam/io/fasta_index/core.clj
@@ -23,10 +23,10 @@
               w ^FAIWriter (writer out-fai)]
     (try
       (writer/write-index! r w)
-      (catch Exception e (do
-                           (cio/delete-file (.url w))
-                           (logging/error "Failed to create FASTA index")
-                           (throw e))))))
+      (catch Exception e
+        (cio/delete-file (.url w))
+        (logging/error "Failed to create FASTA index")
+        (throw e)))))
 
 ;;;; Reading
 

--- a/src/cljam/io/pileup.clj
+++ b/src/cljam/io/pileup.clj
@@ -136,19 +136,19 @@
       (.append w (if reverse? \, \.))
       (.append w (unchecked-char (case-base-fn base))))
     (when deletion
-      (do (.append w \-)
-          (.append w (String/valueOf ^int deletion))
-          (.append w ^String (case-fn
-                              (if ref-reader
-                                (->> {:chr rname
-                                      :start (inc ref-pos)
-                                      :end (+ ref-pos deletion)}
-                                     (cseq/read-sequence ref-reader))
-                                (apply str (repeat deletion \N)))))))
+      (.append w \-)
+      (.append w (String/valueOf ^int deletion))
+      (.append w ^String (case-fn
+                          (if ref-reader
+                            (->> {:chr rname
+                                  :start (inc ref-pos)
+                                  :end (+ ref-pos deletion)}
+                                 (cseq/read-sequence ref-reader))
+                            (apply str (repeat deletion \N))))))
     (when insertion
-      (do (.append w \+)
-          (.append w (String/valueOf (count insertion)))
-          (.append w ^String (case-fn insertion))))
+      (.append w \+)
+      (.append w (String/valueOf (count insertion)))
+      (.append w ^String (case-fn insertion)))
     (when end?
       (.append w \$))))
 

--- a/src/cljam/io/sam/util.clj
+++ b/src/cljam/io/sam/util.clj
@@ -5,9 +5,7 @@
             [cljam.io.sam.util.cigar :as cigar]
             [cljam.io.util.bin :as util-bin]
             [cljam.io.sam.util.option :as opt])
-  (:import [java.nio CharBuffer ByteBuffer]
-           [java.nio.charset StandardCharsets]
-           [cljam.io.protocols SAMAlignment]))
+  (:import [cljam.io.protocols SAMAlignment]))
 
 (def ^:const linear-index-shift 14)
 (def ^:const linear-index-depth 5)

--- a/src/cljam/io/sam/util/refs.clj
+++ b/src/cljam/io/sam/util/refs.clj
@@ -32,4 +32,4 @@
 (defn ref-by-name
   "Returns the first reference which has the specified name."
   [refs name]
-  (some #(if (= (:name %) name) %) refs))
+  (some #(when (= (:name %) name) %) refs))

--- a/src/cljam/io/sam/util/sequence.clj
+++ b/src/cljam/io/sam/util/sequence.clj
@@ -33,7 +33,7 @@
         result-len (quot (inc length) 2)
         in-bb (ByteBuffer/wrap b)
         out-bb (ByteBuffer/allocate result-len)]
-    (dotimes [i result-len]
+    (dotimes [_ result-len]
       (let [u (.get in-bb)
             l (byte (if (.hasRemaining in-bb) (.get in-bb) \=))]
         (->> (bit-and 0x7F l)

--- a/src/cljam/io/twobit/writer.clj
+++ b/src/cljam/io/twobit/writer.clj
@@ -76,14 +76,6 @@
             (recur (conj! r [p l]) nil nil (inc i))
             (recur r nil nil (inc i))))))))
 
-(defn- index-size
-  "Number of bytes required for index."
-  [seqs]
-  (-> (fn [{:keys [name]}]
-        (+ 1 (count name) 4))
-      map
-      (transduce + 0 seqs)))
-
 (defn- write-index!
   [w idx]
   (loop [offset (+ (* 4 4) (reduce + (map #(+ 1 (count (:name %)) 4) idx)))
@@ -173,7 +165,7 @@
             seq-data (or (:seq sequence) (:sequence sequence))
             masks (mask-regions seq-data)
             ambs (amb-regions seq-data)
-            i (first (keep-indexed #(if (= (:name %2) name) %1) @idx-atom))]
+            i (first (keep-indexed #(when (= (:name %2) name) %1) @idx-atom))]
         (swap! idx-atom update i assoc :masks masks :ambs ambs))
       (write-sequence! (.writer wtr) sequence @idx-atom))
     ;; finalize

--- a/src/cljam/io/util/lsb.clj
+++ b/src/cljam/io/util/lsb.clj
@@ -1,7 +1,7 @@
 (ns cljam.io.util.lsb
   "Reading/writing functions of stream and buffer for little-endian data."
   (:refer-clojure :exclude [read-string])
-  (:require [cljam.util :refer [string->bytes bytes->string]])
+  (:require [cljam.util :refer [string->bytes]])
   (:import [java.io DataInput InputStream DataOutputStream EOFException ByteArrayOutputStream]
            [java.nio Buffer ByteBuffer ByteOrder]))
 

--- a/src/cljam/io/vcf.clj
+++ b/src/cljam/io/vcf.clj
@@ -18,8 +18,7 @@
            cljam.io.vcf.reader.VCFReader
            cljam.io.vcf.writer.VCFWriter
            cljam.io.bcf.reader.BCFReader
-           cljam.io.bcf.writer.BCFWriter
-           bgzf4j.BGZFInputStream))
+           cljam.io.bcf.writer.BCFWriter))
 
 ;; Reading
 ;; -------
@@ -37,7 +36,7 @@
                   (bgzf/bgzf-input-stream f)
                   (cio/reader (util/compressor-input-stream f)))
                 (delay (try (csi/read-index (str f ".csi"))
-                            (catch FileNotFoundException e
+                            (catch FileNotFoundException _
                               (tabix/read-index (str f ".tbi"))))))))
 
 (defn ^BCFReader bcf-reader

--- a/src/cljam/io/vcf/writer.clj
+++ b/src/cljam/io/vcf/writer.clj
@@ -148,7 +148,7 @@
 
 (defn- write-meta-info1
   [^VCFWriter wtr k v]
-  (if-not (nil? v)
+  (when-not (nil? v)
     (if (sequential? v)
       (doseq [x v]
         (write-line (.writer wtr) (str meta-info-prefix
@@ -182,12 +182,12 @@
 
 (defn- stringify-data-line-alt
   [v]
-  (if v
+  (when v
     (cstr/join \, v)))
 
 (defn- stringify-data-line-qual
   [x]
-  (if x
+  (when x
     (if (zero? (mod x 1))
       (str (int x))
       (str x))))

--- a/src/cljam/io/wig.clj
+++ b/src/cljam/io/wig.clj
@@ -169,9 +169,7 @@
                                        #(- (:end %) (:start %))))
                    (map
                     (fn [[{{:keys [line format span step]} :track
-                           chr :chr
-                           start :start
-                           end :end} :as xs]]
+                           chr :chr start :start} :as xs]]
                       (case format
                         :variable-step
                         (let [declaration-line (->> (cond-> ["variableStep"

--- a/src/cljam/tools/cli.clj
+++ b/src/cljam/tools/cli.clj
@@ -323,7 +323,7 @@
 
 ;; ### version command
 
-(defn version [args]
+(defn version [_]
   (let [ver (with-open [r (-> "META-INF/maven/cljam/cljam/pom.properties"
                               (clojure.java.io/resource)
                               (clojure.java.io/reader))]

--- a/src/cljam/util.clj
+++ b/src/cljam/util.clj
@@ -1,6 +1,6 @@
 (ns cljam.util
   "General utilities."
-  (:require [clojure.java.io :refer [file] :as cio])
+  (:require [clojure.java.io :as cio])
   (:import [java.net MalformedURLException URL]
            [java.nio.file Files FileVisitor FileVisitResult]
            [java.nio.file.attribute FileAttribute]

--- a/src/cljam/util/chromosome.clj
+++ b/src/cljam/util/chromosome.clj
@@ -43,7 +43,7 @@
              normalize-name
              prepend-chromosome-prefix
              normalize-chromosome-prefix)
-         (if version-suffix (cstr/lower-case version-suffix)))))
+         (when version-suffix (cstr/lower-case version-suffix)))))
 
 (defn is-primary-chromosome?
   [s]

--- a/test/cljam/algo/bam_indexer_test.clj
+++ b/test/cljam/algo/bam_indexer_test.clj
@@ -1,8 +1,27 @@
 (ns cljam.algo.bam-indexer-test
   "Tests for cljam.algo.bam-indexer."
-  (:require [clojure.test :refer :all]
+  (:require [clojure.test :refer [deftest is are use-fixtures]]
             [clojure.java.io :as cio]
-            [cljam.test-common :refer :all]
+            [cljam.test-common :refer
+             [deftest-slow
+              deftest-remote
+              disable-log-fixture
+              with-before-after
+              prepare-cache!
+              prepare-cavia!
+              clean-cache!
+              not-throw?
+              same-file?
+              spit-bam-for-test
+              temp-dir
+              test-bai-file
+              test-sorted-bam-file
+              test-sam-sorted-by-pos
+              test-sam-incomplete-alignments
+              test-sam-incomplete-alignments-sorted-by-pos
+              small-bam-file
+              medium-bam-file
+              large-bam-file]]
             [cljam.io.sam :as sam]
             [cljam.algo.sorter :as sorter]
             [cljam.algo.bam-indexer :as bai]))

--- a/test/cljam/algo/convert_test.clj
+++ b/test/cljam/algo/convert_test.clj
@@ -1,7 +1,22 @@
 (ns cljam.algo.convert-test
-  (:require [clojure.test :refer :all]
+  (:require [clojure.test :refer [deftest is are testing]]
             [clojure.string :as cstr]
-            [cljam.test-common :refer :all]
+            [cljam.test-common :refer
+             [with-before-after
+              prepare-cache!
+              clean-cache!
+              not-throw?
+              same-sam-contents?
+              same-sequence-contents?
+              temp-dir
+              test-sam-file
+              test-bam-file
+              test-paired-bam-file
+              test-fa-file
+              test-twobit-file
+              test-fq-file
+              test-fq-r1-file
+              test-fq-r2-file]]
             [cljam.algo.convert :as convert]
             [cljam.io.sequence :as cseq]
             [cljam.io.fastq :as fq]

--- a/test/cljam/algo/dedupe_test.clj
+++ b/test/cljam/algo/dedupe_test.clj
@@ -1,14 +1,15 @@
 (ns cljam.algo.dedupe-test
-  (:require [clojure.test :refer :all]
-            [cljam.test-common :refer :all]
+  (:require [clojure.test :refer [deftest is]]
+            [cljam.test-common :as common]
             [cljam.algo.dedupe :as dedupe]))
 
 (deftest simple-pe-dedupe
-  (with-before-after {:before (prepare-cache!)
-                      :after (clean-cache!)}
-    (let [out-file (str temp-dir "/deduped.bam")]
-      (is (not-throw? (dedupe/dedupe dedupe-before-bam-file out-file)))
-      (is (same-sam-contents? out-file dedupe-after-bam-file)))))
+  (common/with-before-after {:before (common/prepare-cache!)
+                             :after (common/clean-cache!)}
+    (let [out-file (str common/temp-dir "/deduped.bam")]
+      (is (common/not-throw?
+           (dedupe/dedupe common/dedupe-before-bam-file out-file)))
+      (is (common/same-sam-contents? out-file common/dedupe-after-bam-file)))))
 
 (deftest simple-pe-dedupe-xform
   (is (= (into #{}

--- a/test/cljam/algo/depth_test.clj
+++ b/test/cljam/algo/depth_test.clj
@@ -1,9 +1,9 @@
 (ns cljam.algo.depth-test
-  (:require [clojure.test :refer :all]
+  (:require [clojure.test :refer [deftest is are testing]]
             [cljam.test-common :as common]
             [cljam.io.sam :as sam]
             [cljam.algo.depth :as depth])
-  (:import [clojure.lang LazySeq ArraySeq]))
+  (:import [clojure.lang LazySeq]))
 
 (def test-bam-depth-ref
   [0 0 0 0 0 0 1 1 3 3 3 3 3 3 2 3 3 3 2 2 2 2 1 1 1 1 1 1 2 2 2 2 2 1 1 1 2 2 2 2 1 1 1 1 1])

--- a/test/cljam/algo/dict_test.clj
+++ b/test/cljam/algo/dict_test.clj
@@ -1,9 +1,9 @@
 (ns cljam.algo.dict-test
   "Tests for cljam.algo.dict."
-  (:require [clojure.test :refer :all]
+  (:require [clojure.test :refer [deftest is]]
             [clojure.string :as string]
             [clojure.java.io :as cio]
-            [cljam.test-common :refer :all]
+            [cljam.test-common :as common]
             [cljam.algo.dict :as dict]))
 
 (defn same-dict-file? [f1 f2]
@@ -24,18 +24,19 @@
 ;; Resources
 ;; ---------
 
-(def temp-fa-file (str temp-dir "/test.fa"))
+(def temp-fa-file (str common/temp-dir "/test.fa"))
 (def out-dict-file (str temp-fa-file ".dict"))
 
 ;; Small-size FASTA
 ;; ---------------------------------
 
 (deftest about-create-dict
-  (with-before-after {:before (do (prepare-cache!)
-                                  (cio/copy (cio/file test-fa-file)
-                                            (cio/file temp-fa-file)))
-                      :after (clean-cache!)}
+  (common/with-before-after
+    {:before (do (common/prepare-cache!)
+                 (cio/copy (cio/file common/test-fa-file)
+                           (cio/file temp-fa-file)))
+     :after (common/clean-cache!)}
     ;; Create dictionary without errors
-    (is (not-throw? (dict/create-dict temp-fa-file out-dict-file)))
+    (is (common/not-throw? (dict/create-dict temp-fa-file out-dict-file)))
     ;; Check the file contents
-    (is (same-dict-file? out-dict-file test-fa-dict-file))))
+    (is (same-dict-file? out-dict-file common/test-fa-dict-file))))

--- a/test/cljam/algo/fasta_indexer_test.clj
+++ b/test/cljam/algo/fasta_indexer_test.clj
@@ -1,26 +1,30 @@
 (ns cljam.algo.fasta-indexer-test
   "Tests for cljam.fasta-indexer."
-  (:require [clojure.test :refer :all]
+  (:require [clojure.test :refer [deftest is]]
             [clojure.java.io :as cio]
-            [cljam.test-common :refer :all]
+            [cljam.test-common :as common]
             [cljam.algo.fasta-indexer :as fai]))
 
-(def temp-fa-file (str temp-dir "/test.fa"))
+(def temp-fa-file (str common/temp-dir "/test.fa"))
 
 (deftest about-fasta-indexer
-  (with-before-after {:before (do (prepare-cache!)
-                                  (cio/copy (cio/file test-fa-file)
-                                            (cio/file temp-fa-file)))
-                      :after (clean-cache!)}
-    (is (not-throw? (fai/create-index temp-fa-file (str temp-fa-file ".fai"))))
+  (common/with-before-after
+    {:before (do (common/prepare-cache!)
+                 (cio/copy (cio/file common/test-fa-file)
+                           (cio/file temp-fa-file)))
+     :after (common/clean-cache!)}
+    (is (common/not-throw?
+         (fai/create-index temp-fa-file (str temp-fa-file ".fai"))))
     (is (.isFile (cio/file (str temp-fa-file ".fai"))))
-    (is (same-file? (str temp-fa-file ".fai") test-fai-file))))
+    (is (common/same-file? (str temp-fa-file ".fai") common/test-fai-file))))
 
-(deftest-slow about-fasta-indexer-medium-file
-  (with-before-after {:before (do (prepare-cache!)
-                                  (cio/copy (cio/file medium-fa-file)
-                                            (cio/file temp-fa-file)))
-                      :after (clean-cache!)}
-    (is (not-throw? (fai/create-index temp-fa-file (str temp-fa-file ".fai"))))
+(common/deftest-slow about-fasta-indexer-medium-file
+  (common/with-before-after
+    {:before (do (common/prepare-cache!)
+                 (cio/copy (cio/file common/medium-fa-file)
+                           (cio/file temp-fa-file)))
+     :after (common/clean-cache!)}
+    (is (common/not-throw?
+         (fai/create-index temp-fa-file (str temp-fa-file ".fai"))))
     (is (.isFile (cio/file (str temp-fa-file ".fai"))))
-    (is (same-file? (str temp-fa-file ".fai") medium-fai-file))))
+    (is (common/same-file? (str temp-fa-file ".fai") common/medium-fai-file))))

--- a/test/cljam/algo/normal_test.clj
+++ b/test/cljam/algo/normal_test.clj
@@ -1,7 +1,17 @@
 (ns cljam.algo.normal-test
-  (:require [clojure.test :refer :all]
-            [cljam.test-common :refer :all]
-            [cljam.algo.normal :refer :all]
+  (:require [clojure.test :refer [deftest is testing]]
+            [cljam.test-common :refer
+             [with-before-after
+              prepare-cache!
+              clean-cache!
+              not-throw?
+              same-sam-contents?
+              temp-dir
+              normalize-before-sam-file
+              normalize-after-sam-file
+              normalize-before-bam-file
+              normalize-after-bam-file]]
+            [cljam.algo.normal :as normal]
             [cljam.io.sam :as sam]))
 
 (def temp-sam (str temp-dir "/out.sam"))
@@ -13,26 +23,26 @@
                         :after (clean-cache!)}
       (with-open [rdr (sam/reader normalize-before-sam-file)
                   wtr (sam/writer temp-sam)]
-        (is (not-throw? (normalize rdr wtr))))
+        (is (not-throw? (normal/normalize rdr wtr))))
       (is (same-sam-contents? temp-sam normalize-after-sam-file))))
   (testing "bam -> bam"
     (with-before-after {:before (prepare-cache!)
                         :after (clean-cache!)}
       (with-open [rdr (sam/reader normalize-before-bam-file)
                   wtr (sam/writer temp-bam)]
-        (is (not-throw? (normalize rdr wtr))))
+        (is (not-throw? (normal/normalize rdr wtr))))
       (is (same-sam-contents? temp-bam normalize-after-bam-file))))
   (testing "sam -> bam"
     (with-before-after {:before (prepare-cache!)
                         :after (clean-cache!)}
       (with-open [rdr (sam/reader normalize-before-sam-file)
                   wtr (sam/writer temp-bam)]
-        (is (not-throw? (normalize rdr wtr))))
+        (is (not-throw? (normal/normalize rdr wtr))))
       (is (same-sam-contents? temp-bam normalize-after-bam-file))))
   (testing "bam -> sam"
     (with-before-after {:before (prepare-cache!)
                         :after (clean-cache!)}
       (with-open [rdr (sam/reader normalize-before-bam-file)
                   wtr (sam/writer temp-sam)]
-        (is (not-throw? (normalize rdr wtr))))
+        (is (not-throw? (normal/normalize rdr wtr))))
       (is (same-sam-contents? temp-sam normalize-after-sam-file)))))

--- a/test/cljam/algo/sorter_test.clj
+++ b/test/cljam/algo/sorter_test.clj
@@ -1,6 +1,27 @@
 (ns cljam.algo.sorter-test
-  (:require [clojure.test :refer :all]
-            [cljam.test-common :refer :all]
+  (:require [clojure.test :refer [deftest is use-fixtures]]
+            [cljam.test-common
+             :refer [deftest-slow
+                     deftest-remote
+                     disable-log-fixture
+                     get-shuffled-test-sam
+                     spit-sam-for-test
+                     spit-bam-for-test
+                     slurp-sam-for-test
+                     slurp-bam-for-test
+                     with-before-after
+                     prepare-cache!
+                     prepare-cavia!
+                     clean-cache!
+                     not-throw?
+                     check-sort-order
+                     qname-sorted?
+                     coord-sorted?
+                     temp-dir
+                     test-sam-file
+                     test-bam-file
+                     medium-bam-file
+                     large-bam-file]]
             [cljam.io.sam :as sam]
             [cljam.algo.sorter :as sorter]
             [cljam.io.sam.util.header :as header])

--- a/test/cljam/algo/vcf_indexer_test.clj
+++ b/test/cljam/algo/vcf_indexer_test.clj
@@ -1,9 +1,24 @@
 (ns cljam.algo.vcf-indexer-test
   "Tests for cljam.algo.bam-indexer."
-  (:require [clojure.test :refer :all]
+  (:require [clojure.test :refer [deftest is]]
             [clojure.string :as cstr]
             [clojure.java.io :as cio]
-            [cljam.test-common :refer :all]
+            [cljam.test-common :refer
+             [deftest-remote
+              temp-dir
+              with-before-after
+              prepare-cache!
+              prepare-cavia!
+              clean-cache!
+              not-throw?
+              test-large-vcf-file
+              test-large-vcf-csi-file
+              test-vcf-complex-gz-file
+              test-vcf-changed-chr-order-file
+              test-vcf-changed-chr-order-field-less-file
+              test-vcf-chr-skipped-file
+              test-vcf-various-bins-gz-file
+              test-vcf-various-bins-csi-file]]
             [cljam.io.csi :as csi]
             [cljam.io.vcf :as vcf]
             [cljam.algo.vcf-indexer :as vcf-indexer])

--- a/test/cljam/io/bam_index_test.clj
+++ b/test/cljam/io/bam_index_test.clj
@@ -1,8 +1,16 @@
 (ns cljam.io.bam-index-test
   "Tests for cljam.io.bam-index."
   (:require [clojure.java.io :as cio]
-            [clojure.test :refer :all]
-            [cljam.test-common :refer :all]
+            [clojure.test :refer [deftest is are]]
+            [cljam.test-common :refer
+             [deftest-remote
+              with-before-after
+              prepare-cavia!
+              not-throw?
+              just-map?
+              http-server
+              test-bai-file
+              test-large-bai-file]]
             [cljam.io.bam-index :as bai]))
 
 ;;; bin-index

--- a/test/cljam/io/bcf/reader_test.clj
+++ b/test/cljam/io/bcf/reader_test.clj
@@ -1,5 +1,5 @@
 (ns cljam.io.bcf.reader-test
-  (:require [clojure.test :refer :all]
+  (:require [clojure.test :refer [deftest are]]
             [cljam.io.bcf.reader :as bcf-reader])
   (:import [java.nio ByteBuffer ByteOrder]))
 

--- a/test/cljam/io/bcf/writer_test.clj
+++ b/test/cljam/io/bcf/writer_test.clj
@@ -1,10 +1,14 @@
 (ns cljam.io.bcf.writer-test
-  (:require [clojure.test :refer :all]
+  (:require [clojure.test :refer [deftest is are]]
             [clojure.java.io :as cio]
             [clojure.string :as cstr]
             [cljam.io.bcf.writer :as bcf-writer]
             [cljam.io.util.bgzf :as bgzf]
-            [cljam.test-common :refer :all])
+            [cljam.test-common :refer
+             [with-before-after
+              prepare-cache!
+              clean-cache!
+              temp-dir]])
   (:import [java.nio ByteBuffer ByteOrder]
            [java.io ByteArrayOutputStream File]))
 

--- a/test/cljam/io/bed_test.clj
+++ b/test/cljam/io/bed_test.clj
@@ -1,7 +1,20 @@
 (ns cljam.io.bed-test
   (:require [clojure.java.io :as cio]
-            [clojure.test :refer :all]
-            [cljam.test-common :refer :all]
+            [clojure.test :refer [deftest is are testing]]
+            [cljam.test-common :refer
+             [with-before-after
+              prepare-cache!
+              clean-cache!
+              not-throw?
+              http-server
+              temp-dir
+              test-bed-file1
+              test-bed-file1-gz
+              test-bed-file2
+              test-bed-file2-bz2
+              test-bed-file3
+              test-sorted-bam-file
+              medium-fa-file]]
             [cljam.io.bed :as bed]
             [cljam.io.sam :as sam]
             [cljam.io.sam.util :as sam-util]
@@ -13,13 +26,13 @@
 (defn- str->bed [^String s]
   (with-open [bais (ByteArrayInputStream. (.getBytes s))
               isr (InputStreamReader. bais)
-              br (bed/BEDReader. (BufferedReader. isr) nil)]
+              br (BEDReader. (BufferedReader. isr) nil)]
     (doall (bed/read-fields br))))
 
 (defn- bed->str [xs]
   (with-open [bao (ByteArrayOutputStream.)
               osw (OutputStreamWriter. bao)
-              bw (bed/BEDWriter. (BufferedWriter. osw) nil)]
+              bw (BEDWriter. (BufferedWriter. osw) nil)]
     (bed/write-fields bw xs)
     (.flush ^BufferedWriter (.writer bw))
     (.toString bao)))
@@ -339,7 +352,7 @@
       (are [x] (with-before-after {:before (prepare-cache!)
                                    :after (clean-cache!)}
                  (with-open [rdr (bed/reader test-bed-file1)
-                             wtr (bed/writer temp-file)]
+                             wtr (bed/writer x)]
                    (not-throw? (bed/write-fields wtr (bed/read-fields rdr)))))
         temp-file
         (cio/file temp-file)

--- a/test/cljam/io/bigwig_test.clj
+++ b/test/cljam/io/bigwig_test.clj
@@ -1,10 +1,15 @@
 (ns cljam.io.bigwig-test
-  (:require [clojure.test :refer :all]
+  (:require [clojure.test :refer [deftest is are testing]]
             [clojure.java.io :as cio]
-            [cljam.test-common :refer :all]
+            [cljam.test-common :refer
+             [http-server
+              test-bigwig-variable-file
+              test-bigwig-fixed-file
+              test-bigwig-bedgraph-file
+              test-bigwig-non-leaf-blocks-file]]
             [cljam.io.bigwig :as bigwig])
-  (:import [cljam.io.bigwig BIGWIGReader BigWigHeaders FixedWidthHeader
-            ZoomHeader TotalSummary ExtendedHeader BptHeader BbiChromInfo
+  (:import [cljam.io.bigwig BigWigHeaders FixedWidthHeader
+            ZoomHeader TotalSummary BptHeader BbiChromInfo
             CirTree]))
 
 (def ^:private ^BigWigHeaders test-bigwig-fixed-fields

--- a/test/cljam/io/csi_test.clj
+++ b/test/cljam/io/csi_test.clj
@@ -1,7 +1,17 @@
 (ns cljam.io.csi-test
   (:require [clojure.java.io :as cio]
-            [clojure.test :refer :all]
-            [cljam.test-common :refer :all]
+            [clojure.test :refer [deftest is are]]
+            [cljam.test-common :refer
+             [deftest-remote
+              with-before-after
+              prepare-cache!
+              prepare-cavia!
+              clean-cache!
+              http-server
+              temp-dir
+              small-bam-file
+              test-csi-file
+              test-large-vcf-csi-file]]
             [cljam.io.csi :as csi])
   (:import
    [cljam.io.csi CSI]))

--- a/test/cljam/io/fasta/core_test.clj
+++ b/test/cljam/io/fasta/core_test.clj
@@ -1,7 +1,18 @@
 (ns cljam.io.fasta.core-test
-  (:require [clojure.test :refer :all]
+  (:require [clojure.test :refer [deftest is are]]
             [clojure.string :as cstr]
-            [cljam.test-common :refer :all]
+            [cljam.test-common :refer
+             [not-throw?
+              temp-dir
+              test-fa-file
+              test-fa-bz2-file
+              test-fa-header
+              test-fa-sequences
+              test-fa-data
+              test-tabix-file
+              medium-fa-file
+              medium-fa-gz-file
+              medium-fa-bgz-file]]
             [cljam.io.fasta.core :as fa-core]))
 
 (def temp-test-fa-file (str temp-dir "/test.fa"))

--- a/test/cljam/io/fastq_test.clj
+++ b/test/cljam/io/fastq_test.clj
@@ -1,6 +1,17 @@
 (ns cljam.io.fastq-test
-  (:require [clojure.test :refer :all]
-            [cljam.test-common :refer :all]
+  (:require [clojure.test :refer [deftest is are testing]]
+            [cljam.test-common :refer
+             [with-before-after
+              prepare-cache!
+              clean-cache!
+              not-throw?
+              http-server
+              temp-dir
+              test-fq-file
+              test-fq-sequences
+              test-fq-sequences-raw
+              test-fq-gz-file
+              test-fq-bz2-file]]
             [clojure.java.io :as cio]
             [cljam.io.fastq :as fq]))
 

--- a/test/cljam/io/gff_test.clj
+++ b/test/cljam/io/gff_test.clj
@@ -1,8 +1,15 @@
 (ns cljam.io.gff-test
-  (:require [clojure.test :refer :all]
+  (:require [clojure.test :refer [deftest is are testing]]
             [clojure.string :as cstr]
             [clojure.java.io :as cio]
-            [cljam.test-common :refer :all]
+            [cljam.test-common :refer
+             [with-before-after
+              prepare-cache!
+              clean-cache!
+              not-throw?
+              http-server
+              temp-dir
+              test-gff3-file]]
             [cljam.io.gff :as gff])
   (:import [java.io ByteArrayInputStream ByteArrayOutputStream]
            [cljam.io.gff GFFReader GFFWriter]))

--- a/test/cljam/io/pileup_test.clj
+++ b/test/cljam/io/pileup_test.clj
@@ -1,9 +1,16 @@
 (ns cljam.io.pileup-test
-  (:require [clojure.test :refer :all]
+  (:require [clojure.test :refer [deftest is are testing]]
             [clojure.java.io :as cio]
             [clojure.string :as cstr]
             [clojure.walk :as walk]
-            [cljam.test-common :refer :all]
+            [cljam.test-common :refer
+             [with-before-after
+              prepare-cache!
+              clean-cache!
+              not-throw?
+              http-server
+              temp-dir
+              test-pileup-file]]
             [cljam.io.pileup :as plpio]
             [cljam.io.sequence :as cseq]
             [cljam.io.fasta-index.core :as fai]

--- a/test/cljam/io/sam/util/cigar_test.clj
+++ b/test/cljam/io/sam/util/cigar_test.clj
@@ -1,5 +1,5 @@
 (ns cljam.io.sam.util.cigar-test
-  (:require [clojure.test :refer :all]
+  (:require [clojure.test :refer [deftest is are]]
             [cljam.io.sam.util.cigar :as cigar])
   (:import [java.nio ByteBuffer ByteOrder]))
 

--- a/test/cljam/io/sam/util/flag_test.clj
+++ b/test/cljam/io/sam/util/flag_test.clj
@@ -1,5 +1,5 @@
 (ns cljam.io.sam.util.flag-test
-  (:require [clojure.test :refer :all]
+  (:require [clojure.test :refer [deftest are testing]]
             [cljam.io.sam.util.flag :as flag]))
 
 (deftest flags

--- a/test/cljam/io/sam/util/header_test.clj
+++ b/test/cljam/io/sam/util/header_test.clj
@@ -1,5 +1,5 @@
 (ns cljam.io.sam.util.header-test
-  (:require [clojure.test :refer :all]
+  (:require [clojure.test :refer [deftest is]]
             [cljam.io.sam.util.header :as header]))
 
 (deftest into-rf

--- a/test/cljam/io/sam/util/option_test.clj
+++ b/test/cljam/io/sam/util/option_test.clj
@@ -1,5 +1,5 @@
 (ns cljam.io.sam.util.option-test
-  (:require [clojure.test :refer :all]
+  (:require [clojure.test :refer [deftest is are testing]]
             [cljam.io.sam.util.option :as opt]))
 
 (deftest parse-optional-field

--- a/test/cljam/io/sam/util/refs_test.clj
+++ b/test/cljam/io/sam/util/refs_test.clj
@@ -1,6 +1,6 @@
 (ns cljam.io.sam.util.refs-test
-  (:require [clojure.test :refer :all]
-            [cljam.test-common :refer :all]
+  (:require [clojure.test :refer [deftest is are]]
+            [cljam.test-common :refer [test-sam]]
             [cljam.io.sam.util.refs :as refs]))
 
 ;; Reference functions

--- a/test/cljam/io/sam/util/sequence_test.clj
+++ b/test/cljam/io/sam/util/sequence_test.clj
@@ -1,5 +1,5 @@
 (ns cljam.io.sam.util.sequence-test
-  (:require [clojure.test :refer :all]
+  (:require [clojure.test :refer [deftest is are]]
             [clojure.string :as cstr]
             [cljam.io.sam.util.sequence :as sam-seq]
             [cljam.util :as util]))

--- a/test/cljam/io/sam_test.clj
+++ b/test/cljam/io/sam_test.clj
@@ -1,7 +1,41 @@
 (ns cljam.io.sam-test
-  (:require [clojure.test :refer :all]
+  (:require [clojure.test :refer [deftest is are testing]]
             [clojure.java.io :as cio]
-            [cljam.test-common :refer :all]
+            [cljam.test-common :refer
+             [deftest-slow
+              deftest-remote
+              with-before-after
+              prepare-cache!
+              prepare-cavia!
+              clean-cache!
+              slurp-sam-for-test
+              slurp-bam-for-test
+              spit-sam-for-test
+              spit-bam-for-test
+              not-throw?
+              same-file?
+              data->clj
+              http-server
+              temp-dir
+              test-sam-file
+              test-bam-file
+              test-sam
+              test-sam-data
+              test-sam-refs
+              test-sam-sorted-by-pos
+              test-sorted-bam-file
+              test-sorted-bam-data
+              small-bam-file
+              medium-bam-file
+              medium-sam-refs
+              large-bam-file
+              large-sam-refs
+              opts-sam-file
+              opts-bam-file
+              test-sam-blocks
+              test-bai-file
+              test-fa-file
+              test-tabix-file]]
             [cljam.io.sam :as sam]
             [cljam.io.protocols :as protocols]))
 

--- a/test/cljam/io/sequence_test.clj
+++ b/test/cljam/io/sequence_test.clj
@@ -1,8 +1,26 @@
 (ns cljam.io.sequence-test
-  (:require [clojure.test :refer :all]
+  (:require [clojure.test :refer [deftest is are testing]]
             [clojure.java.io :as cio]
             [clojure.string :as cstr]
-            [cljam.test-common :refer :all]
+            [cljam.test-common :refer
+             [with-before-after
+              prepare-cache!
+              clean-cache!
+              not-throw?
+              same-file?
+              same-sequence-contents?
+              http-server
+              temp-dir
+              test-fa-file
+              test-fai-file
+              test-twobit-file
+              test-twobit-n-file
+              test-twobit-be-file
+              test-twobit-be-n-file
+              medium-fa-file
+              medium-fai-file
+              medium-fa-bgz-file
+              medium-twobit-file]]
             [cljam.io.fasta.core :as fa-core]
             [cljam.io.sequence :as cseq]
             [cljam.io.protocols :as protocols]))
@@ -155,12 +173,17 @@
       (is (= (for [i (range 1 45) j (range i 46)]
                (cseq/read-sequence r {:chr "ref" :start i :end j}))
              (for [i (range 1 45) j (range i 46)]
+               (cseq/read-sequence c {:chr "ref" :start i :end j}))
+             (for [i (range 1 45) j (range i 46)]
                (subs "AGCATGTTAGATAAGATAGCTGTGCTAGTAGGCAGTCAGCGCCAT" (dec i) j))))
       (is (= (protocols/read-in-region r {:chr "ref2" :start 1 :end 40})
+             (protocols/read-in-region c {:chr "ref2" :start 1 :end 40})
              "AGGTTTTATAAAACAATTAAGTCTACAGAGCAACTACGCG"))
       (is (= (protocols/read-in-region r {:chr "ref2" :start 1 :end 40} {:mask? false})
+             (protocols/read-in-region c {:chr "ref2" :start 1 :end 40} {:mask? false})
              "AGGTTTTATAAAACAATTAAGTCTACAGAGCAACTACGCG"))
       (is (= (protocols/read-in-region r {:chr "ref2" :start 1 :end 40} {:mask? true})
+             (protocols/read-in-region c {:chr "ref2" :start 1 :end 40} {:mask? true})
              "aggttttataaaacaattaagtctacagagcaactacgcg"))))
   (testing "reference test with N"
     (with-open [r (cseq/twobit-reader test-twobit-n-file)

--- a/test/cljam/io/tabix_test.clj
+++ b/test/cljam/io/tabix_test.clj
@@ -1,7 +1,15 @@
 (ns cljam.io.tabix-test
   (:require [clojure.java.io :as cio]
-            [clojure.test :refer :all]
-            [cljam.test-common :refer :all]
+            [clojure.test :refer [deftest is are]]
+            [cljam.test-common :refer
+             [deftest-remote
+              with-before-after
+              prepare-cavia!
+              not-throw?
+              http-server
+              small-bam-file
+              test-tabix-file
+              test-large-tabix-file]]
             [cljam.io.tabix :as tbi])
   (:import
    [cljam.io.tabix Tabix]

--- a/test/cljam/io/util/bgzf/gzi_test.clj
+++ b/test/cljam/io/util/bgzf/gzi_test.clj
@@ -1,5 +1,5 @@
 (ns cljam.io.util.bgzf.gzi-test
-  (:require [clojure.test :refer :all]
+  (:require [clojure.test :refer [deftest is are]]
             [cljam.test-common :as common]
             [cljam.io.util.bgzf.gzi :as gzi]))
 

--- a/test/cljam/io/util/bin_test.clj
+++ b/test/cljam/io/util/bin_test.clj
@@ -1,7 +1,9 @@
 (ns cljam.io.util.bin-test
   "Tests for cljam.io.util.bin."
-  (:require [clojure.test :refer :all]
-            [cljam.test-common :refer :all]
+  (:require [clojure.test :refer [deftest is are testing]]
+            [cljam.test-common :refer
+             [test-tabix-file
+              test-csi-file]]
             [cljam.io.tabix :as tabix]
             [cljam.io.csi :as csi]
             [cljam.io.util.bin :as util-bin]))

--- a/test/cljam/io/util/lsb_test.clj
+++ b/test/cljam/io/util/lsb_test.clj
@@ -1,10 +1,9 @@
 (ns cljam.io.util.lsb-test
-  (:require [clojure.test :refer :all]
+  (:require [clojure.test :refer [deftest is]]
             [clojure.java.io :as cio]
             [cljam.test-common :as common]
             [cljam.io.util.lsb :as lsb])
-  (:import [java.nio ByteBuffer ByteOrder]
-           [java.io RandomAccessFile DataInputStream FileInputStream]
+  (:import [java.io RandomAccessFile DataInputStream FileInputStream]
            [bgzf4j BGZFInputStream BGZFOutputStream]))
 
 (deftest about-byte-buffer

--- a/test/cljam/io/util_test.clj
+++ b/test/cljam/io/util_test.clj
@@ -1,7 +1,60 @@
 (ns cljam.io.util-test
-  (:require [clojure.test :refer :all]
+  (:require [clojure.test :refer [deftest is are testing]]
             [clojure.java.io :as cio]
-            [cljam.test-common :refer :all]
+            [cljam.test-common :refer
+             [with-before-after
+              prepare-cache!
+              clean-cache!
+              temp-dir
+              test-sam-file
+              medium-sam-file
+              medium-bam-file
+              normalize-before-sam-file
+              normalize-after-sam-file
+              normalize-before-bam-file
+              normalize-after-bam-file
+              opts-sam-file
+              opts-bam-file
+              test-bam-file
+              test-paired-bam-file
+              test-sorted-bam-file
+              small-bam-file
+              dedupe-before-bam-file
+              dedupe-after-bam-file
+              test-bai-file
+              test-fa-file
+              test-fa-bz2-file
+              test-fa-dict-file
+              medium-fa-file
+              medium-fa-gz-file
+              test-fai-file
+              medium-fai-file
+              test-twobit-file
+              test-twobit-n-file
+              test-twobit-be-file
+              test-twobit-be-n-file
+              medium-twobit-file
+              test-fq-file
+              test-bed-file1
+              test-bed-file1-gz
+              test-bed-file2
+              test-bed-file2-bz2
+              test-bed-file3
+              test-bed-file4
+              test-bed-file4-bgz
+              test-tabix-file
+              test-vcf-v4_0-file
+              test-vcf-v4_3-file
+              test-pileup-file
+              test-bcf-v4_3-file
+              test-bcf-complex-file
+              test-gff3-file
+              test-wig-file1
+              test-wig-file2
+              test-bigwig-fixed-file
+              test-bigwig-variable-file
+              test-bigwig-bedgraph-file
+              test-bigwig-non-leaf-blocks-file]]
             [cljam.io.bed :as bed]
             [cljam.io.fastq :as fastq]
             [cljam.io.sam :as sam]

--- a/test/cljam/io/vcf/util/check_test.clj
+++ b/test/cljam/io/vcf/util/check_test.clj
@@ -1,5 +1,5 @@
 (ns cljam.io.vcf.util.check-test
-  (:require [clojure.test :refer :all]
+  (:require [clojure.test :refer [deftest are]]
             [cljam.io.protocols :as protocols]
             [cljam.io.vcf.util.check :as check]))
 

--- a/test/cljam/io/vcf/util/normalize_test.clj
+++ b/test/cljam/io/vcf/util/normalize_test.clj
@@ -1,7 +1,7 @@
 (ns cljam.io.vcf.util.normalize-test
   (:require
-   [clojure.test :refer :all]
-   [cljam.test-common :refer :all]
+   [clojure.test :refer [deftest is are testing]]
+   [cljam.test-common :refer [medium-twobit-file]]
    [cljam.io.vcf.util.normalize :as norm]
    [cljam.io.protocols :as protocols]
    [cljam.io.sequence :as io-seq]

--- a/test/cljam/io/vcf/util_test.clj
+++ b/test/cljam/io/vcf/util_test.clj
@@ -1,6 +1,14 @@
 (ns cljam.io.vcf.util-test
-  (:require [clojure.test :refer :all]
-            [cljam.test-common :refer :all]
+  (:require [clojure.test :refer [deftest are]]
+            [cljam.test-common :refer
+             [test-vcf-v4_3-meta-info
+              test-vcf-v4_3-header
+              test-vcf-v4_3-variants
+              test-vcf-v4_3-variants-deep
+              test-vcf-v4_0-meta-info
+              test-vcf-v4_0-header
+              test-vcf-v4_0-variants
+              test-vcf-v4_0-variants-deep]]
             [cljam.io.vcf.util :as vcf-util]))
 
 (deftest about-parse-info

--- a/test/cljam/io/vcf/writer_test.clj
+++ b/test/cljam/io/vcf/writer_test.clj
@@ -1,6 +1,5 @@
 (ns cljam.io.vcf.writer-test
-  (:require [clojure.test :refer :all]
-            [cljam.test-common :refer :all]
+  (:require [clojure.test :refer [deftest is are]]
             [cljam.io.vcf.writer :as vcf-writer])
   (:import [java.io StringWriter BufferedWriter]
            [cljam.io.vcf.writer VCFWriter]))

--- a/test/cljam/io/vcf_test.clj
+++ b/test/cljam/io/vcf_test.clj
@@ -1,7 +1,38 @@
 (ns cljam.io.vcf-test
-  (:require [clojure.test :refer :all]
+  (:require [clojure.test :refer [deftest is are testing]]
             [clojure.java.io :as cio]
-            [cljam.test-common :refer :all]
+            [cljam.test-common :refer
+             [deftest-remote
+              with-before-after
+              prepare-cache!
+              prepare-cavia!
+              clean-cache!
+              not-throw?
+              http-server
+              temp-dir
+              test-bam-file
+              test-vcf-v4_0-file
+              test-vcf-v4_0-meta-info
+              test-vcf-v4_0-header
+              test-vcf-v4_0-variants
+              test-vcf-v4_0-variants-deep
+              test-vcf-v4_3-file
+              test-vcf-v4_3-meta-info
+              test-vcf-v4_3-header
+              test-vcf-v4_3-variants
+              test-vcf-v4_3-variants-deep
+              test-bcf-v4_3-file
+              test-bcf-invalid-file
+              test-vcf-no-samples-file
+              test-vcf-no-samples-variants-deep
+              test-bcf-no-samples-file
+              test-vcf-complex-file
+              test-vcf-complex-gz-file
+              test-bcf-complex-file
+              test-large-vcf-file
+              test-large-bcf-file
+              test-vcf-various-bins-gz-file
+              test-bcf-various-bins-file]]
             [cljam.io.vcf :as vcf])
   (:import bgzf4j.BGZFException))
 
@@ -22,11 +53,11 @@
 
 (deftest bcf-reader-test
   (is (thrown? BGZFException
-               (with-open [r (vcf/bcf-reader test-vcf-v4_3-file)] nil)))
+               (with-open [_ (vcf/bcf-reader test-vcf-v4_3-file)] nil)))
   (is (thrown? java.io.IOException
-               (with-open [r (vcf/bcf-reader test-bam-file)] nil)))
+               (with-open [_ (vcf/bcf-reader test-bam-file)] nil)))
   (is (thrown? java.io.IOException
-               (with-open [r (vcf/bcf-reader test-bcf-invalid-file)] nil))))
+               (with-open [_ (vcf/bcf-reader test-bcf-invalid-file)] nil))))
 
 (deftest reader-test
   (testing "vcf"

--- a/test/cljam/io/wig_test.clj
+++ b/test/cljam/io/wig_test.clj
@@ -1,8 +1,16 @@
 (ns cljam.io.wig-test
-  (:require [clojure.test :refer :all]
+  (:require [clojure.test :refer [deftest is are testing]]
             [clojure.java.io :as cio]
             [clojure.string :as cstr]
-            [cljam.test-common :refer :all]
+            [cljam.test-common :refer
+             [with-before-after
+              prepare-cache!
+              clean-cache!
+              not-throw?
+              http-server
+              temp-dir
+              test-wig-file1
+              test-wig-file2]]
             [cljam.io.wig :as wig])
   (:import [java.io BufferedReader InputStreamReader ByteArrayInputStream
             ByteArrayOutputStream OutputStreamWriter BufferedWriter]
@@ -73,14 +81,14 @@
   [^String s]
   (with-open [bais (ByteArrayInputStream. (.getBytes s))
               isr (InputStreamReader. bais)
-              br (wig/WIGReader. (BufferedReader. isr) nil)]
+              br (WIGReader. (BufferedReader. isr) nil)]
     (doall (wig/read-fields br))))
 
 (defn- wig->str
   [xs]
   (with-open [bao (ByteArrayOutputStream.)
               osw (OutputStreamWriter. bao)
-              bw (wig/WIGWriter. (BufferedWriter. osw) nil)]
+              bw (WIGWriter. (BufferedWriter. osw) nil)]
     (wig/write-fields bw xs)
     (.flush ^BufferedWriter (.writer bw))
     (.toString bao)))

--- a/test/cljam/tools/cli_test.clj
+++ b/test/cljam/tools/cli_test.clj
@@ -1,6 +1,29 @@
 (ns cljam.tools.cli-test
-  (:require [clojure.test :refer :all]
-            [cljam.test-common :refer :all]
+  (:require [clojure.test :refer [deftest is are testing use-fixtures]]
+            [cljam.test-common :refer
+             [with-before-after
+              prepare-cache!
+              clean-cache!
+              not-throw?
+              same-sam-contents?
+              same-sequence-contents?
+              check-sort-order
+              slurp-sam-for-test
+              slurp-bam-for-test
+              disable-log-fixture
+              temp-dir
+              test-sam-file
+              test-bam-file
+              test-sam-sorted-by-pos
+              test-sam-sorted-by-qname
+              test-sorted-bam-file
+              test-fa-file
+              test-twobit-file
+              normalize-before-bam-file
+              normalize-after-bam-file
+              test-pileup-file
+              test-pileup-dir
+              test-sorted-bam-levels]]
             [clojure.java.io :as cio]
             [cljam.tools.cli :as cli]
             [cljam.io.sam :as sam])

--- a/test/cljam/util/chromosome_test.clj
+++ b/test/cljam/util/chromosome_test.clj
@@ -1,5 +1,5 @@
 (ns cljam.util.chromosome-test
-  (:require [clojure.test :refer :all]
+  (:require [clojure.test :refer [deftest is are]]
             [cljam.util.chromosome :as chr]))
 
 (deftest normalize-chromosome-key

--- a/test/cljam/util/region_test.clj
+++ b/test/cljam/util/region_test.clj
@@ -1,5 +1,5 @@
 (ns cljam.util.region-test
-  (:require [clojure.test :refer :all]
+  (:require [clojure.test :refer [deftest are testing]]
             [cljam.util.region :as region]))
 
 (defn into* ([] []) ([r] r) ([r x] (conj r x)))

--- a/test/cljam/util/sequence_test.clj
+++ b/test/cljam/util/sequence_test.clj
@@ -1,5 +1,5 @@
 (ns cljam.util.sequence-test
-  (:require [clojure.test :refer :all]
+  (:require [clojure.test :refer [deftest are]]
             [cljam.util.sequence :as util-seq]))
 
 (deftest revcomp

--- a/test/cljam/util/whole_genome_test.clj
+++ b/test/cljam/util/whole_genome_test.clj
@@ -1,5 +1,5 @@
 (ns cljam.util.whole-genome-test
-  (:require [clojure.test :refer :all]
+  (:require [clojure.test :refer [deftest is are testing]]
             [cljam.util.whole-genome :as wg]))
 
 (def simple-refs [{:name "1", :len 100} {:name "2", :len 200} {:name "3", :len 300}])

--- a/test/cljam/util_test.clj
+++ b/test/cljam/util_test.clj
@@ -2,8 +2,12 @@
   "Tests for cljam.util."
   (:require [clojure.java.io :as cio]
             [clojure.string :as cstr]
-            [clojure.test :refer :all]
-            [cljam.test-common :refer :all]
+            [clojure.test :refer [deftest is are testing]]
+            [cljam.test-common :refer
+             [with-before-after
+              prepare-cache!
+              clean-cache!
+              temp-dir]]
             [cljam.util :as util])
   (:import [java.io File]
            [java.net URL]


### PR DESCRIPTION
##### summary
- Fixed warnings and errors reported by `clj-kondo`
    - Explicit `:refer`
    - Remove unused `require`, `import`, args and local vars
    - Remove redundant `do`
    - and some more warnings
- Added a config file `.clj-kondo/config.edn` for suppressing false-positive errors

##### checks
- `lein check` 🆗 
- `lein test :all` 🆗 
