### PR TITLE
Add explanation to info exception.

### DIFF
--- a/src/cljam/io/vcf/util.clj
+++ b/src/cljam/io/vcf/util.clj
@@ -40,7 +40,10 @@
               {}
               (map (fn [ss]
                      (let [[k vs] (cstr/split ss #"\=" 2)]
-                       [(keyword k) ((parser-map k) vs)])))))))))
+                       (if-let [parser (parser-map k)]
+                         [(keyword k) (parser vs)]
+                         (throw (ex-info (str "Undeclared INFO, " k ".")
+                                         {:info ss}))))))))))))
 
 (defn info-stringifier
   "Returns a stringifier function of INFO field.


### PR DESCRIPTION
I added exception information about which INFO key is the problem to make it easier to understand the exception when reading the VCF, such as missing a reserved INFO key.

I've seen type errors during INFO parsing in the past, but I lost the VCF file that caused it, so I didn't add any other checking features this time.Then I had Cljam read some VCF files (known databases and others) and found no other problems, so I'll do the rest when I find them.