### PR TITLE
Update the version of lint-action to read the clj-kondo config file.

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -11,7 +11,7 @@ jobs:
       id : master_base_sha
       if : github.ref  == 'refs/heads/master'
       run: echo  "::set-output name=base_sha::${{ github.event.before }}"
-    - uses: xcoo/clj-lint-action@v1.1.5
+    - uses: xcoo/clj-lint-action@v1.1.6
       with:
         linters: "[\"clj-kondo\" \"kibit\" \"eastwood\"]"
         github_token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
I updated the version of clj-lint-action so that the config of clj-kondo can be read.

In this version upgrade of clj-lint-action, the command to move the working directory to the repository and the line break of the source code have been added.