### PR TITLE
Fix parser generation not to interpret unnecessary data when calculat…

### DIFF
--- a/src/cljam/io/bcf/reader.clj
+++ b/src/cljam/io/bcf/reader.clj
@@ -339,14 +339,14 @@
         contigs (->> (:contig (.meta-info rdr))
                      (map-indexed (fn [index contig] [(:id contig) index]))
                      (into {}))
-        parse-fn (make-parse-fn rdr (meta->map (:info (.meta-info rdr))) :deep)]
+        parse-fn (make-parse-fn rdr (meta->map (:info (.meta-info rdr))) :shallow)]
     (letfn [(step [beg-pointer]
               (when (pos? (.available input-stream))
                 (when-let [line (read-data-line-buffer input-stream)]
                   (let [end-pointer (.getFilePointer input-stream)
-                        {:keys [chr pos ref info]} (parse-fn line)]
+                        {:keys [chr pos rlen]} (parse-fn line)]
                     (cons {:file-beg beg-pointer, :file-end end-pointer
                            :chr-index (contigs chr), :beg pos, :chr chr,
-                           :end (or (:END info) (dec (+ pos (count ref))))}
+                           :end (dec (+ pos rlen))}
                           (lazy-seq (step end-pointer)))))))]
       (step (.getFilePointer input-stream)))))

--- a/src/cljam/io/vcf/reader.clj
+++ b/src/cljam/io/vcf/reader.clj
@@ -243,9 +243,9 @@
                                (map-indexed (fn [index contig]
                                               [(:id contig) index]))
                                (into {}))
-        kws (mapv keyword (drop 8 (.header rdr)))
-        parse (comp (vcf-util/variant-parser (.meta-info rdr) (.header rdr))
-                    #(parse-data-line % kws))]
+        parse (comp (vcf-util/variant-parser (.meta-info rdr)
+                                             (take 8 (.header rdr)))
+                    #(parse-data-line % nil))]
     (letfn [(step [contigs beg-pointer]
               (when-let [line (.readLine input-stream)]
                 (let [end-pointer (.getFilePointer input-stream)]


### PR DESCRIPTION
To fix #240.
I improved index generation speed by changing parsers in `read-file-offsets` for vcf and bcf.
- Changed that of bcf not to interpret sample
- Changed it to: shallow in bcf and changed the end of the mutation to use rlen.

### vcf benchmark
```
> bcftools view ALL.chr22.shapeit2_integrated_snvindels_v2a_27022019.GRCh38.phased.vcf.gz  |head -n 1000 > /tmp/index-bench.vcf
> bgzip /tmp/index-bench.vcf
```
- PR version
```
user=> (quick-bench
  #_=> (vcf-indexer/create-index
  #_=>        "/tmp/index-bench.vcf.gz"
  #_=>        "/tmp/index-bench.vcf.gz.csi"
  #_=>        {:shift 14 :depth 5}))
Evaluation count : 6 in 6 samples of 1 calls.
             Execution time mean : 192.050578 ms
    Execution time std-deviation : 9.026152 ms
   Execution time lower quantile : 183.364991 ms ( 2.5%)
   Execution time upper quantile : 205.642765 ms (97.5%)
                   Overhead used : 13.876721 ns
```
- old version
```
user=> (quick-bench
  #_=> (vcf-indexer/create-index
  #_=>        "/tmp/index-bench.vcf.gz"
  #_=>        "/tmp/index-bench.vcf.gz.csi"
  #_=>        {:shift 14 :depth 5}))
Evaluation count : 6 in 6 samples of 1 calls.
             Execution time mean : 9.188136 sec
    Execution time std-deviation : 29.107864 ms
   Execution time lower quantile : 9.143654 sec ( 2.5%)
   Execution time upper quantile : 9.217992 sec (97.5%)
                   Overhead used : 13.904601 ns
```
### bcf benchmark
```
> bcftools view /tmp/index-bench.vcf.gz  -o /tmp/index-bench.bcf
```
- PR version
```
user=> (quick-bench
  #_=> (vcf-indexer/create-index
  #_=>        "/tmp/index-bench.bcf"
  #_=>        "/tmp/index-bench.bcf.csi"
  #_=>        {:shift 14 :depth 5}))
Evaluation count : 48 in 6 samples of 8 calls.
             Execution time mean : 15.261828 ms
    Execution time std-deviation : 544.830560 µs
   Execution time lower quantile : 14.609601 ms ( 2.5%)
   Execution time upper quantile : 15.972899 ms (97.5%)
                   Overhead used : 14.402711 ns
```
- old version
- Give up because it takes too long.