### PR TITLE
Update actions/setup-java to v2

### DIFF
--- a/.github/workflows/format.yml
+++ b/.github/workflows/format.yml
@@ -8,9 +8,10 @@ jobs:
     steps:
     - uses: actions/checkout@v2
     - name: Setup Java
-      uses: actions/setup-java@v1
+      uses: actions/setup-java@v2
       with:
         java-version: '11'
+        distribution: 'adopt'
         architecture: x64
     - name: Cache m2 repository
       uses: actions/cache@v2.1.4

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -7,14 +7,15 @@ jobs:
     runs-on: ubuntu-18.04
     strategy:
       matrix:
-        java: [ '1.8', '11', '15', '16-ea' ]
+        java: [ '8', '11', '16', '17-ea']
     name: Java ${{ matrix.java }}
     steps:
     - uses: actions/checkout@v2
     - name: Setup Java
-      uses: actions/setup-java@v1
+      uses: actions/setup-java@v2
       with:
         java-version: ${{ matrix.java }}
+        distribution: 'adopt'
         architecture: x64
     - name: Cache m2 repository
       uses: actions/cache@v2.1.4
@@ -45,9 +46,10 @@ jobs:
     steps:
     - uses: actions/checkout@v2
     - name: Setup Java
-      uses: actions/setup-java@v1
+      uses: actions/setup-java@v2
       with:
-        java-version: '1.8'
+        java-version: '8'
+        distribution: 'adopt'
         architecture: x64
     - name: Deploy
       env:


### PR DESCRIPTION
Related to: #224 

The differences between v1 and v2 are listed in https://github.com/actions/setup-java#v2-vs-v1
- v2 requires `distribution:` value, which is set to `adopt` here
- v2 requires `java-version:` to be a SemVer