### PR TITLE
Add support for indexed? for vcf/bcf.

### DIFF
--- a/src/cljam/io/bcf/reader.clj
+++ b/src/cljam/io/bcf/reader.clj
@@ -10,7 +10,7 @@
             [cljam.util :as util]
             [cljam.io.util.bin :as util-bin]
             [cljam.io.csi :as csi])
-  (:import [java.io Closeable IOException]
+  (:import [java.io Closeable IOException FileNotFoundException]
            [java.net URL]
            [java.nio Buffer ByteBuffer]
            [bgzf4j BGZFInputStream]))
@@ -27,7 +27,12 @@
   (reader-url [this] (.url this))
   (read [this] (protocols/read this {}))
   (read [this option] (read-variants this option))
-  (indexed? [_] false)
+  (indexed? [_]
+    (try
+      @index-delay
+      true
+      (catch FileNotFoundException _
+        false)))
   protocols/IRegionReader
   (read-in-region [this region]
     (protocols/read-in-region this region {}))

--- a/src/cljam/io/vcf.clj
+++ b/src/cljam/io/vcf.clj
@@ -2,6 +2,7 @@
   "Functions to read and write the VCF (Variant Call Format) format and BCF (its
   binary equivalent). See https://samtools.github.io/hts-specs/ for the detail
   VCF/BCF specifications."
+  (:refer-clojure :exclude [indexed?])
   (:require [clojure.java.io :as cio]
             [cljam.util :as util]
             [cljam.io.protocols :as protocols]
@@ -96,6 +97,12 @@
   "Returns header of VCF/BCF file as a sequence of strings."
   [rdr]
   (protocols/header rdr))
+
+(defn indexed?
+  "Returns true if the reader can be randomly accessed, false if not. Note this
+  function immediately realizes a delayed index."
+  [rdr]
+  (protocols/indexed? rdr))
 
 (defn read-variants
   "Reads variants of the VCF/BCF file, returning them as a lazy sequence. rdr

--- a/src/cljam/io/vcf/reader.clj
+++ b/src/cljam/io/vcf/reader.clj
@@ -8,7 +8,7 @@
             [proton.core :refer [as-long]]
             [cljam.io.util.bin :as util-bin]
             [cljam.io.vcf.util :as vcf-util])
-  (:import [java.io Closeable BufferedReader]
+  (:import [java.io Closeable BufferedReader FileNotFoundException]
            [clojure.lang LazilyPersistentVector]
            bgzf4j.BGZFInputStream))
 
@@ -25,7 +25,12 @@
   (reader-url [this] (.url this))
   (read [this] (read-variants this))
   (read [this option] (read-variants this option))
-  (indexed? [_] false)
+  (indexed? [_]
+    (try
+      @index-delay
+      true
+      (catch FileNotFoundException _
+        false)))
   protocols/IRegionReader
   (read-in-region [this region]
     (protocols/read-in-region this region {}))


### PR DESCRIPTION
Since `indexed?` of vcf / bcf was not implemented, I added it.
The implementation is almost the same as the `indexed?` of fasta.