### PR TITLE
Add base_sha option to clj-lint-action.

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -7,9 +7,14 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v2
-    - uses: xcoo/clj-lint-action@v1.1.1
+    - name : master base sha
+      id : master_base_sha
+      if : github.ref  == 'refs/heads/master'
+      run: echo  "::set-output name=base_sha::${{ github.event.before }}"
+    - uses: xcoo/clj-lint-action@v1.1.5
       with:
         linters: "[\"clj-kondo\" \"kibit\" \"eastwood\"]"
         github_token: ${{ secrets.GITHUB_TOKEN }}
         runner: ":leiningen"
+        base_sha: ${{ github.event.pull_request.base.sha||steps.master_base_sha.outputs.base_sha }}
         eastwood_linters: "[:all]"


### PR DESCRIPTION
This PR adds the option of clj-lint-action.
Without this option, the second commit on the branch would not be able to take the diff.