### PR TITLE
Avoid StackOverflowError while reading a VCF with many lines of meta

### DIFF
--- a/src/cljam/io/vcf/reader.clj
+++ b/src/cljam/io/vcf/reader.clj
@@ -61,7 +61,7 @@
 (defn- dot->nil
   [^String s]
   ;; Avoid calling equiv on strings.
-  (if (and (= 1 (.length s)) (= \. (.charAt s 0))) nil s))
+  (when-not (and (= 1 (.length s)) (= \. (.charAt s 0))) s))
 
 ;; Loading meta-information
 ;; ------------------------

--- a/src/cljam/io/vcf/reader.clj
+++ b/src/cljam/io/vcf/reader.clj
@@ -180,7 +180,7 @@
     (if-not (or (meta-line? line) (header-line? line))
       (cons (parse-data-line line kws)
             (lazy-seq (read-data-lines rdr header kws)))
-      (read-data-lines rdr header kws))))
+      (recur rdr header kws))))
 
 (defn read-variants
   ([rdr]


### PR DESCRIPTION
With current implementation, many lines of meta (say 4k lines of contig definition) causes StackOverflowError like below.

```
 :cause nil
 :via
 [{:type java.lang.StackOverflowError
   :message nil
   :at [clojure.lang.PersistentHashMap$BitmapIndexedNode ensureEditable "PersistentHashMap.java" 812]}]
 :trace
 [[clojure.lang.PersistentHashMap$BitmapIndexedNode ensureEditable "PersistentHashMap.java" 812]
  [clojure.lang.PersistentHashMap$BitmapIndexedNode assoc "PersistentHashMap.java" 894]
  [clojure.lang.PersistentHashMap$TransientHashMap doAssoc "PersistentHashMap.java" 327]
  [clojure.lang.ATransientMap assoc "ATransientMap.java" 64]
  [clojure.lang.PersistentHashMap create "PersistentHashMap.java" 78]
  [clojure.core$hash_map invokeStatic "core.clj" 389]
  [clojure.core$hash_map doInvoke "core.clj" 381]
  [clojure.lang.RestFn applyTo "RestFn.java" 137]
  [clojure.core$apply invokeStatic "core.clj" 667]
  [clojure.core$apply invoke "core.clj" 662]
  [cljam.io.vcf.reader$parse_data_line invokeStatic "reader.clj" 173]
  [cljam.io.vcf.reader$parse_data_line invoke "reader.clj" 154]
  [cljam.io.vcf.reader$read_data_lines invokeStatic "reader.clj" 181]
  [cljam.io.vcf.reader$read_data_lines invoke "reader.clj" 175]
  [cljam.io.vcf.reader$read_data_lines invokeStatic "reader.clj" 183]

;; continues recursive call's stack trace
```

I fixed the problem explicitly call `recur` to utlize tail call optimization.