### PR TITLE
Fix error that occurs when querying intervals for missing chr

### DIFF
--- a/src/cljam/util/intervals.clj
+++ b/src/cljam/util/intervals.clj
@@ -64,4 +64,4 @@
   "Find intervals that are on the given `chr` and overlap the given interval
   [`start` `end`] using indexes created by `index-intervals`."
   [indexed-intervals chr start end]
-  (find-overlap-intervals* (get indexed-intervals chr) start end))
+  (some-> (get indexed-intervals chr) (find-overlap-intervals* start end)))

--- a/test/cljam/util/intervals_test.clj
+++ b/test/cljam/util/intervals_test.clj
@@ -37,5 +37,6 @@
                      "chr2" 201 240 #{{:chr "chr2" :start 150 :end 250}
                                       {:chr "chr2" :start 180 :end 300}
                                       {:chr "chr2" :start 182 :end 201}
-                                      {:chr "chr2" :start 200 :end 400}})))
+                                      {:chr "chr2" :start 200 :end 400}}
+                     "chr3" 1 10 #{})))
                :sorted-map :nclist))


### PR DESCRIPTION
When issuing an interval query (using `c.u.i/find-overlap-intervals`) for a missing chr in the index, an error will be thrown:

```clojure
(require '[cljam.util.intervals :as intervals])

(def index
  (intervals/index-intervals
   [{:chr "chr1", :start 10000, :end 15000}
    {:chr "chr1", :start 20000, :end 25000}]))

(intervals/find-overlap-intervals index "chr1" 13000 17000)
;=> ({:chr "chr1", :start 10000, :end 15000})
(intervals/find-overlap-intervals index "chr1" 17000 19000)
;=> ()

(intervals/find-overlap-intervals index "chr2" 13000 17000)
;; Execution error (IllegalArgumentException) at cljam.util.intervals/eval5662$fn$G (intervals.clj:4).
;; No implementation of method: :find-overlap-intervals* of protocol: #'cljam.util.intervals/IIntervals found for class: nil
```

This PR fixes the error by guarding against `nil` with `some->`.