### PR TITLE
Create an index file while writing a sorted BAM file

### DIFF
--- a/src/cljam/algo/convert.clj
+++ b/src/cljam/algo/convert.clj
@@ -46,10 +46,10 @@
 
 (defn convert-sam
   "Converts file format between SAM and BAM based on the file extension."
-  [in out & {:keys [n-threads num-block]
-             :or {n-threads 0, num-block default-num-block}}]
+  [in out & {:keys [n-threads num-block create-index?]
+             :or {n-threads 0, num-block default-num-block, create-index? false}}]
   (with-open [rdr (sam/reader in)
-              wtr (sam/writer out)]
+              wtr (sam/writer out create-index?)]
     (binding [*n-threads* n-threads]
       (cond
         (io-util/sam-writer? wtr) (convert-sam* rdr wtr num-block sam-write-alignments)

--- a/src/cljam/io/bam/core.clj
+++ b/src/cljam/io/bam/core.clj
@@ -52,6 +52,13 @@
 ;; Writing
 ;; -------
 
-(defn ^BAMWriter writer [f]
-  (BAMWriter. (util/as-url f)
-              (DataOutputStream. (bgzf/bgzf-output-stream f))))
+(defn ^BAMWriter writer
+  ([f] (writer f false))
+  ([f create-index?]
+   (let [index (if create-index? {:no-coordinate-alns 0} false)
+         w (bgzf/bgzf-output-stream f)]
+     (BAMWriter. (util/as-url f)
+                 w
+                 (DataOutputStream. w)
+                 (atom nil)
+                 (atom index)))))

--- a/src/cljam/io/bam/writer.clj
+++ b/src/cljam/io/bam/writer.clj
@@ -1,23 +1,44 @@
 (ns cljam.io.bam.writer
   "Writer of BAM file format."
-  (:require [cljam.io.protocols :as protocols]
+  (:require [clojure.java.io :as cio]
+            [cljam.io.protocols :as protocols]
             [cljam.io.sam.util.refs :as refs]
             [cljam.io.sam.util.header :as header]
             [cljam.io.util.lsb :as lsb]
             [cljam.io.bam.common :as common]
-            [cljam.io.bam.encoder :as encoder])
-  (:import [java.io Closeable]))
+            [cljam.io.bam.encoder :as encoder]
+            [cljam.io.bam.decoder :as bam-decoder]
+            [cljam.io.bam-index.writer :as bai-writer])
+  (:import [java.io ByteArrayOutputStream Closeable DataOutputStream]
+           [cljam.io.bam.decoder BAMRawBlock]
+           [bgzf4j BGZFOutputStream]))
 
 (declare write-header* write-refs* write-alignments* write-blocks*)
+
+(defn- sort-by-pos?
+  "Returns true if the bam is sorted by coordinate, false if not.
+   It is detected by`@HD SO:coordinate` tag in the header."
+  [header]
+  (let [so (:SO (:HD header))]
+    (= so (name :coordinate))))
 
 ;;
 ;; BAMWriter
 ;;
 
-(deftype BAMWriter [url writer]
+(deftype BAMWriter [url writer data-writer refs index]
   Closeable
   (close [this]
-    (.close ^Closeable (.writer this)))
+    (.close ^Closeable (.data-writer this))
+    (when-let [idx @index]
+      (let [last-pointer (.getFilePointer ^BGZFOutputStream writer)
+            n-refs (count @refs)]
+        (with-open [w (->> (str url ".bai")
+                           cio/output-stream
+                           DataOutputStream.)]
+          (->> (bai-writer/update-last-pointer idx last-pointer)
+               (bai-writer/finalize-index n-refs)
+               (bai-writer/write-index*! w n-refs))))))
   protocols/IWriter
   (writer-url [this]
     (.url this))
@@ -36,15 +57,18 @@
 ;;
 
 (defn write-header* [^BAMWriter wtr header]
-  (let [w (.writer wtr)
+  (swap! (.index wtr) #(and (sort-by-pos? header) %))
+  (let [w (.data-writer wtr)
         header-string (str (header/stringify-header header) \newline)]
     (lsb/write-bytes w (.getBytes ^String common/bam-magic)) ; magic
     (lsb/write-int w (count header-string))
     (lsb/write-string w header-string)))
 
 (defn write-refs* [^BAMWriter wtr header]
-  (let [w (.writer wtr)
+  (let [w (.data-writer wtr)
         refs (refs/make-refs header)]
+    (when @(.index wtr)
+      (reset! (.refs wtr) refs))
     (lsb/write-int w (count refs))
     (doseq [ref refs]
       (lsb/write-int w (inc (count (:name ref))))
@@ -53,14 +77,50 @@
       (lsb/write-int w (:len ref)))))
 
 (defn write-alignments* [^BAMWriter wtr alns header]
-  (let [w (.writer wtr)
+  (let [dw (.data-writer wtr)
+        w ^BGZFOutputStream (.writer wtr)
         refs (refs/make-refs header)]
-    (doseq [a alns]
-      (lsb/write-int w (encoder/get-block-size a))
-      (encoder/encode-alignment w a refs))))
+    (with-open [baos (ByteArrayOutputStream. 4096)
+                dos (DataOutputStream. baos)]
+      (let [pointer-block (map
+                           (fn [a]
+                             (let [pointer-beg (.getFilePointer w)]
+                               (.reset baos)
+                               (encoder/encode-alignment dos a refs)
+                               (lsb/write-int dw (.size baos))
+                               (.writeTo baos dw)
+                               (when @(.index wtr)
+                                 (bam-decoder/decode-pointer-block
+                                  (BAMRawBlock. (.toByteArray baos)
+                                                pointer-beg
+                                                (.getFilePointer w))))))
+                           alns)]
+        (if @(.index wtr)
+          (reset! (.index wtr)
+                  (->> pointer-block
+                       bai-writer/make-index*
+                       (bai-writer/merge-index @(.index wtr))))
+          (dorun pointer-block))
+        nil))))
 
 (defn write-blocks* [^BAMWriter wtr blocks]
-  (let [w (.writer wtr)]
-    (doseq [b blocks]
-      (lsb/write-int w (alength ^bytes (:data b)))
-      (lsb/write-bytes w (:data b)))))
+  (let [dw (.data-writer wtr)
+        w ^BGZFOutputStream (.writer wtr)
+        pointer-block (map
+                       (fn [{:keys [data]}]
+                         (let [pointer-beg (.getFilePointer w)]
+                           (lsb/write-int dw (alength ^bytes data))
+                           (lsb/write-bytes dw data)
+                           (when @(.index wtr)
+                             (bam-decoder/decode-pointer-block
+                              (BAMRawBlock. data
+                                            pointer-beg
+                                            (.getFilePointer w))))))
+                       blocks)]
+    (if @(.index wtr)
+      (reset! (.index wtr)
+              (->> pointer-block
+                   bai-writer/make-index*
+                   (bai-writer/merge-index @(.index wtr))))
+      (dorun pointer-block))
+    nil))

--- a/src/cljam/io/sam.clj
+++ b/src/cljam/io/sam.clj
@@ -89,17 +89,23 @@
 (defn ^BAMWriter bam-writer
   "Returns an open cljam.io.bam.writer.BAMWriter of f. Should be used inside
   with-open to ensure the writer is properly closed."
-  [f]
-  (bam-core/writer f))
+  ([f]
+   (bam-writer f false))
+  ([f create-index?]
+   (bam-core/writer f create-index?)))
 
 (defn ^Closeable writer
   "Selects suitable writer from f's extension, returning the writer. This
   function supports SAM and BAM format."
-  [f]
-  (case (io-util/file-type f)
-    :sam (sam-writer f)
-    :bam (bam-writer f)
-    (throw (IllegalArgumentException. "Invalid file type"))))
+  ([f]
+   (writer f false))
+  ([f create-index?]
+   (case (io-util/file-type f)
+     :sam (if create-index?
+            (throw (ex-info "SAM file indexing is not implemented." {}))
+            (sam-writer f))
+     :bam (bam-writer f create-index?)
+     (throw (IllegalArgumentException. "Invalid file type")))))
 
 (defn write-header
   "Writes header to the SAM/BAM file."

--- a/src/cljam/tools/cli.clj
+++ b/src/cljam/tools/cli.clj
@@ -90,12 +90,13 @@
   [["-t" "--thread THREAD" "Number of threads (0 is auto)"
     :default 0
     :parse-fn #(Integer/parseInt %)]
+   ["-i" "--index" "Create Index"]
    ["-h" "--help" "Print help"]])
 
 (defn- convert-usage [options-summary]
   (->> ["Convert file format based on the file extension."
         ""
-        "Usage: cljam convert [-t THREAD] <in-file> <out-file> [<out-file-2> [<out-file-3>]]"
+        "Usage: cljam convert [-t THREAD] [-i] <in-file> <out-file> [<out-file-2> [<out-file-3>]]"
         ""
         "Options:"
         options-summary]
@@ -108,18 +109,19 @@
       (not (<= 2 (count arguments) 4)) (exit 1 (convert-usage summary))
       errors (exit 1 (error-msg errors)))
     (let [[in & [out & more :as outs]] arguments]
-      (convert/convert in (if more outs out) :n-threads (:thread options))))
+      (convert/convert in (if more outs out) :n-threads (:thread options) :create-index? (:index options))))
   nil)
 
 ;; ### normalize command
 
 (def ^:private normalize-cli-options
-  [["-h" "--help"]])
+  [["-i" "--index" "Create Index"]
+   ["-h" "--help"]])
 
 (defn- normalize-usage [options-summary]
   (->> ["Normalize references of alignments"
         ""
-        "Usage: cljam normalize <in.bam|sam> <out.bam|sam>"
+        "Usage: cljam normalize [-i] <in.bam|sam> <out.bam|sam>"
         ""
         "Options:"
         options-summary]
@@ -133,7 +135,7 @@
       errors (exit 1 (error-msg errors)))
     (let [[in out] arguments]
       (with-open [r (sam/reader in)
-                  w (sam/writer out)]
+                  w (sam/writer out (:index options))]
         (normal/normalize r w))))
   nil)
 
@@ -145,12 +147,13 @@
    ["-c" "--chunk CHUNK" "Maximum number of alignments sorted per thread."
     :default sorter/default-chunk-size
     :parse-fn #(Integer/parseInt %)]
+   ["-i" "--index" "Create Index"]
    ["-h" "--help" "Print help"]])
 
 (defn- sort-usage [options-summary]
   (->> ["Sort alignments by leftmost coordinates."
         ""
-        "Usage: cljam sort [-o ORDER] [-c CHUNK] <in.bam|sam> <out.bam|sam>"
+        "Usage: cljam sort [-o ORDER] [-c CHUNK] [-i] <in.bam|sam> <out.bam|sam>"
         ""
         "Options:"
         options-summary]
@@ -164,7 +167,7 @@
       errors (exit 1 (error-msg errors)))
     (let [[in out] arguments]
       (with-open [r (sam/reader in)
-                  w (sam/writer out)]
+                  w (sam/writer out (:index options))]
         (condp = (:order options)
           (name header/order-coordinate) (sorter/sort-by-pos r w {:chunk-size (:chunk options)})
           (name header/order-queryname) (sorter/sort-by-qname r w {:chunk-size (:chunk options)})))))
@@ -298,12 +301,13 @@
 ;; ### level command
 
 (def ^:private level-cli-options
-  [["-h" "--help"]])
+  [["-i" "--index" "Create Index"]
+   ["-h" "--help"]])
 
 (defn- level-usage [options-summary]
   (->> ["Analyze a BAM file and add level information of alignments."
         ""
-        "Usage: cljam level <in.bam> <out.bam>"
+        "Usage: cljam level [-i] <in.bam> <out.bam>"
         ""
         "Options:"
         options-summary]
@@ -317,7 +321,7 @@
       errors (exit 1 (error-msg errors)))
     (let [[in out] arguments]
       (with-open [r (sam/reader in)
-                  w (sam/writer out)]
+                  w (sam/writer out (:index options))]
         (level/add-level r w))))
   nil)
 

--- a/test/cljam/io/bam_index/writer_test.clj
+++ b/test/cljam/io/bam_index/writer_test.clj
@@ -1,0 +1,110 @@
+(ns cljam.io.bam-index.writer-test
+  "Tests for cljam.io.bam-index."
+  (:require [clojure.test :refer [deftest is testing]]
+            [cljam.io.bam-index.writer :as writer]))
+
+(def update-last-pointer 29229056)
+(def input-index-1 {0 {:meta-data {:first-offset 97
+                                   :last-offset 555
+                                   :aligned-alns 6
+                                   :unaligned-alns 0}
+                       :bin-index {4681 [{:beg 97, :end 555}]}
+                       :linear-index {0 97}}
+                    1 {:meta-data {:first-offset 555
+                                   :last-offset 1031
+                                   :aligned-alns 6
+                                   :unaligned-alns 0}
+                       :bin-index {4681 [{:beg 555, :end 1031}]}
+                       :linear-index {0 555}}
+                    :no-coordinate-alns 0})
+(def output-index-1 {0 {:meta-data {:first-offset 97
+                                    :last-offset 555
+                                    :aligned-alns 6
+                                    :unaligned-alns 0}
+                        :bin-index {4681 [{:beg 97, :end 555}]}
+                        :linear-index {0 97}}
+                     1 {:meta-data {:first-offset 555
+                                    :last-offset 29229056
+                                    :aligned-alns 6
+                                    :unaligned-alns 0}
+                        :bin-index {4681 [{:beg 555, :end 29229056}]}
+                        :linear-index {0 555}}
+                     :no-coordinate-alns 0})
+(def input-index-2 {0 {:meta-data {:first-offset 97
+                                   :last-offset 555
+                                   :aligned-alns 6
+                                   :unaligned-alns 0}
+                       :bin-index {4681 [{:beg 97, :end 345}]
+                                   4781 [{:beg 345, :end 555}]}
+                       :linear-index {0 97}}
+                    1 {:meta-data {:first-offset 555
+                                   :last-offset 1031
+                                   :aligned-alns 6
+                                   :unaligned-alns 0}
+                       :bin-index {4881 [{:beg 555, :end 800}
+                                         {:beg 900, :end 1031}]}
+                       :linear-index {0 555}}
+                    2 {:meta-data {:first-offset 1031
+                                   :last-offset 2031
+                                   :aligned-alns 6
+                                   :unaligned-alns 0}
+                       :bin-index {4981 [{:beg 1031, :end 1131}
+                                         {:beg 1231, :end 1331}]
+                                   5081 [{:beg 1331, :end 1431}
+                                         {:beg 1531, :end 2031}]}
+                       :linear-index {0 1031}}
+                    :no-coordinate-alns 0})
+(def output-index-2 {0 {:meta-data {:first-offset 97
+                                    :last-offset 555
+                                    :aligned-alns 6
+                                    :unaligned-alns 0}
+                        :bin-index {4681 [{:beg 97, :end 345}]
+                                    4781 [{:beg 345, :end 555}]}
+                        :linear-index {0 97}}
+                     1 {:meta-data {:first-offset 555
+                                    :last-offset 1031
+                                    :aligned-alns 6
+                                    :unaligned-alns 0}
+                        :bin-index {4881 [{:beg 555, :end 800}
+                                          {:beg 900, :end 1031}]}
+                        :linear-index {0 555}}
+                     2 {:meta-data {:first-offset 1031
+                                    :last-offset 29229056
+                                    :aligned-alns 6
+                                    :unaligned-alns 0}
+                        :bin-index {4981 [{:beg 1031, :end 1131}
+                                          {:beg 1231, :end 1331}]
+                                    5081 [{:beg 1331, :end 1431}
+                                          {:beg 1531, :end 29229056}]}
+                        :linear-index {0 1031}}
+                     :no-coordinate-alns 0})
+(def input-index-not-update-1 {:no-coordinate-alns 0})
+(def input-index-not-update-2 {0 {:meta-data {:first-offset 97
+                                              :last-offset 555
+                                              :aligned-alns 6
+                                              :unaligned-alns 0}
+                                  :bin-index {4681 [{:beg 97, :end 555}]}
+                                  :linear-index {0 97}}
+                               1 {:meta-data {:first-offset 555
+                                              :last-offset 1031
+                                              :aligned-alns 6
+                                              :unaligned-alns 0}
+                                  :bin-index {4681 [{:beg 555, :end 1031}]}
+                                  :linear-index {0 555}}
+                               :no-coordinate-alns 3})
+
+;;; unit test
+
+;;; update-last-pointer
+
+(deftest update-last-pointer-test
+  (testing "update"
+    (let [output-1 (writer/update-last-pointer input-index-1 update-last-pointer)
+          output-2 (writer/update-last-pointer input-index-2 update-last-pointer)]
+      (is (= output-1 output-index-1))
+      (is (= output-2 output-index-2))))
+  (testing "not update"
+    (let [output-1 (writer/update-last-pointer input-index-not-update-1 update-last-pointer)
+          output-2 (writer/update-last-pointer input-index-not-update-2 update-last-pointer)]
+      (is (= output-1 input-index-not-update-1))
+      (is (= output-2 input-index-not-update-2)))))


### PR DESCRIPTION
This PR is to add a function to create an index file if it is already sorted when creating a BAM file.
PR for issue #141 .