### PR TITLE
Introduce GitHub Dependabot to keep dependencies up to date

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,6 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "daily"


### PR DESCRIPTION
This PR adds settings for GitHub Dependabot to keep GitHub Actions dependencies up to date.
Currently, GitHub Dependabot checks only GitHub Actions dependencies, not others in `project.clj`.