### PR TITLE
Use bgzip as default for writing `.gz` files

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -35,7 +35,7 @@
              :1.9 {:dependencies [[org.clojure/clojure "1.9.0"]]}
              :1.10 {:dependencies [[org.clojure/clojure "1.10.3"]]}
              :uberjar {:dependencies [[org.clojure/clojure "1.10.3"]
-                                      [org.apache.logging.log4j/log4j-api "2.14.1"]
+                                      [org.apache.logging.log4j/log4j-api "2.17.0"]
                                       [org.apache.logging.log4j/log4j-core "2.14.1"]]
                        :resource-paths ["bin-resources"]
                        :main cljam.tools.main

--- a/project.clj
+++ b/project.clj
@@ -4,7 +4,7 @@
   :license {:name "Apache License, Version 2.0"
             :url "https://www.apache.org/licenses/LICENSE-2.0"}
   :dependencies [[org.clojure/core.memoize "1.0.253"]
-                 [org.clojure/tools.logging "1.1.0"]
+                 [org.clojure/tools.logging "1.2.3"]
                  [org.clojure/tools.cli "1.0.206"]
                  [org.apache.commons/commons-compress "1.21"]
                  [clj-sub-command "0.6.0"]

--- a/project.clj
+++ b/project.clj
@@ -36,7 +36,7 @@
              :1.10 {:dependencies [[org.clojure/clojure "1.10.3"]]}
              :uberjar {:dependencies [[org.clojure/clojure "1.10.3"]
                                       [org.apache.logging.log4j/log4j-api "2.17.0"]
-                                      [org.apache.logging.log4j/log4j-core "2.14.1"]]
+                                      [org.apache.logging.log4j/log4j-core "2.17.0"]]
                        :resource-paths ["bin-resources"]
                        :main cljam.tools.main
                        :jvm-opts ["-Dclojure.compiler.direct-linking=true"]

--- a/project.clj
+++ b/project.clj
@@ -3,7 +3,7 @@
   :url "https://github.com/chrovis/cljam"
   :license {:name "Apache License, Version 2.0"
             :url "https://www.apache.org/licenses/LICENSE-2.0"}
-  :dependencies [[org.clojure/core.memoize "1.0.250"]
+  :dependencies [[org.clojure/core.memoize "1.0.253"]
                  [org.clojure/tools.logging "1.1.0"]
                  [org.clojure/tools.cli "1.0.206"]
                  [org.apache.commons/commons-compress "1.21"]

--- a/test/cljam/util_test.clj
+++ b/test/cljam/util_test.clj
@@ -96,3 +96,30 @@
 
     ""  nil
     nil nil))
+
+(deftest compressor-output-stream-test
+  (are [?filename ?data]
+       (util/with-temp-dir [d "compressor-output-stream-test"]
+         (let [f (cio/file d ?filename)
+               buf (byte-array (count ?data))]
+           (with-open [os (util/compressor-output-stream f)]
+             (.write os (.getBytes "compressor-output-stream-test")))
+           (with-open [is (cio/input-stream f)]
+             (.read is buf))
+           (= (map unchecked-byte ?data) (seq buf))))
+    ;; BGZF
+    "test.gz"    [0x1f 0x8b 0x08 0x04 0x00 0x00 0x00 0x00
+                  0x00 0xff 0x06 0x00 (int \B) (int \C) 0x02 0x00]
+    "test.bgz"   [0x1f 0x8b 0x08 0x04 0x00 0x00 0x00 0x00
+                  0x00 0xff 0x06 0x00 (int \B) (int \C) 0x02 0x00]
+    "test.bgzip" [0x1f 0x8b 0x08 0x04 0x00 0x00 0x00 0x00
+                  0x00 0xff 0x06 0x00 (int \B) (int \C) 0x02 0x00]
+
+    ;; raw GZIP
+    "test.gzip"  [0x1f 0x8b 0x08 0x00]
+
+    ;; BZIP2
+    "test.bz2"   [(int \B) (int \Z) (int \h) (int \9)
+                  0x31 0x41 0x59 0x26 0x53 0x59]
+    "test.bzip2" [(int \B) (int \Z) (int \h) (int \9)
+                  0x31 0x41 0x59 0x26 0x53 0x59]))

--- a/test/cljam/util_test.clj
+++ b/test/cljam/util_test.clj
@@ -29,12 +29,10 @@
       (is (deleted? d))
       (is (deleted? e))))
   (testing "users can delete temp directories before entering a finally clause"
-    (try
-      (util/with-temp-dir [d "foo", e "bar"]
-        (cio/delete-file d true)
-        (cio/delete-file e true))
-      (catch Exception e (is false e))
-      (finally (is true))))
+    (is (util/with-temp-dir [d "foo", e "bar"]
+          (cio/delete-file d true)
+          (cio/delete-file e true)
+          true)))
   (testing "automatically deletes subdirectories created by users"
     (let [sub-dirs (util/with-temp-dir [d "foo"]
                      (let [sub-dirs [(cio/file d "bar") (cio/file d "qux")]]


### PR DESCRIPTION
Fixes #251 

This PR changes the behavior of `cljam.util/compressor-output-stream`.
It now returns `BGZFOutputStream` instead of `GzipCompressorOutputStream` for files with `.gz` extension.
Since BGZIP is just a special case of GZIP, existing codes using `cljam.util/compressor-output-stream` with `.gz` should still work.
To get `GzipCompressorOutputStream`, we can use the 2nd argument or `.gzip` extension.

This PR also includes
- Update log4j to 2.17.0
- Some minor fixes suggested by linters