### PR TITLE
Fix/apply lint

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -10,7 +10,7 @@ jobs:
     - name : master base sha
       id : master_base_sha
       if : github.ref  == 'refs/heads/master'
-      run: echo  "::set-output name=base_sha::${{ github.event.before }}"
+      run: echo "base_sha=${{ github.event.before }}" >> $GITHUB_OUTPUT
     - uses: xcoo/clj-lint-action@v1.1.11
       with:
         linters: "[\"clj-kondo\" \"kibit\" \"eastwood\"]"

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -18,3 +18,4 @@ jobs:
         runner: ":leiningen"
         base_sha: ${{ github.event.pull_request.base.sha||steps.master_base_sha.outputs.base_sha }}
         eastwood_linters: "[:all]"
+        linter_options: "{:eastwood {:exclude-linters [:keyword-typos :unused-namespaces :boxed-math :reflection]}}"

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -29,9 +29,9 @@ jobs:
     - name: Run lein check
       if: matrix.java == '11'
       run: >-
-        ! lein check 2>&1 > /dev/null |
+        ! lein update-in :global-vars assoc '*unchecked-math*' :warn-on-boxed -- check 2>&1 > /dev/null |
         grep cljam |
-        sed -E 's/^Reflection warning, ([^:]+):([0-9]+):([0-9]+) - (.*)$/::warning file=\1,line=\2,col=\3::\4/' |
+        sed -E 's/^Reflection warning, ([^:]+):([0-9]+):([0-9]+) - (.*)$/::warning file=\1,line=\2,col=\3::\4/;s/^Boxed math warning, ([^:]+):([0-9]+):([0-9]+) - (.*)$/::warning file=\1,line=\2,col=\3::\4/' |
         grep '::warning'
     - name: Run tests
       run: |

--- a/project.clj
+++ b/project.clj
@@ -29,7 +29,8 @@
                                     :remote :remote ; Tests with remote resources
                                     :all (constantly true)}
                    :main ^:skip-aot cljam.tools.main
-                   :global-vars {*warn-on-reflection* true}}
+                   :global-vars {*warn-on-reflection* true
+                                 *unchecked-math* :warn-on-boxed}}
              :1.7 {:dependencies [[org.clojure/clojure "1.7.0"]]}
              :1.8 {:dependencies [[org.clojure/clojure "1.8.0"]]}
              :1.9 {:dependencies [[org.clojure/clojure "1.9.0"]]}

--- a/src/cljam/algo/convert.clj
+++ b/src/cljam/algo/convert.clj
@@ -20,7 +20,7 @@
 (def ^:private default-num-block 100000)
 
 (defn- sam-write-alignments [rdr wtr hdr num-block]
-  (when (and (pos? *n-threads*) (> (get-exec-n-threads) 1))
+  (when (and (pos? (int *n-threads*)) (> (get-exec-n-threads) 1))
     (logging/warn "Concurrent SAM writing is not supported."))
   (doseq [alns (partition-all num-block (sam/read-alignments rdr {}))]
     (sam/write-alignments wtr alns hdr)))

--- a/src/cljam/algo/level.clj
+++ b/src/cljam/algo/level.clj
@@ -33,7 +33,7 @@
         lv (loop [i 0 x (first s) xs (next s)]
              (if-not x
                (do (vswap! state conj end) i)
-               (if (< x pos)
+               (if (< (long x) pos)
                  (do (vswap! state assoc i end) i)
                  (recur (inc i) (first xs) (next xs)))))]
     (update a :options conj {:LV {:type "i" :value (int lv)}})))

--- a/src/cljam/common.clj
+++ b/src/cljam/common.clj
@@ -10,7 +10,8 @@
   *n-threads* itself will be used if it is more than zero. Otherwise,
   (processors + 3) will be used. Note that this return value includes the main
   thread."
+  ^long
   []
-  (if (pos? *n-threads*)
+  (if (pos? (long *n-threads*))
     *n-threads*
     (+ 3 (.. Runtime getRuntime availableProcessors))))

--- a/src/cljam/io/bam/core.clj
+++ b/src/cljam/io/bam/core.clj
@@ -29,8 +29,9 @@
       (throw (FileNotFoundException.
               (str "Could not find BAM Index file for " bam-url)))))
 
-(defn ^BAMReader reader
+(defn reader
   "Creates a `cljam.io.bam.BAMReader` instance for the given file."
+  ^BAMReader
   [f]
   (let [rdr (bgzf/bgzf-input-stream f)
         data-rdr (DataInputStream. rdr)]
@@ -41,8 +42,9 @@
       (BAMReader. (util/as-url f)
                   header refs rdr data-rdr index-delay (.getFilePointer rdr)))))
 
-(defn ^BAMReader clone-reader
+(defn clone-reader
   "Clones bam reader sharing persistent objects."
+  ^BAMReader
   [^BAMReader rdr]
   (let [bgzf-rdr (bgzf/bgzf-input-stream (.url rdr))
         data-rdr (DataInputStream. bgzf-rdr)]
@@ -52,9 +54,9 @@
 ;; Writing
 ;; -------
 
-(defn ^BAMWriter writer
-  ([f] (writer f false))
-  ([f create-index?]
+(defn writer
+  (^BAMWriter [f] (writer f false))
+  (^BAMWriter [f create-index?]
    (let [index (if create-index? {:no-coordinate-alns 0} false)
          w (bgzf/bgzf-output-stream f)]
      (BAMWriter. (util/as-url f)

--- a/src/cljam/io/bam/reader.clj
+++ b/src/cljam/io/bam/reader.clj
@@ -74,9 +74,9 @@
   (read-in-region [this region _]
     (protocols/read-alignments this region)))
 
-(defn- ^"[B" read-a-block!
+(defn- read-a-block!
   "Reads a single alignment block from a reader."
-  [rdr]
+  ^"[B" [rdr]
   (let [block-size (lsb/read-int rdr)]
     (lsb/read-bytes rdr block-size)))
 
@@ -133,11 +133,11 @@
   "Reads header section of BAM file and returns it as a map."
   [rdr]
   (let [header (header/parse-header (lsb/read-string rdr (lsb/read-int rdr)))
-        n-ref (lsb/read-int rdr)
+        n-ref (int (lsb/read-int rdr))
         refs (loop [i n-ref, ret []]
                (if (zero? i)
                  ret
-                 (let [l-name (lsb/read-int rdr)
+                 (let [l-name (int (lsb/read-int rdr))
                        name   (lsb/read-string rdr l-name)
                        l-ref  (lsb/read-int rdr)]
                    (recur (dec i)

--- a/src/cljam/io/bam_index/core.clj
+++ b/src/cljam/io/bam_index/core.clj
@@ -58,7 +58,7 @@
 ;; ## Writing
 
 
-(defn ^BAIWriter writer
+(defn writer ^BAIWriter
   [f refs]
   (BAIWriter. (DataOutputStream. (FileOutputStream. (cio/file f)))
               refs

--- a/src/cljam/io/bam_index/reader.clj
+++ b/src/cljam/io/bam_index/reader.clj
@@ -15,7 +15,7 @@
 
 (defn- skip-chunks!
   [rdr]
-  (let [n-chunks (lsb/read-int rdr)]
+  (let [n-chunks (int (lsb/read-int rdr))]
     (loop [i 0]
       (when (< i n-chunks)
         (lsb/skip rdr 16)
@@ -23,7 +23,7 @@
 
 (defn- skip-bin-index!
   [rdr]
-  (let [n-bidx (lsb/read-int rdr)]
+  (let [n-bidx (int (lsb/read-int rdr))]
     (loop [i 0]
       (when (< i n-bidx)
         (lsb/skip rdr 4)
@@ -32,14 +32,14 @@
 
 (defn- skip-linear-index!
   [rdr]
-  (let [n-lidx (lsb/read-int rdr)]
+  (let [n-lidx (int (lsb/read-int rdr))]
     (loop [i 0]
       (when (< i n-lidx)
         (lsb/skip rdr 8)
         (recur (inc i))))))
 
 (defn- skip-index!
-  [rdr n]
+  [rdr ^long n]
   (loop [i 0]
     (when (< i n)
       (skip-bin-index! rdr)
@@ -48,7 +48,7 @@
 
 (defn- read-chunks!
   [rdr]
-  (let [n (lsb/read-int rdr)]
+  (let [n (int (lsb/read-int rdr))]
     (loop [i 0, chunks []]
       (if (< i n)
         (recur (inc i) (conj chunks (Chunk. (lsb/read-long rdr) (lsb/read-long rdr))))
@@ -56,7 +56,7 @@
 
 (defn- read-bin-index**!
   [rdr]
-  (let [n (lsb/read-int rdr)]
+  (let [n (int (lsb/read-int rdr))]
     (loop [i 0, bidx []]
       (if (< i n)
         (let [bin (lsb/read-int rdr)
@@ -65,8 +65,8 @@
         bidx))))
 
 (defn- read-bin-index*!
-  [rdr ref-idx]
-  (let [n-ref (lsb/read-int rdr)]
+  [rdr ^long ref-idx]
+  (let [n-ref (int (lsb/read-int rdr))]
     (when (>= ref-idx n-ref)
       (throw (IndexOutOfBoundsException. "The reference index number is invalid")))
     (skip-index! rdr ref-idx)
@@ -74,15 +74,15 @@
 
 (defn- read-linear-index**!
   [rdr]
-  (let [n (lsb/read-int rdr)]
+  (let [n (int (lsb/read-int rdr))]
     (loop [i 0, lidx []]
       (if (< i n)
         (recur (inc i) (conj lidx (lsb/read-long rdr)))
         lidx))))
 
 (defn- read-linear-index*!
-  [rdr ref-idx]
-  (let [n-ref (lsb/read-int rdr)]
+  [rdr ^long ref-idx]
+  (let [n-ref (int (lsb/read-int rdr))]
     (when (>= ref-idx n-ref)
       (throw (IndexOutOfBoundsException. "The reference index number is invalid")))
     (skip-index! rdr ref-idx)

--- a/src/cljam/io/bam_index/writer.clj
+++ b/src/cljam/io/bam_index/writer.clj
@@ -96,8 +96,8 @@
         win-end (if (zero? aln-end)
                   win-beg
                   (util-bin/pos->lidx-offset aln-end linear-index-shift))
-        min* (fn [x]
-               (if x (min x beg) beg))]
+        min* (fn ^long [x]
+               (if x (min (long x) beg) beg))]
     (loop [i win-beg, ret linear-index]
       (if (<= i win-end)
         (recur (inc i) (assoc ret i (min* (get ret i))))
@@ -159,7 +159,7 @@
   "Complements a linear index.
   e.g. ([1 10] [3 30]) -> ([0 0] [1 10] [2 10] [3 30])"
   [linear-index]
-  (loop [[f & r] (if (zero? (ffirst linear-index))
+  (loop [[f & r] (if (zero? (long (ffirst linear-index)))
                    linear-index
                    (conj linear-index [0 0]))
          ret []]
@@ -210,7 +210,8 @@
 (defn merge-index
   "Merges two intermediate indices, returning the merged intermediate index."
   [idx1 idx2]
-  (let [no-coordinate-alns (+ (:no-coordinate-alns idx1) (:no-coordinate-alns idx2))
+  (let [no-coordinate-alns (+ (long (:no-coordinate-alns idx1))
+                              (long (:no-coordinate-alns idx2)))
         idx1 (dissoc idx1 :no-coordinate-alns)
         idx2 (dissoc idx2 :no-coordinate-alns)]
     (-> (merge-with
@@ -289,7 +290,7 @@
   "Update the last pointer of the index to the given value."
   [index eof-ptr]
   (if (or (= (keys index) [:no-coordinate-alns])
-          (pos? (get index :no-coordinate-alns 0)))
+          (pos? (long (get index :no-coordinate-alns 0))))
     index
     (let [last-ref (apply max (keys (dissoc index :no-coordinate-alns)))
           last-key (->> (for [[bin chunks] (get-in index [last-ref :bin-index])

--- a/src/cljam/io/bam_index/writer.clj
+++ b/src/cljam/io/bam_index/writer.clj
@@ -19,7 +19,7 @@
 
 (deftype BAIWriter [^DataOutputStream writer refs url]
   Closeable
-  (close [this]
+  (close [_]
     (.close writer)))
 
 

--- a/src/cljam/io/bcf/reader.clj
+++ b/src/cljam/io/bcf/reader.clj
@@ -36,12 +36,15 @@
   protocols/IRegionReader
   (read-in-region [this region]
     (protocols/read-in-region this region {}))
-  (read-in-region [this {:keys [chr start end]} option]
+  (read-in-region [this {:keys [chr ^long start ^long end]} option]
     (logging/warn "May cause degradation of performance.")
     (filter
-     (fn [v] (and (if chr (= (:chr v) chr) true)
-                  (if start (<= start (:pos v)) true)
-                  (if end (<= (+ (:pos v) (count (:ref v))) end) true)))
+     (fn [{^long v-pos :pos
+           v-chr :chr
+           v-ref :ref}]
+       (and (if chr (= v-chr chr) true)
+            (if start (<= start v-pos) true)
+            (if end (<= (+ v-pos (count v-ref)) end) true)))
      (read-variants this option))))
 
 ;; need dynamic extension for namespace issue.
@@ -75,15 +78,15 @@
      :header (first (map vcf-reader/parse-header-line headers))}))
 
 (defn reader
-  "Returns an open cljam.bcf.reader.BCFReader of f. Should be used inside with-open to
-  ensure the Reader is properly closed.
-   Throws IOException if failed to parse BCF file format."
+  "Returns an open cljam.bcf.reader.BCFReader of f. Should be used inside
+  with-open to ensure the Reader is properly closed.
+  Throws IOException if failed to parse BCF file format."
   ^BCFReader
   [f]
   (let [rdr (bgzf/bgzf-input-stream f)
         magic (lsb/read-bytes rdr 5)]
     (if (= (seq magic) (map byte "BCF\2\2"))
-      (let [hlen (lsb/read-int rdr)
+      (let [hlen (int (lsb/read-int rdr))
             header-buf (lsb/read-bytes rdr hlen)]
         (if (zero? (aget ^bytes header-buf (dec hlen))) ;; NULL-terminated
           (let [{:keys [header meta]} (->> (String. ^bytes header-buf
@@ -95,24 +98,29 @@
                         (delay (csi/read-index (str f ".csi")))))
           (do
             (.close rdr)
-            (throw (IOException. (str "Invalid file format. BCF header must be NULL-terminated."))))))
+            (throw
+             (IOException.
+              "Invalid file format. BCF header must be NULL-terminated.")))))
       (do
         (.close rdr)
-        (throw (IOException. (str "Invalid file format. BCF v2.2 magic not found in " f)))))))
+        (throw
+         (IOException.
+          (str "Invalid file format. BCF v2.2 magic not found in " f)))))))
 
 (defn- read-typed-atomic-value
   "Reads an atomic value, which is typed as either
   integer(8,16,32 bit) or float or character."
   [r ^long type-id]
   (case type-id
-    1 (let [i (lsb/read-byte r)]
+    1 (let [i (byte (lsb/read-byte r))]
         (case (bit-and 0xFF i) 0x80 nil 0x81 :eov i))
-    2 (let [i (lsb/read-short r)]
+    2 (let [i (short (lsb/read-short r))]
         (case (bit-and 0xFFFF i) 0x8000 nil 0x8001 :eov i))
-    3 (let [i (lsb/read-int r)]
+    3 (let [i (int (lsb/read-int r))]
         (case (bit-and 0xFFFFFFFF i) 0x80000000 nil 0x80000001 :eov i))
-    5 (let [i (lsb/read-int r)]
-        (case (bit-and 0xFFFFFFFF i) 0x7F800001 nil 0x7F800002 :eov (Float/intBitsToFloat i)))
+    5 (let [i (int (lsb/read-int r))]
+        (case (bit-and 0xFFFFFFFF i) 0x7F800001 nil 0x7F800002
+              :eov (Float/intBitsToFloat i)))
     7 (lsb/read-byte r)))
 
 (defn- bytes->strs
@@ -128,10 +136,10 @@
   after type specifier byte."
   ([rdr]
    (first (read-typed-value rdr 1)))
-  ([rdr n-sample]
-   (let [type-byte (lsb/read-byte rdr)
+  ([rdr ^long n-sample]
+   (let [type-byte (int (lsb/read-byte rdr))
          len (unsigned-bit-shift-right (bit-and 0xF0 type-byte) 4)
-         total-len (if (= len 15) (first (read-typed-value rdr)) len)
+         total-len (if (= len 15) (long (first (read-typed-value rdr))) len)
          type-id (bit-and 0x0F type-byte)]
      (case type-id
        0 (repeat n-sample nil)
@@ -169,7 +177,7 @@
   "Parses only chromosome, position and ref-length. Can be used for position-based querying."
   [contigs {:keys [^ByteBuffer shared] :as m}]
   (let [chrom-id (lsb/read-int shared)
-        pos (inc (lsb/read-int shared))
+        pos (inc (int (lsb/read-int shared)))
         rlen (lsb/read-int shared)]
     (.position ^Buffer shared 0)
     (assoc m :chr (:id (contigs chrom-id)) :pos pos :rlen rlen)))
@@ -178,13 +186,13 @@
   "Parses full data of a variant. Returns a map containing indices for meta-info."
   [{:keys [^ByteBuffer shared ^ByteBuffer individual]}]
   (let [chrom-id (lsb/read-int shared)
-        pos (inc (lsb/read-int shared))
+        pos (inc (int (lsb/read-int shared)))
         rlen (lsb/read-int shared)
         qual (lsb/read-int shared)
-        n-allele-info (lsb/read-int shared)
+        n-allele-info (int (lsb/read-int shared))
         n-allele (unsigned-bit-shift-right n-allele-info 16)
         n-info (bit-and n-allele-info 0xFFFF)
-        n-fmt-sample (lsb/read-uint shared)
+        n-fmt-sample (long (lsb/read-uint shared))
         n-fmt (bit-and 0xFF (unsigned-bit-shift-right n-fmt-sample 24))
         n-sample (bit-and n-fmt-sample 0xFFFFFF)
         id (let [i (read-typed-value shared)] (if (sequential? i) (first i) i))
@@ -305,7 +313,7 @@
   "Reads variants of the BCF file randomly using csi file.
    Returns them as a lazy sequence."
   [^BCFReader rdr
-   {:keys [chr start end] :or {start 1 end 4294967296}}
+   {:keys [chr ^long start ^long end] :or {start 1 end 4294967296}}
    {:keys [depth] :or {depth :deep}}]
   (let [info (meta->map (:info (.meta-info rdr)))
         parse-fn  (make-parse-fn rdr info depth)
@@ -325,10 +333,11 @@
             repeatedly
             (take-while identity)
             (filter
-             (fn [{chr' :chr :keys [pos ref info]}]
+             (fn [{chr' :chr :keys [^long pos ref info]}]
                (and (= chr' chr)
                     (<= pos end)
-                    (<= start (get info :END (dec (+ pos (count ref))))))))))
+                    (<= start
+                        (long (get info :END (dec (+ pos (count ref)))))))))))
      spans)))
 
 (defn read-file-offsets
@@ -345,7 +354,7 @@
               (when (pos? (.available input-stream))
                 (when-let [line (read-data-line-buffer input-stream)]
                   (let [end-pointer (.getFilePointer input-stream)
-                        {:keys [chr pos rlen]} (parse-fn line)]
+                        {:keys [chr ^long pos ^long rlen]} (parse-fn line)]
                     (cons {:file-beg beg-pointer, :file-end end-pointer
                            :chr-index (contigs chr), :beg pos, :chr chr,
                            :end (dec (+ pos rlen))}

--- a/src/cljam/io/bcf/reader.clj
+++ b/src/cljam/io/bcf/reader.clj
@@ -74,10 +74,11 @@
             metas)
      :header (first (map vcf-reader/parse-header-line headers))}))
 
-(defn ^BCFReader reader
+(defn reader
   "Returns an open cljam.bcf.reader.BCFReader of f. Should be used inside with-open to
   ensure the Reader is properly closed.
    Throws IOException if failed to parse BCF file format."
+  ^BCFReader
   [f]
   (let [rdr (bgzf/bgzf-input-stream f)
         magic (lsb/read-bytes rdr 5)]

--- a/src/cljam/io/bcf/writer.clj
+++ b/src/cljam/io/bcf/writer.clj
@@ -57,7 +57,7 @@
                    (str (char 0)) ;; NULL-terminated
                    .getBytes)
         hlen (alength hdr-ba)]
-    (lsb/write-bytes wtr (byte-array (map byte "BCF\2\2")))
+    (lsb/write-bytes wtr (byte-array (map (comp byte int) "BCF\2\2")))
     (lsb/write-int wtr hlen)
     (lsb/write-bytes wtr hdr-ba)))
 
@@ -146,7 +146,7 @@
          len-bytes (when (<= 15 max-len)
                      (encode-typed-value :int max-len))
          n-bytes (+ (* n-sample max-len (case type-id 1 1 2 2 3 4 5 4 7 1))
-                    1 (if len-bytes (alength ^bytes len-bytes) 0))
+                    1 (if len-bytes (long (alength ^bytes len-bytes)) 0))
          bb (ByteBuffer/allocate n-bytes)]
      (.order bb ByteOrder/LITTLE_ENDIAN)
      (.put bb (unchecked-byte type-byte))
@@ -160,7 +160,7 @@
          3 (.putInt bb (unchecked-int (get int32-special-map b b)))
          5 (.putInt bb (unchecked-int (or (get float32-special-map b)
                                           (Float/floatToRawIntBits b))))
-         7 (.put bb (byte (get {nil 0 :eov 0} b b)))))
+         7 (.put bb (byte (get {nil 0 :eov 0} b (int b))))))
      (.array bb))))
 
 (defn- concat-bytes
@@ -251,7 +251,7 @@
     (-> (apply dissoc variant kws)
         (assoc :n-sample (count indiv-kws)
                :ref-length (if-let [e (get-in variant [:info :END])]
-                             (inc (- e (:pos variant)))
+                             (inc (- (long e) (long (:pos variant))))
                              (count (:ref variant)))
                :format (map (comp :idx second) fmts)
                :genotype genotype)

--- a/src/cljam/io/bcf/writer.clj
+++ b/src/cljam/io/bcf/writer.clj
@@ -75,7 +75,7 @@
         (update :contig #(map-indexed (fn [i c] (assoc c :idx (str i))) %))
         (merge fif))))
 
-(defn ^BCFWriter writer
+(defn writer
   "Returns an open cljam.bcf.BCFWriter of f.
    Meta-information lines and a header line will be written in this function.
    Should be used inside with-open to ensure the Writer is properly closed. e.g.
@@ -84,6 +84,7 @@
                              {:file-date \"20090805\", :source \"myImpu...\" ...}
                              [\"CHROM\" \"POS\" \"ID\" \"REF\" \"ALT\" ...])]
        (WRITING-BCF))"
+  ^BCFWriter
   [f meta-info header]
   (let [bos (bgzf/bgzf-output-stream f)
         dos (DataOutputStream. bos)

--- a/src/cljam/io/bed.clj
+++ b/src/cljam/io/bed.clj
@@ -21,12 +21,12 @@
   protocols/IReader
   (reader-url [this] (.url this))
   (read [this] (protocols/read this {}))
-  (read [this option] (read-fields this))
+  (read [this _] (read-fields this))
   (indexed? [_] false)
   protocols/IRegionReader
   (read-in-region [this region]
     (protocols/read-in-region this region {}))
-  (read-in-region [this {:keys [chr start end]} option]
+  (read-in-region [this {:keys [chr start end]} _]
     (logging/warn "May cause degradation of performance.")
     (filter (fn [m] (and (or (not chr) (= (:chr m) chr))
                          (or (not start) (<= start (:start m)))
@@ -40,15 +40,17 @@
   protocols/IWriter
   (writer-url [this] (.url this)))
 
-(defn ^BEDReader reader
+(defn reader
   "Returns an open cljam.io.bed.BEDReader of f. Should be used inside with-open
   to ensure the reader is properly closed."
+  ^BEDReader
   [f]
   (BEDReader. (cio/reader (util/compressor-input-stream f)) (util/as-url f)))
 
-(defn ^BEDWriter writer
+(defn writer
   "Returns an open cljam.io.bed.BEDWriter of f. Should be used inside with-open
   to ensure the writer is properly closed."
+  ^BEDWriter
   [f]
   (BEDWriter. (cio/writer (util/compressor-output-stream f)) (util/as-url f)))
 

--- a/src/cljam/io/bed.clj
+++ b/src/cljam/io/bed.clj
@@ -26,11 +26,14 @@
   protocols/IRegionReader
   (read-in-region [this region]
     (protocols/read-in-region this region {}))
-  (read-in-region [this {:keys [chr start end]} _]
+  (read-in-region [this {:keys [chr ^long start ^long end]} _]
     (logging/warn "May cause degradation of performance.")
-    (filter (fn [m] (and (or (not chr) (= (:chr m) chr))
-                         (or (not start) (<= start (:start m)))
-                         (or (not end) (<= (:end m) end))))
+    (filter (fn [{^long m-start :start
+                  ^long m-end :end
+                  m-chr :chr}]
+              (and (or (not chr) (= m-chr chr))
+                   (or (not start) (<= start m-start))
+                   (or (not end) (<= m-end end))))
             (read-fields this))))
 
 (defrecord BEDWriter [^BufferedWriter writer ^URL url]
@@ -86,7 +89,7 @@
   {:post [;; First 3 fields are required.
           (:chr %) (:start %) (:end %)
           ;; The chromEnd base is not included in the display of the feature.
-          (< (:start %) (:end %))
+          (< (long (:start %)) (long (:end %)))
           ;; Lower-numbered fields must be populated if higher-numbered fields are used.
           (every? true? (drop-while false? (map nil? ((apply juxt bed-columns) %))))
           ;; A score between 0 and 1000.
@@ -98,9 +101,15 @@
           ;; The first blockStart value must be 0.
           (if-let [[f] (:block-starts %)] (= 0 f) true)
           ;; The final blockStart position plus the final blockSize value must equal chromEnd.
-          (if-let [xs (:block-starts %)] (= (+ (last xs) (last (:block-sizes %))) (- (:end %) (:start %))) true)
+          (if-let [xs (:block-starts %)] (= (+ (long (last xs))
+                                               (long (last (:block-sizes %))))
+                                            (- (long (:end %))
+                                               (long (:start %)))) true)
           ;; Blocks may not overlap.
-          (if-let [xs (:block-starts %)] (apply <= (mapcat (fn [a b] [a (+ a b)]) xs (:block-sizes %))) true)]}
+          (if-let [xs (:block-starts %)]
+            (apply <= (mapcat (fn [^long a ^long b] [a (+ a b)])
+                              xs (:block-sizes %)))
+            true)]}
   (reduce
    (fn deserialize-bed-reduce-fn [m [k f]] (update-some m k f))
    (zipmap bed-columns (cstr/split s #"\s+"))
@@ -120,7 +129,7 @@
   {:pre [;; First 3 fields are required.
          (:chr m) (:start m) (:end m)
          ;; The chromEnd base is not included in the display of the feature.
-         (< (:start m) (:end m))
+         (< (long (:start m)) (long (:end m)))
          ;; Lower-numbered fields must be populated if higher-numbered fields are used.
          (every? true? (drop-while false? (map nil? ((apply juxt bed-columns) m))))
          ;; A score between 0 and 1000.
@@ -132,9 +141,14 @@
          ;; The first blockStart value must be 0.
          (if-let [[f] (:block-starts m)] (= 0 f) true)
          ;; The final blockStart position plus the final blockSize value must equal chromEnd.
-         (if-let [xs (:block-starts m)] (= (+ (last xs) (last (:block-sizes m))) (- (:end m) (:start m))) true)
+         (if-let [xs (:block-starts m)]
+           (= (+ (long (last xs)) (long (last (:block-sizes m))))
+              (- (long (:end m)) (long (:start m)))) true)
          ;; Blocks may not overlap.
-         (if-let [xs (:block-starts m)] (apply <= (mapcat (fn [a b] [a (+ a b)]) xs (:block-sizes m))) true)]}
+         (if-let [xs (:block-starts m)]
+           (apply <= (mapcat (fn [^long a ^long b] [a (+ a b)])
+                             xs (:block-sizes m)))
+           true)]}
   (->> (-> m
            (update-some :strand #(case % :forward "+" :reverse "-" nil "."))
            (update-some :block-sizes long-list->str)
@@ -277,15 +291,18 @@
     (when-first [{:keys [chr]} (filter #(not (chr->len (:chr %))) xs)]
       (let [msg (str "Length of chromosome " chr " not specified")]
         (throw (IllegalArgumentException. msg))))
-    (letfn [(complement [xs chrs pos]
+    (letfn [(complement [xs chrs ^long pos]
               (lazy-seq
                (when-let [chr (first chrs)]
-                 (let [len (get chr->len chr)
-                       x (first xs)]
-                   (if (and x (= (:chr x) chr))
-                     (cond->> (complement (next xs) chrs (inc (:end x)))
-                       (< pos (:start x))
-                       (cons {:chr chr :start pos :end (dec (:start x))}))
+                 (let [len (long (get chr->len chr))
+                       {^long x-start :start
+                        ^long x-end :end
+                        x-chr :chr
+                        :as x} (first xs)]
+                   (if (and x (= x-chr chr))
+                     (cond->> (complement (next xs) chrs (inc x-end))
+                       (< pos (long (:start x)))
+                       (cons {:chr chr :start pos :end (dec x-start)}))
                      (cond->> (complement xs (next chrs) 1)
                        (< pos len)
                        (cons {:chr chr :start pos :end len})))))))]

--- a/src/cljam/io/bigwig.clj
+++ b/src/cljam/io/bigwig.clj
@@ -73,25 +73,25 @@
 
 (defn- check-bigwig-magic
   "Checks if the magic is right for bigWig format. Otherwise, throws IOException."
-  [uint]
+  [^long uint]
   (when-not (= uint bigwig-magic)
     (throw (IOException. "Invalid bigWig magic"))))
 
 (defn- check-version
   "Ranged from [1,4]. Throws IOException if the version is out of range."
-  [ushort]
+  [^long ushort]
   (when-not (<= 1 ushort 4)
     (throw (IOException. "Invalid bigWig version"))))
 
 (defn- check-field-count
   "For bigWig 0. Throws IOException if the fieldCount is invalid."
-  [ushort]
+  [^long ushort]
   (when-not (zero? ushort)
     (throw (IOException. "Invalid bigWig fieldCount"))))
 
 (defn- check-defined-field-count
   "For bigWig 0. Throws IOException if the definedFieldCount is invalid."
-  [ushort]
+  [^long ushort]
   (when-not (zero? ushort)
     (throw (IOException. "Invalid bigWig definedFieldCount"))))
 
@@ -129,7 +129,7 @@
 (defn- read-zoom-headers
   "Returns a vector of ZoomHeader from reader."
   [^RandomAccessFile r {:keys [zoom-levels]}]
-  (letfn [(read-zoom-header [n acc]
+  (letfn [(read-zoom-header [^long n acc]
             (if (zero? n)
               acc
               (let [reduction-level (lsb/read-uint r)
@@ -144,7 +144,7 @@
 
 (defn- read-total-summary
   "Returns a totalSummay. If it isn't present, returns nil."
-  [^RandomAccessFile r {:keys [total-summary-offset]}]
+  [^RandomAccessFile r {:keys [^long total-summary-offset]}]
   (when-not (zero? total-summary-offset)
     (.seek r total-summary-offset)
     (let [bases-covered (lsb/read-long r)
@@ -158,7 +158,7 @@
 (defn- read-extended-header
   "Returns an extendedHeader. It it isn't present, returns nil."
   [^RandomAccessFile r {:keys [extension-offset]}]
-  (when-not (zero? extension-offset)
+  (when-not (zero? (long extension-offset))
     (.seek r extension-offset)
     (let [extension-size (lsb/read-ushort r)
           extra-index-count (lsb/read-ushort r)
@@ -209,7 +209,7 @@
   (->> (lsb/read-bytes r length)
        (reduce
         (fn [cs c]
-          (if (zero? c)
+          (if (zero? (byte c))
             (reduced cs)
             (conj cs c)))
         [])
@@ -240,7 +240,7 @@
   [^RandomAccessFile r {:keys [key-size root-offset]}]
   (letfn [(traverse [block-start]
             (.seek r block-start)
-            (let [leaf? (-> r lsb/read-ubyte zero? not)
+            (let [leaf? (-> r lsb/read-ubyte short zero? not)
                   _reversed (lsb/read-ubyte r)
                   child-count (lsb/read-ushort r)]
               (if leaf?
@@ -281,15 +281,15 @@
 (defn- cir-tree-overlaps?
   "Returns true if the given blocks are overlapped."
   [id start end start-chrom-ix start-base end-chrom-ix end-base]
-  (letfn [(cmp [a-hi a-lo b-hi b-lo]
+  (letfn [(cmp ^long [^long a-hi ^long a-lo ^long b-hi ^long b-lo]
             (cond
               (< a-hi b-hi) 1
               (> a-hi b-hi) -1
               (< a-lo b-lo) 1
               (> a-lo b-lo) -1
               :else 0))]
-    (and (pos? (cmp id start end-chrom-ix end-base))
-         (neg? (cmp id end start-chrom-ix start-base)))))
+    (and (pos? (long (cmp id start end-chrom-ix end-base)))
+         (neg? (long (cmp id end start-chrom-ix start-base))))))
 
 (defn- cir-tree-leaves->blocks
   "Convert CirTree leaves into blocks that contain a flat map including offset and size."
@@ -313,7 +313,7 @@
   [^RandomAccessFile r id start end {:keys [root-offset]}]
   (letfn [(make-blocks [index-file-offset]
             (.seek r index-file-offset)
-            (let [leaf? (-> r lsb/read-ubyte zero? not)
+            (let [leaf? (-> r lsb/read-ubyte short zero? not)
                   _reserved (lsb/read-ubyte r)
                   child-count (lsb/read-ushort r)]
               (if leaf?
@@ -348,9 +348,9 @@
 
 (defn- range-intersection
   "Returns a range intersection of two ranges that include `start` and `end`."
-  [a b]
-  (- (min (:end a) (:end b))
-     (max (:start a) (:start b))))
+  ^long [a b]
+  (- (min (long (:end a)) (long (:end b)))
+     (max (long (:start a)) (long (:start b)))))
 
 (defn- ->bedgraph
   "Converts bigWig tracks into BedGraph format (1-based, fully-closed)."
@@ -371,28 +371,30 @@
   "Converts bigWig tracks into variableStep tracks of wig format
   (1-start, fully-closed)."
   [^ByteBuffer bb item-span item-count chrom rng]
-  (->> (repeatedly item-count
-                   (fn []
-                     (let [start (.getInt bb)
-                           value (.getFloat bb)]
-                       (when (pos? (range-intersection rng {:start start
-                                                            :end (+ start item-span)}))
-                         {:track {:line nil :format :variable-step :chr chrom
-                                  :step nil :span item-span}
-                          :chr chrom :start (inc start)
-                          :end (+ start item-span) :value value}))))
-       (remove nil?)
-       doall))
+  (let [item-span (long item-span)]
+    (->> (repeatedly
+          item-count
+          (fn []
+            (let [start (.getInt bb)
+                  value (.getFloat bb)]
+              (when (pos? (range-intersection
+                           rng {:start start, :end (+ start item-span)}))
+                {:track {:line nil :format :variable-step :chr chrom
+                         :step nil :span item-span}
+                 :chr chrom :start (inc start)
+                 :end (+ start item-span) :value value}))))
+         (remove nil?)
+         doall)))
 
 (defn- ->fixed-step
   "Converts bigWig tracks into fixedStep tracks of wig format
   (1-start, fully-closed)."
   [^ByteBuffer bb start item-step item-span item-count chrom rng]
   (reduce
-   (fn [acc i]
+   (fn [acc ^long i]
      (let [value (.getFloat bb)
-           cur-start (+ start (* i item-step))
-           cur-end (+ cur-start item-span)]
+           cur-start (+ (long start) (* i (long item-step)))
+           cur-end (+ cur-start (long item-span))]
        (if (pos? (range-intersection rng {:start cur-start :end cur-end}))
          (conj acc {:track {:line nil :format :fixed-step :chr chrom
                             :step item-step :span item-span}

--- a/src/cljam/io/bigwig.clj
+++ b/src/cljam/io/bigwig.clj
@@ -58,12 +58,13 @@
   protocols/IReader
   (reader-url [this] (.url this))
   (read [this] (read-tracks this))
-  (read [this option] (read-tracks this))
+  (read [this _] (read-tracks this))
   (indexed? [_] false))
 
-(defn ^BIGWIGReader reader
+(defn reader
   "Returns an open cljam.io.bigwig.BIGWIGReader of f. Should be used inside with-open
   to ensure the reader is properly closed."
+  ^BIGWIGReader
   [f]
   (let [f (.getAbsolutePath (cio/file f))
         reader (RandomAccessFile. f "r")

--- a/src/cljam/io/csi.clj
+++ b/src/cljam/io/csi.clj
@@ -9,7 +9,7 @@
            [java.io DataInputStream DataOutputStream IOException]
            [java.nio ByteBuffer ByteOrder]))
 
-(def ^:const ^:private ^String csi-magic "CSI\1")
+(def ^:const ^:private csi-magic "CSI\1")
 
 (def ^:private ^:const default-vcf-csi-aux
   {:format 2, :col-seq 1, :col-beg 2, :col-end 0, :meta-char \#, :skip 0})

--- a/src/cljam/io/csi.clj
+++ b/src/cljam/io/csi.clj
@@ -9,7 +9,7 @@
            [java.io DataInputStream DataOutputStream IOException]
            [java.nio ByteBuffer ByteOrder]))
 
-(def ^:const ^:private csi-magic "CSI\1")
+(def ^:const ^:private ^String csi-magic "CSI\1")
 
 (def ^:private ^:const default-vcf-csi-aux
   {:format 2, :col-seq 1, :col-beg 2, :col-end 0, :meta-char \#, :skip 0})

--- a/src/cljam/io/csi.clj
+++ b/src/cljam/io/csi.clj
@@ -102,7 +102,7 @@
                  #(into
                    (sorted-map)
                    (keep
-                    (fn [{:keys [bin loffset]}]
+                    (fn [{:keys [^long bin loffset]}]
                       (when (<= bin max-bin)
                         [(util-bin/bin-beg bin min-shift depth)
                          loffset]))) %)
@@ -154,8 +154,9 @@
 
 (defn- calc-loffsets [begs file-offsets]
   (->> begs
-       (map (fn [beg]
-              [beg (->> (drop-while #(< (:end %) beg) file-offsets)
+       (map (fn [^long beg]
+              [beg (->> file-offsets
+                        (drop-while #(< (long (:end %)) beg))
                         (map :file-beg)
                         first)]))
        (into (sorted-map))))
@@ -165,7 +166,7 @@
    (fn [r [k v]]
      (if (contains? r k)
        (assoc r k v)
-       (conj (into r (repeat (- k (count r)) nil)) v)))
+       (conj (into r (repeat (- (long k) (count r)) nil)) v)))
    []
    xs))
 
@@ -185,7 +186,8 @@
                          l (calc-loffsets
                             (into #{}
                                   (comp
-                                   (filter #(<= % (util-bin/max-bin depth)))
+                                   (filter (fn [^long x]
+                                             (<= x (util-bin/max-bin depth))))
                                    (map #(util-bin/bin-beg % shift depth)))
                                   (keys b))
                             offsets)
@@ -223,7 +225,7 @@
           (lsb/write-int w bin)
           (lsb/write-long
            w
-           (if (<= bin max-bin)
+           (if (<= (long bin) max-bin)
              (get loffset (util-bin/bin-beg bin (.min-shift csi) (.depth csi)))
              0))
           (lsb/write-int w (count chunks))

--- a/src/cljam/io/dict/core.clj
+++ b/src/cljam/io/dict/core.clj
@@ -14,9 +14,10 @@
 ;; Writing
 ;; -------
 
-(defn ^DICTWriter writer
+(defn writer
   "Opens f, returning a `cljam.dict.writer.DICTWriter`. Should be used inside
   `with-open` to ensure the writer is properly closed."
+  ^DICTWriter
   [f]
   (DICTWriter. (cio/writer f)
                (util/as-url f)))

--- a/src/cljam/io/dict/writer.clj
+++ b/src/cljam/io/dict/writer.clj
@@ -10,7 +10,7 @@
 
 (deftype DICTWriter [^java.io.BufferedWriter writer url]
   java.io.Closeable
-  (close [this]
+  (close [_]
     (.close writer)))
 
 ;; Making dict

--- a/src/cljam/io/dict/writer.clj
+++ b/src/cljam/io/dict/writer.clj
@@ -17,11 +17,11 @@
 ;; -----------
 
 (def ^:const ^:private upper-case-offset
-  "Equals to `(- (byte \\A) (byte \\a))`."
+  "Equals to `(- (byte (int \\A)) (byte (int \\a)))`."
   -32)
 
-(defn- upper-case [b]
-  (if (or (< b (byte \a)) (> b (byte \z)))
+(defn- upper-case [^long b]
+  (if (or (< b (byte (int \a))) (> b (byte (int \z))))
     b
     (byte (+ b upper-case-offset))))
 
@@ -42,7 +42,7 @@
 (defn- update-dict-status
   [dict-status sequence]
   {:sequence (str (:sequence dict-status) sequence)
-   :len (+ (:len dict-status) (count (filter graph? sequence)))})
+   :len (+ (long (:len dict-status)) (count (filter graph? sequence)))})
 
 (defn make-dict
   "Calculates sequence dictionary from the headers and sequences, returning it

--- a/src/cljam/io/fasta/core.clj
+++ b/src/cljam/io/fasta/core.clj
@@ -35,7 +35,7 @@
      (delay (bgzip-index f)))
     (RandomAccessFile. (cio/as-file f) "r")))
 
-(defn ^FASTAReader reader
+(defn reader ^FASTAReader
   [f]
   (let [url (util/as-url f)]
     (FASTAReader. (random-accessor url)
@@ -43,8 +43,9 @@
                   url
                   (delay (fasta-index url)))))
 
-(defn ^FASTAReader clone-reader
+(defn clone-reader
   "Clones fasta reader sharing persistent objects."
+  ^FASTAReader
   [^FASTAReader rdr]
   (let [url (.url rdr)
         r (if (instance? RandomAccessFile (.reader rdr))

--- a/src/cljam/io/fasta/writer.clj
+++ b/src/cljam/io/fasta/writer.clj
@@ -28,7 +28,7 @@
     (FASTAWriter. (util/as-url abs-f) cols writer index-writer (volatile! 0))))
 
 (defn- write-name
-  [^FASTAWriter w ^String n]
+  ^long [^FASTAWriter w ^String n]
   (let [wtr ^BufferedWriter (.writer w)]
     (.write wtr (int \>))
     (.write wtr n)
@@ -67,12 +67,12 @@
                               (write-seq w seq-data))]
     (when-let [iwtr ^BufferedWriter (.index-writer w)]
       (let [c (Math/min (.cols w) (int seq-len))
-            offset (+ @(.curr-offset w) name-bytes)]
+            offset (+ (long @(.curr-offset w)) name-bytes)]
         (->> [chr-name seq-len offset c (+ c (.length (System/lineSeparator)))]
              (cstr/join \tab)
              (.write iwtr))
         (.newLine iwtr)
-        (vswap! (.curr-offset w) + name-bytes seq-bytes)))))
+        (vreset! (.curr-offset w) (+ offset (long seq-bytes)))))))
 
 (defn write-sequences
   [w xs]

--- a/src/cljam/io/fasta_index/core.clj
+++ b/src/cljam/io/fasta_index/core.clj
@@ -63,16 +63,20 @@
 
 (defn get-span
   "Calculate byte spans for FASTA file"
-  [^FAIReader fai name start end]
+  [^FAIReader fai name ^long start ^long end]
   (let [start (max 0 start)
         end (max 0 end)]
-    (when-let [index (get (.indices fai) name nil)]
-      (let [start (min (:len index) start)
-            end (min (:len index) end)
-            proj (fn [pos]
-                   (+ (:offset index)
-                      (+ (* (quot pos (:line-blen index))
-                            (:line-len index))
-                         (rem pos (:line-blen index)))))]
+    (when-let [{^long index-offset :offset
+                ^long index-len :len
+                ^long index-line-len :line-len
+                ^long index-line-blen :line-blen}
+               (get (.indices fai) name nil)]
+      (let [start (min index-len start)
+            end (min index-len end)
+            proj (fn [^long pos]
+                   (+ index-offset
+                      (+ (* (quot pos index-line-blen)
+                            index-line-len)
+                         (rem pos index-line-blen))))]
         (when (< start end)
           [(proj start) (proj end)])))))

--- a/src/cljam/io/fasta_index/writer.clj
+++ b/src/cljam/io/fasta_index/writer.clj
@@ -33,7 +33,7 @@
               (reset! current-index i))
             (do (swap! current-index
                        assoc
-                       :len (+ (:len @current-index) llen))
+                       :len (+ (long (:len @current-index)) llen))
                 (when (or (nil? (:line-blen @current-index))
                           (nil? (:line-len @current-index)))
                   (swap! current-index

--- a/src/cljam/io/fastq.clj
+++ b/src/cljam/io/fastq.clj
@@ -26,17 +26,19 @@
   protocols/IWriter
   (writer-url [this] (.url this)))
 
-(defn ^FASTQReader reader
+(defn reader
   "Returns an open cljam.io.fastq.FASTQReader of f. Should be used inside
   with-open to ensure the reader is properly closed."
+  ^FASTQReader
   [f]
   (-> (util/compressor-input-stream f)
       cio/reader
       (FASTQReader. (util/as-url f))))
 
-(defn ^FASTQWriter writer
+(defn writer
   "Returns an open cljam.io.fastq.FASTQWriter of f. Should be used inside
   with-open to ensure the writer is properly closed."
+  ^FASTQWriter
   [f]
   (-> (util/compressor-output-stream f)
       cio/writer
@@ -44,8 +46,9 @@
 
 (defrecord FASTQRead [^String name ^String sequence quality])
 
-(defn- ^FASTQRead deserialize-fastq
+(defn- deserialize-fastq
   "Deserialize a read from 4 lines of fastq file."
+  ^FASTQRead
   [[^String name-line ^String seq-line ^String plus-line ^String qual-line]
    {:keys [decode-quality] :or {decode-quality :phred33}}]
   {:pre [(not-empty name-line)
@@ -82,8 +85,9 @@
           (map #(deserialize-fastq % opts)))
     (line-seq (.reader rdr)))))
 
-(defn- ^String serialize-fastq
+(defn- serialize-fastq
   "Serialize a FASTQRead to FASTQ format string."
+  ^String
   [^FASTQRead {:keys [^String name ^String sequence quality]}
    {:keys [encode-quality] :or {encode-quality :phred33}}]
   {:pre [(not-empty name)
@@ -137,8 +141,9 @@
        :index (Integer/parseInt index)
        :pair (Integer/parseInt pair)})))
 
-(defn ^String serialize-casava-name
+(defn serialize-casava-name
   "Encode fastq name map to Casava-style string."
+  ^String
   [{:keys [instrument lane tile x y index pair]}]
   (when (and instrument lane tile x y index pair)
     (str instrument \: lane \: tile \: x \: y \# index \/ pair)))
@@ -163,8 +168,9 @@
        :control (Integer/parseInt control)
        :index index})))
 
-(defn ^String serialize-casava-1_8-name
+(defn serialize-casava-1_8-name
   "Encode fastq name map to Casava1.8-style string."
+  ^String
   [{:keys [instrument run flowcell lane tile x y pair filtered control index]}]
   (when (and instrument run flowcell lane tile x y pair (not (nil? filtered)) control index)
     (str instrument \: run \: flowcell \: lane \: tile \: x \: y " "
@@ -175,7 +181,8 @@
   [^String name]
   (first (keep #(% name) [deserialize-casava-1_8-name deserialize-casava-name])))
 
-(defn ^String serialize-name
+(defn serialize-name
   "Try encoding name of fastq read."
+  ^String
   [name]
   (first (keep #(% name) [serialize-casava-1_8-name serialize-casava-name])))

--- a/src/cljam/io/fastq.clj
+++ b/src/cljam/io/fastq.clj
@@ -110,8 +110,8 @@
       (.put cb ^String quality)
       (doseq [q quality]
         (.put cb (char (case encode-quality
-                         :phred33 (+ q 33)
-                         :phred64 (+ q 64)
+                         :phred33 (+ (long q) 33)
+                         :phred64 (+ (long q) 64)
                          q)))))
     (.put cb \newline)
     (.flip ^Buffer cb)

--- a/src/cljam/io/gff.clj
+++ b/src/cljam/io/gff.clj
@@ -33,7 +33,7 @@
       (= i 0x3D)
       (= i 0x7F)))
 
-(defn- ^String encode [pred ^String s]
+(defn- encode ^String [pred ^String s]
   (let [cb (CharBuffer/wrap s)
         sb (StringBuilder. (.length s))]
     (while (.hasRemaining cb)
@@ -50,10 +50,10 @@
           (.append sb c))))
     (str sb)))
 
-(defn- ^String encode-in-attr [s]
+(defn- encode-in-attr ^String [s]
   (encode escape-in-attr? s))
 
-(defn- ^String decode [pred ^String s]
+(defn- decode ^String [pred ^String s]
   (when s
     (let [cb (CharBuffer/wrap s)
           sb (StringBuilder. (.length s))]
@@ -75,10 +75,10 @@
             (.append sb c))))
       (str sb))))
 
-(defn- ^String decode-in-attr [s]
+(defn- decode-in-attr ^String [s]
   (decode escape-in-attr? s))
 
-(defn- ^String encode-multiple [xs]
+(defn- encode-multiple ^String [xs]
   (cstr/join \, (map encode-in-attr xs)))
 
 (defn- decode-multiple [s]
@@ -88,7 +88,7 @@
   target-regexp
   #"(\S+) ([1-9]\d*) ([1-9]\d*)(?: ([+-]))?")
 
-(defn- ^String encode-target [{:keys [chr start end strand]}]
+(defn- encode-target ^String [{:keys [chr start end strand]}]
   (cstr/join \space (cond-> [(encode escape-in-target? chr) start end]
                       strand (conj (case strand :forward \+ :reverse \-)))))
 
@@ -99,7 +99,7 @@
              :end (p/as-long end)}
       strand (assoc :strand (case (first strand) \+ :forward \- :reverse)))))
 
-(defn- ^String encode-gap [xs]
+(defn- encode-gap ^String [xs]
   (cstr/join \space (map (fn [[op len]] (str op len)) xs)))
 
 (defn- decode-gap [s]
@@ -109,7 +109,7 @@
         (fn [[_ [op] len]]
           [op (p/as-long len)]))))
 
-(defn- ^String encode-db [xs]
+(defn- encode-db ^String [xs]
   (->> xs
        (map
         (fn [{:keys [db-tag id]}]
@@ -175,9 +175,10 @@
   [^GFFReader reader]
   (.version reader))
 
-(defn ^GFFReader reader
+(defn reader
   "Returns an open `cljam.io.gff.GFFReader` instance of `f`. Should be used
   inside `with-open` to ensure the reader is properly closed."
+  ^GFFReader
   [f]
   (let [r ^BufferedReader (cio/reader (util/compressor-input-stream f))]
     (try
@@ -256,15 +257,15 @@
   (close [this]
     (.close ^Closeable (.writer this))))
 
-(defn ^GFFWriter writer
+(defn writer
   "Returns an open `cljam.io.gff.GFFWriter` instance of `f`. Should be used
   inside `with-open` to ensure the writer is properly closed. Can take an
   optional argument `options`, a map containing `:version`, `:major-revision`,
   `:minor-revision` and `:encoding`. Currently supporting only `:version` 3.
   To compress outputs, set `:encoding` to `:gzip` or `:bzip2`."
-  ([f]
+  (^GFFWriter [f]
    (writer f {}))
-  ([f options]
+  (^GFFWriter [f options]
    (let [{:keys [encoding version] :as opts} (merge {:version 3} options)
          url (try (util/as-url f) (catch Exception _ nil))]
      (when-not (= 3 version)

--- a/src/cljam/io/pileup.clj
+++ b/src/cljam/io/pileup.clj
@@ -32,9 +32,10 @@
   (close [this]
     (.close ^Closeable (.reader this))))
 
-(defn ^PileupReader reader
+(defn reader
   "Returns an open instance of cljam.io.pileup.PileupReader of f. Should be used
   inside with-open to ensure the reader is properly closed."
+  ^PileupReader
   [f]
   (PileupReader. (cio/reader f)))
 
@@ -179,13 +180,13 @@
     (.close ^Closeable (.writer this))
     (some-> ^Closeable (.ref-reader this) .close)))
 
-(defn ^PileupWriter writer
+(defn writer
   "Returns an open instance of cljam.io.pileup.PileupWriter of f. Should be used
   inside with-open to ensure the writer is properly closed. A reference sequence
   is used when the second arg `reference-path` is supplied."
-  ([f]
+  (^PileupWriter [f]
    (writer f nil))
-  ([f reference-path]
+  (^PileupWriter [f reference-path]
    (PileupWriter. (cio/writer f) (some-> reference-path cseq/reader))))
 
 (defn write-piles

--- a/src/cljam/io/pileup.clj
+++ b/src/cljam/io/pileup.clj
@@ -43,10 +43,14 @@
   upper-table
   (let [ba (byte-array 128)]
     (doseq [c "ATGCN"]
-      (aset-byte ba (byte c) (byte c))
-      (aset-byte ba (+ (byte c) (- (byte \a) (byte \A))) (byte c)))
+      (aset-byte ba (byte (int c)) (byte (int c)))
+      (aset-byte ba
+                 (+ (byte (int c))
+                    (- (byte (int \a))
+                       (byte (int \A))))
+                 (byte (int c))))
     (doseq [[from to] [[\, -1] [\. -1] [\< \>] [\> \>] [\* \*]]]
-      (aset-byte ba (byte from) (byte to)))
+      (aset-byte ba (byte (int from)) (byte (int to))))
     ba))
 
 (defn- parse-bases-col
@@ -82,14 +86,14 @@
                                                       (recur (inc j) (inc k) (+ (* 10 results) (- (int c) 48)))
                                                       [k results]))))
                   indel-seq (when indel-num
-                              (let [s (+ i (if mapq 4 2) indel-num-chars)]
-                                (cstr/upper-case (.substring column s (+ s indel-num)))))
+                              (let [s (+ i (if mapq 4 2) (long indel-num-chars))]
+                                (cstr/upper-case (.substring column s (+ s (long indel-num))))))
                   end? (boolean (or (= \$ x)
                                     (and indel-num
-                                         (not= len (+ i (if mapq 4 2) indel-num-chars indel-num))
-                                         (= \$ (.charAt column (+ i (if mapq 4 2) indel-num-chars indel-num))))))
+                                         (not= len (+ i (if mapq 4 2) (long indel-num-chars) (long indel-num)))
+                                         (= \$ (.charAt column (+ i (if mapq 4 2) (long indel-num-chars) (long indel-num)))))))
                   next-pos (long (+ i 1 (if mapq 2 0)
-                                    (if indel-num (+ 1 indel-num-chars indel-num) 0)
+                                    (if indel-num (+ 1 (long indel-num-chars) (long indel-num)) 0)
                                     (if end? 1 0)))]
               (recur next-pos
                      (conj! results (PileupBase. start? mapq upper-base -1 reverse? end? (when ins? indel-seq) (when del? indel-num) nil nil))))))
@@ -138,12 +142,12 @@
       (.append w (unchecked-char (case-base-fn base))))
     (when deletion
       (.append w \-)
-      (.append w (String/valueOf ^int deletion))
+      (.append w (String/valueOf (int deletion)))
       (.append w ^String (case-fn
                           (if ref-reader
                             (->> {:chr rname
-                                  :start (inc ref-pos)
-                                  :end (+ ref-pos deletion)}
+                                  :start (inc (long ref-pos))
+                                  :end (+ (long ref-pos) (int deletion))}
                                  (cseq/read-sequence ref-reader))
                             (apply str (repeat deletion \N))))))
     (when insertion

--- a/src/cljam/io/sam.clj
+++ b/src/cljam/io/sam.clj
@@ -17,28 +17,32 @@
 ;; Reading
 ;; -------
 
-(defn ^SAMReader sam-reader
+(defn sam-reader
   "Returns an open cljam.io.sam.reader.SAMReader of f. Should be used inside
   with-open to ensure the reader is properly closed."
+  ^SAMReader
   [f]
   (sam-reader/reader f))
 
-(defn ^BAMReader bam-reader
+(defn bam-reader
   "Returns an open cljam.io.bam.reader.BAMReader of f. Should be used inside
   with-open to ensure the reader is properly closed."
+  ^BAMReader
   [f]
   (bam-core/reader f))
 
-(defn ^BAMReader clone-bam-reader
+(defn clone-bam-reader
   "Clones bam reader sharing persistent objects."
+  ^BAMReader
   [r]
   (bam-core/clone-reader r))
 
-(defn ^Closeable reader
+(defn reader
   "Selects suitable reader from f's extension, returning the reader. Opens a new
   reader if the arg represents a file such as String path, java.io.File, or
   java.net.URL. If a reader is given, clones the reader. This function supports
   SAM and BAM formats."
+  ^Closeable
   [f]
   (if (io-util/bam-reader? f)
     (clone-bam-reader f)
@@ -80,26 +84,27 @@
 ;; Writing
 ;; -------
 
-(defn ^SAMWriter sam-writer
+(defn sam-writer
   "Returns an open cljam.io.sam.writer.SAMWriter of f. Should be used inside
   with-open to ensure the writer is properly closed."
+  ^SAMWriter
   [f]
   (sam-writer/writer f))
 
-(defn ^BAMWriter bam-writer
+(defn bam-writer
   "Returns an open cljam.io.bam.writer.BAMWriter of f. Should be used inside
   with-open to ensure the writer is properly closed."
-  ([f]
+  (^BAMWriter [f]
    (bam-writer f false))
-  ([f create-index?]
+  (^BAMWriter [f create-index?]
    (bam-core/writer f create-index?)))
 
-(defn ^Closeable writer
+(defn writer
   "Selects suitable writer from f's extension, returning the writer. This
   function supports SAM and BAM format."
-  ([f]
+  (^Closeable [f]
    (writer f false))
-  ([f create-index?]
+  (^Closeable [f create-index?]
    (case (io-util/file-type f)
      :sam (if create-index?
             (throw (ex-info "SAM file indexing is not implemented." {}))

--- a/src/cljam/io/sam/reader.clj
+++ b/src/cljam/io/sam/reader.clj
@@ -62,8 +62,8 @@
   (eduction
    (filter
     (fn [a] (and (if chr (= (:rname a) chr) true)
-                 (if start (<= start (sam-util/get-end a)) true)
-                 (if end (<= (:pos a) end) true))))
+                 (if start (<= (long start) (sam-util/get-end a)) true)
+                 (if end (<= (long (:pos a)) (long end)) true))))
    (read-alignments* sam-reader)))
 
 (defn- parse-coordinate

--- a/src/cljam/io/sam/reader.clj
+++ b/src/cljam/io/sam/reader.clj
@@ -28,8 +28,8 @@
   protocols/IRegionReader
   (read-in-region [this region]
     (protocols/read-in-region this region {}))
-  (read-in-region [this region option]
-    (read-alignments-in-region* this region option))
+  (read-in-region [this region _]
+    (read-alignments-in-region* this region))
   protocols/IAlignmentReader
   (read-header [this]
     (.header this))
@@ -45,7 +45,7 @@
     (protocols/read-blocks this {}))
   (read-blocks [this region]
     (protocols/read-blocks this region {}))
-  (read-blocks [this region option]
+  (read-blocks [this _ option]
     (read-blocks* this option)))
 
 (defn- read-alignments*

--- a/src/cljam/io/sam/util.clj
+++ b/src/cljam/io/sam/util.clj
@@ -16,7 +16,7 @@
   [line]
   (let [[qname flag rname pos-str mapq cigar rnext pnext tlen seq qual & options] (cstr/split line #"\t")
         pos (Integer/parseInt pos-str)
-        ref-length (cigar/count-ref cigar)
+        ref-length (int (cigar/count-ref cigar))
         end (if (zero? ref-length) 0 (int (dec (+ pos ref-length))))]
     (SAMAlignment. qname (Integer/parseInt flag) rname pos end (Integer/parseInt mapq)
                    cigar rnext (Integer/parseInt pnext) (Integer/parseInt tlen) (cstr/upper-case seq)
@@ -35,11 +35,12 @@
 
 (defn get-end
   "Returns the end position in reference for the given alignment."
-  [aln]
-  (let [ref-length (cigar/count-ref (:cigar aln))]
-    (if (zero? ref-length)
-      (:pos aln)
-      (dec (+ (:pos aln) ref-length)))))
+  ^long
+  [{:keys [^long pos cigar]}]
+  (let [ref-length (cigar/count-ref cigar)]
+    (if (zero? (long ref-length))
+      pos
+      (dec (+ pos (long ref-length))))))
 
 (defn compute-bin
   "Returns indexing bin based on alignment start and end."

--- a/src/cljam/io/sam/util/cigar.clj
+++ b/src/cljam/io/sam/util/cigar.clj
@@ -54,7 +54,7 @@
 
 (defn count-op
   "Returns length of CIGAR operations."
-  [^String s]
+  ^long [^String s]
   (count (parse s)))
 
 (defn- count-ref-str*
@@ -69,6 +69,7 @@
 
 (defn count-ref-bytes
   "Count covering length in reference from encoded CIGAR byte-array."
+  ^long
   [cigar-bytes]
   (let [buf (ByteBuffer/wrap cigar-bytes)]
     (.order buf ByteOrder/LITTLE_ENDIAN)
@@ -108,8 +109,9 @@
 (defn encode-cigar
   "Encodes CIGAR string into a sequence of longs."
   [cigar]
-  (mapv #(bit-or (bit-shift-left (first %) 4)
-                 (case (second %) \M 0 \I 1 \D 2 \N 3 \S 4 \H 5 \P 6 \= 7 \X 8))
+  (mapv (fn [[^long n c]]
+          (bit-or (bit-shift-left n 4)
+                  (case c \M 0 \I 1 \D 2 \N 3 \S 4 \H 5 \P 6 \= 7 \X 8)))
         (parse cigar)))
 
 (defmulti count-ref

--- a/src/cljam/io/sam/util/flag.clj
+++ b/src/cljam/io/sam/util/flag.clj
@@ -81,6 +81,7 @@
 
 (defn r1r2
   "Returns 0 for single-end, 1 for R1 and 2 for R2."
+  ^long
   [^long f]
   (-> f
       (bit-and 0xC0) ;; last-bit first-bit

--- a/src/cljam/io/sam/util/sequence.clj
+++ b/src/cljam/io/sam/util/sequence.clj
@@ -35,15 +35,14 @@
         out-bb (ByteBuffer/allocate result-len)]
     (dotimes [_ result-len]
       (let [u (.get in-bb)
-            l (byte (if (.hasRemaining in-bb) (.get in-bb) \=))]
+            l (byte (if (.hasRemaining in-bb) (.get in-bb) (byte (int \=))))]
         (->> (bit-and 0x7F l)
              (bit-or (bit-shift-left (bit-and 0x7F u) 7))
              (aget ^bytes two-bytes-to-compressed-bases-table)
              (.put out-bb))))
     (.array out-bb)))
 
-(def ^:const ^:private ^String
-  compressed-bases-to-bases-table
+(def ^:const ^:private compressed-bases-to-bases-table
   ;; Index: compressed base n containing two nibbles => 2n
   ;; Value 2n+0: base for upper nibble of n.
   ;; Value 2n+1: base for lower nibble of n.
@@ -72,6 +71,6 @@
   (dotimes [i (alength bases)]
     (let [b (aget bases i)]
       (cond
-        (= b (byte \.)) (aset-byte bases i (byte \N))
-        (<= (byte \a) b (byte \z)) (aset-byte bases i (- b 32))))) ;; Upper-case ASCII offset
+        (= b (byte (int \.))) (aset-byte bases i (byte (int \N)))
+        (<= (byte (int \a)) b (byte (int \z))) (aset-byte bases i (- b 32))))) ;; Upper-case ASCII offset
   bases)

--- a/src/cljam/io/sam/util/sequence.clj
+++ b/src/cljam/io/sam/util/sequence.clj
@@ -42,7 +42,8 @@
              (.put out-bb))))
     (.array out-bb)))
 
-(def ^:const ^:private compressed-bases-to-bases-table
+(def ^:const ^:private ^String
+  compressed-bases-to-bases-table
   ;; Index: compressed base n containing two nibbles => 2n
   ;; Value 2n+0: base for upper nibble of n.
   ;; Value 2n+1: base for lower nibble of n.

--- a/src/cljam/io/sam/writer.clj
+++ b/src/cljam/io/sam/writer.clj
@@ -15,7 +15,7 @@
 
 (deftype SAMWriter [^BufferedWriter writer url]
   Closeable
-  (close [this]
+  (close [_]
     (.close writer))
   protocols/IWriter
   (writer-url [this]
@@ -23,7 +23,7 @@
   protocols/IAlignmentWriter
   (write-header [this header]
     (write-header* this header))
-  (write-refs [this refs]
+  (write-refs [_ _]
     (logging/debug "SAMWriter does not support write-refs"))
   (write-alignments [this alignments refs]
     (write-alignments* this alignments refs))
@@ -56,7 +56,8 @@
 ;; Public
 ;; ------
 
-(defn ^SAMWriter writer
+(defn writer
+  ^SAMWriter
   [f]
   (->SAMWriter (cio/writer f)
                (util/as-url f)))

--- a/src/cljam/io/sequence.clj
+++ b/src/cljam/io/sequence.clj
@@ -17,23 +17,26 @@
 ;; Reading
 ;; -------
 
-(defn ^FASTAReader fasta-reader
+(defn fasta-reader
   "Returns an open cljam.io.fasta.reader.FASTAReader of f. Should be used inside
   with-open to ensure the reader is properly closed."
+  ^FASTAReader
   [f]
   (fa-core/reader f))
 
-(defn ^TwoBitReader twobit-reader
+(defn twobit-reader
   "Returns an open cljam.io.twobit.reader.TwoBitReader of f. Should be used
   inside with-open to ensure the reader is properly closed."
+  ^TwoBitReader
   [f]
   (tb-reader/reader f))
 
-(defn ^Closeable reader
+(defn reader
   "Selects suitable reader from f's extension, returning the open reader. Opens
   a new reader if the arg represents a file such as String path, java.io.File,
   or java.net.URL. If a reader is given, clones the reader. This function
   supports FASTA and TwoBit formats."
+  ^Closeable
   [f]
   (cond
     (io-util/fasta-reader? f) (fa-core/clone-reader f)
@@ -77,29 +80,30 @@
 ;; Writing
 ;; -------
 
-(defn ^FASTAWriter fasta-writer
+(defn fasta-writer
   "Returns an open cljam.io.fasta.writer.FASTAWriter of f with options:
     :cols - Maximum number of characters written in one row.
     :create-index? - If true, .fai will be created simultaneously.
   Should be used inside with-open to ensure the writer is properly closed."
-  ([f]
+  (^FASTAWriter [f]
    (fasta-writer f {}))
-  ([f options]
+  (^FASTAWriter [f options]
    (fa-writer/writer f options)))
 
-(defn ^TwoBitWriter twobit-writer
+(defn twobit-writer
   "Returns an open cljam.io.twobit.writer.TwoBitWriter of f with options:
     :index - metadata of indexed sequences. The amount of memory usage can be
       reduced if index is supplied.
   Should be used inside with-open to ensure the writer is properly closed."
-  ([f]
+  (^TwoBitWriter [f]
    (twobit-writer f {}))
-  ([f options]
+  (^TwoBitWriter [f options]
    (tb-writer/writer f options)))
 
-(defn ^Closeable writer
+(defn writer
   "Selects suitable writer from f's extension, returning the open writer. This
   function supports FASTA and TwoBit format."
+  ^Closeable
   [f & options]
   (case (io-util/file-type f)
     :fasta (apply fasta-writer f options)

--- a/src/cljam/io/twobit/reader.clj
+++ b/src/cljam/io/twobit/reader.clj
@@ -54,20 +54,20 @@
         (.put m chr (Chrom. chr len offset i header))))
     m))
 
-(def ^:private ^"[[C" twobit-to-str
+(def ^:private ^{:tag (Class/forName "[[C")} twobit-to-str
   (let [table "TCAG"]
     (->> 256
          range
          (map
-          (fn [j] (let [i (byte (- j 128))
-                        n4 (bit-and i 2r11)
-                        n3 (bit-and (unsigned-bit-shift-right i 2) 2r11)
-                        n2 (bit-and (unsigned-bit-shift-right i 4) 2r11)
-                        n1 (bit-and (unsigned-bit-shift-right i 6) 2r11)]
-                    (char-array [(.charAt table n1)
-                                 (.charAt table n2)
-                                 (.charAt table n3)
-                                 (.charAt table n4)]))))
+          (fn [^long j] (let [i (byte (- j 128))
+                              n4 (bit-and i 2r11)
+                              n3 (bit-and (unsigned-bit-shift-right i 2) 2r11)
+                              n2 (bit-and (unsigned-bit-shift-right i 4) 2r11)
+                              n1 (bit-and (unsigned-bit-shift-right i 6) 2r11)]
+                          (char-array [(.charAt table n1)
+                                       (.charAt table n2)
+                                       (.charAt table n3)
+                                       (.charAt table n4)]))))
          (into-array (Class/forName "[C")))))
 
 (defn replace-ambs!
@@ -105,11 +105,11 @@
   (^String [rdr region]
    (read-sequence rdr region {}))
   (^String [^TwoBitReader rdr
-            {:keys [chr start end]}
+            {:keys [chr ^long start ^long end]}
             {:keys [mask?] :or {mask? false}}]
    (when-let [^Chrom c (get (.index rdr) chr)]
      (let [start' (long (max 1 (or start 1)))
-           end' (long (min (.len c) (or end (.len c))))]
+           end' (min (.len c) (long (or end (.len c))))]
        (when (<= start' end')
          ;; Potential seek & read.
          (let [^ChromHeader h @(.header c)

--- a/src/cljam/io/twobit/writer.clj
+++ b/src/cljam/io/twobit/writer.clj
@@ -50,7 +50,7 @@
           (persistent! r))
         (if (<= (int \a) (int (.charAt s (int i))))
           (if p
-            (recur r p (inc l) (inc i))
+            (recur r p (inc (long l)) (inc i))
             (recur r i 1 (inc i)))
           (if p
             (recur (conj! r [p l]) nil nil (inc i))
@@ -70,7 +70,7 @@
           (persistent! r))
         (if (= \N (.charAt s (int i)))
           (if p
-            (recur r p (inc l) (inc i))
+            (recur r p (inc (long l)) (inc i))
             (recur r i 1 (inc i)))
           (if p
             (recur (conj! r [p l]) nil nil (inc i))
@@ -78,7 +78,8 @@
 
 (defn- write-index!
   [w idx]
-  (loop [offset (+ (* 4 4) (reduce + (map #(+ 1 (count (:name %)) 4) idx)))
+  (loop [offset (+ (* 4 4)
+                   (long (reduce + (map #(+ 1 (count (:name %)) 4) idx))))
          idx idx]
     (when-let [{:keys [name len]} (first idx)]
       (lsb/write-ubyte w (count name))
@@ -88,7 +89,7 @@
                 (if-let [{:keys [ambs masks]} (first idx)]
                   (+ 4 4 (* 2 4 (count ambs)) 4 (* 2 4 (count masks)) 4)
                   0) ; dummy
-                (quot (dec (+ len 4)) 4))
+                (quot (dec (+ (long len) 4)) 4))
              (next idx)))))
 
 (def ^:private
@@ -115,10 +116,13 @@
             (aget table (.get bb)))
            unchecked-int
            (.write o)))
-    (when (pos? (mod len 4))
-      (loop [b 0 i (mod len 4) j 1]
+    (when (pos? (rem len 4))
+      (loop [b 0 i (rem len 4) j 1]
         (if (pos? i)
-          (recur (bit-or b (bit-shift-left (aget table (.get bb)) (* 2 (- 4 j)))) (dec i) (inc j))
+          (recur
+           (bit-or b (bit-shift-left (aget table (.get bb)) (* 2 (- 4 j))))
+           (dec i)
+           (inc j))
           (.write o (unchecked-int b)))))))
 
 (defn- write-sequence!

--- a/src/cljam/io/util/bgzf.clj
+++ b/src/cljam/io/util/bgzf.clj
@@ -44,10 +44,10 @@
       (catch MalformedURLException _
         (make-bgzf-output-stream (cio/as-file x))))))
 
-(defn ^BGZFInputStream bgzf-input-stream [x]
+(defn bgzf-input-stream ^BGZFInputStream [x]
   (make-bgzf-input-stream x))
 
-(defn ^BGZFOutputStream bgzf-output-stream [x]
+(defn bgzf-output-stream ^BGZFOutputStream [x]
   (make-bgzf-output-stream x))
 
 (def ^:private ^:const shift-amount 16)

--- a/src/cljam/io/util/bgzf.clj
+++ b/src/cljam/io/util/bgzf.clj
@@ -58,23 +58,26 @@
 
 (defn compare
   "Negative if fp1 is earlier in file than fp2, positive if it is later, 0 if equal."
+  ^long
   [^long fp1 ^long fp2]
   (cond
     (= fp1 fp2)                 0
-   ;; When treating as unsigned, negative number is > positive.
+    ;; When treating as unsigned, negative number is > positive.
     (and (< fp1 0) (>= fp2 0))  1
     (and (>= fp1 0) (< fp2 0)) -1
-   ;; Either both negative or both non-negative, so regular comparison works.
+    ;; Either both negative or both non-negative, so regular comparison works.
     (< fp1 fp2)                -1
     :else                       1))
 
 (defn get-block-address
   "File offset of start of BGZF block for this file pointer."
+  ^long
   [^long fp]
   (bit-and (bit-shift-right fp shift-amount) address-mask))
 
 (defn get-block-offset
   "Offset into uncompressed block for this virtual file pointer."
+  ^long
   [^long fp]
   (bit-and fp offset-mask))
 
@@ -92,8 +95,8 @@
        (= (unchecked-byte 0x1f) (aget b 0))
        (= (unchecked-byte 0x8b) (aget b 1))
        (bit-test (aget b 3) 2) ;; FEXTRA
-       (= (byte \B) (aget b 12)) ;; SI1
-       (= (byte \C) (aget b 13)) ;; SI2
+       (= (byte (int \B)) (aget b 12)) ;; SI1
+       (= (byte (int \C)) (aget b 13)) ;; SI2
        (= 2 (aget b 14)) ;; LEN
        (zero? (aget b 15))))
 

--- a/src/cljam/io/util/bgzf/gzi.clj
+++ b/src/cljam/io/util/bgzf/gzi.clj
@@ -39,9 +39,9 @@
   "Returns an uncompressed offset for a given virtual file offset"
   ^long [gzi ^long compressed-offset]
   (let [off (unsigned-bit-shift-right compressed-offset 16)
-        [uncompressed] (->> gzi
-                            rseq
-                            (filter (fn [[_ c]] (= (long c) off)))
-                            first)]
-    (assert uncompressed)
+        uncompressed (->> gzi
+                          rseq
+                          (filter (fn [[_ c]] (= (long c) off)))
+                          ffirst
+                          long)]
     (+ uncompressed (bit-and compressed-offset 0xffff))))

--- a/src/cljam/io/util/bin.clj
+++ b/src/cljam/io/util/bin.clj
@@ -50,7 +50,7 @@
 
 (defn pos->lidx-offset
   "Returns an offset of a linear index that the given `pos` belongs to."
-  [^long pos ^long linear-index-shift]
+  ^long [^long pos ^long linear-index-shift]
   (bit-shift-right (if (<= pos 0) 0 (dec pos)) linear-index-shift))
 
 (defn reg->bins

--- a/src/cljam/io/util/chunk.clj
+++ b/src/cljam/io/util/chunk.clj
@@ -11,6 +11,7 @@
 (defn compare
   "Returns a negative if chunk1 is earlier than chunk2, a positive if it is
   later, 0 if it is equal."
+  ^long
   [^Chunk chunk1 ^Chunk chunk2]
   (let [ret (Long/signum (- (.beg chunk1) (.beg chunk2)))]
     (if (zero? ret)

--- a/src/cljam/io/util/lsb.clj
+++ b/src/cljam/io/util/lsb.clj
@@ -5,12 +5,12 @@
   (:import [java.io DataInput InputStream DataOutputStream EOFException ByteArrayOutputStream]
            [java.nio Buffer ByteBuffer ByteOrder]))
 
-(defn ^ByteBuffer gen-byte-buffer
+(defn gen-byte-buffer
   "Generates a new `java.nio.ByteBuffer` instance with little-endian byte order.
   The default buffer size is 8."
-  ([]
+  (^ByteBuffer []
    (.order (ByteBuffer/allocate 8) ByteOrder/LITTLE_ENDIAN))
-  ([size]
+  (^ByteBuffer [size]
    (.order (ByteBuffer/allocate size) ByteOrder/LITTLE_ENDIAN)))
 
 ;; Reading

--- a/src/cljam/io/util/lsb.clj
+++ b/src/cljam/io/util/lsb.clj
@@ -94,13 +94,13 @@
       (.readFully this (.array bb))
       (.getShort bb)))
   (read-ushort [this]
-    (bit-and (read-short this) 0xFFFF))
+    (bit-and (short (read-short this)) 0xFFFF))
   (read-int [this]
     (let [bb (gen-byte-buffer 4)]
       (.readFully this (.array bb))
       (.getInt bb)))
   (read-uint [this]
-    (bit-and (read-int this) 0xFFFFFFFF))
+    (bit-and (int (read-int this)) 0xFFFFFFFF))
   (read-long [this]
     (let [bb (gen-byte-buffer 8)]
       (.readFully this (.array bb))
@@ -143,13 +143,13 @@
       (read-bytes this (.array bb) 0 2)
       (.getShort bb)))
   (read-ushort [this]
-    (bit-and (read-short this) 0xFFFF))
+    (bit-and (short (read-short this)) 0xFFFF))
   (read-int [this]
     (let [bb (gen-byte-buffer 4)]
       (read-bytes this (.array bb) 0 4)
       (.getInt bb)))
   (read-uint [this]
-    (bit-and (read-int this) 0xFFFFFFFF))
+    (bit-and (int (read-int this)) 0xFFFFFFFF))
   (read-long [this]
     (let [bb (gen-byte-buffer 8)]
       (read-bytes this (.array bb) 0 8)

--- a/src/cljam/io/vcf.clj
+++ b/src/cljam/io/vcf.clj
@@ -24,9 +24,10 @@
 ;; Reading
 ;; -------
 
-(defn ^VCFReader vcf-reader
+(defn vcf-reader
   "Returns an open cljam.io.vcf.reader.VCFReader of f. Should be used inside
   with-open to ensure the reader is properly closed."
+  ^VCFReader
   [f]
   (let [meta-info (with-open [r (cio/reader (util/compressor-input-stream f))]
                     (vcf-reader/load-meta-info r))
@@ -40,15 +41,17 @@
                             (catch FileNotFoundException _
                               (tabix/read-index (str f ".tbi"))))))))
 
-(defn ^BCFReader bcf-reader
+(defn bcf-reader
   "Returns an open cljam.io.bcf.reader.BCFReader of f. Should be used inside
   with-open to ensure the reader is properly closed. Throws IOException if
   failed to parse BCF file format."
+  ^BCFReader
   [f]
   (bcf-reader/reader f))
 
-(defn ^VCFReader clone-vcf-reader
+(defn clone-vcf-reader
   "Clones vcf reader sharing persistent objects."
+  ^VCFReader
   [^VCFReader rdr]
   (let [url (.url rdr)
         input-stream (if (bgzf/bgzip? url)
@@ -58,25 +61,28 @@
                 input-stream
                 (.index-delay rdr))))
 
-(defn ^BCFReader clone-bcf-reader
+(defn clone-bcf-reader
   "Clones bcf reader sharing persistent objects."
+  ^BCFReader
   [^BCFReader rdr]
   (let [url (.url rdr)
         input-stream (bgzf/bgzf-input-stream url)]
     (BCFReader. (.url rdr) (.meta-info rdr) (.header rdr)
                 input-stream (.start-pos rdr) (.index-delay rdr))))
 
-(defn ^Closeable clone-reader
+(defn clone-reader
   "Clones vcf/bcf reader sharing persistent objects."
+  ^Closeable
   [rdr]
   (cond
     (io-util/vcf-reader? rdr) (clone-vcf-reader rdr)
     (io-util/bcf-reader? rdr) (clone-bcf-reader rdr)
     :else (throw (IllegalArgumentException. "Invalid file type"))))
 
-(defn ^Closeable reader
+(defn reader
   "Selects suitable reader from f's extension, returning the open reader. This
   function supports VCF and BCF formats."
+  ^Closeable
   [f]
   (if (or (io-util/vcf-reader? f)
           (io-util/bcf-reader? f))
@@ -131,7 +137,7 @@
 ;; Writing
 ;; -------
 
-(defn ^VCFWriter vcf-writer
+(defn vcf-writer
   "Returns an open cljam.io.vcf.writer.VCFWriter of f. Meta-information lines
   and a header line will be written in this function. Should be used inside
   with-open to ensure the writer is properly closed. e.g.
@@ -140,6 +146,7 @@
                                 {:file-date \"20090805\", :source \"myImpu...\" ...}
                                 [\"CHROM\" \"POS\" \"ID\" \"REF\" \"ALT\" ...])]
       (WRITING-VCF))"
+  ^VCFWriter
   [f meta-info header]
   (doto (VCFWriter. (util/as-url f)
                     (cio/writer (util/compressor-output-stream f))
@@ -148,7 +155,7 @@
     (vcf-writer/write-meta-info meta-info)
     (vcf-writer/write-header header)))
 
-(defn ^BCFWriter bcf-writer
+(defn bcf-writer
   "Returns an open cljam.io.bcf.writer.BCFWriter of f. Meta-information lines
   and a header line will be written in this function. Should be used inside
   with-open to ensure the writer is properly closed. e.g.
@@ -157,12 +164,14 @@
                                  {:file-date \"20090805\", :source \"myImpu...\" ...}
                                  [\"CHROM\" \"POS\" \"ID\" \"REF\" \"ALT\" ...])]
        (WRITING-BCF))"
+  ^BCFWriter
   [f meta-info header]
   (bcf-writer/writer f meta-info header))
 
-(defn ^Closeable writer
+(defn writer
   "Selects suitable writer from f's extension, returning the open writer. This
   function supports VCF and BCF formats."
+  ^Closeable
   [f meta-info header]
   (case (io-util/file-type f)
     :vcf (vcf-writer f meta-info header)

--- a/src/cljam/io/vcf/util.clj
+++ b/src/cljam/io/vcf/util.clj
@@ -169,7 +169,7 @@
   [gt]
   (let [parsed-gt (or (cond-> gt (string? gt) parse-genotype) [[nil]])]
     (->> (assoc-in (vec parsed-gt) [0 1] false)
-         (map (fn [[allele phased]]
+         (map (fn [[^long allele phased]]
                 (bit-or
                  (bit-shift-left (if allele (inc allele) 0) 1)
                  (if phased 1 0)))))))
@@ -178,7 +178,9 @@
   "Convert a sequence of integers to genotype string."
   [vs]
   (->> vs
-       (mapcat (fn [i] [(if (odd? i) \| \/) (if (zero? (quot i 2)) "." (dec (quot i 2)))]))
+       (mapcat (fn [^long i]
+                 [(if (odd? i) \| \/)
+                  (if (zero? (quot i 2)) "." (dec (quot i 2)))]))
        rest
        (apply str)
        (#(when-not (dot-or-nil? ^String %) %))))

--- a/src/cljam/io/vcf/util/normalize.clj
+++ b/src/cljam/io/vcf/util/normalize.clj
@@ -71,7 +71,7 @@
   [seq-reader {:keys [chr ^long pos ref alt]
                {:keys [END]} :info :as v} ^long window]
   (let [alleles (cons ref alt)
-        min-end (long (dec (+ pos (apply min (map count alleles)))))
+        min-end (dec (+ pos (long (apply min (map count alleles)))))
         regs (regions-before chr pos window)
         ref-seqs (sequence ;; unchunk
                   (mapcat
@@ -88,10 +88,11 @@
                             long
                             (Math/min (dec min-end)))]
     (if (pos? matched-length)
-      (let [pos' (or (some (fn [{:keys [start end]}]
+      (let [pos' (-> (some (fn [{:keys [start end]}]
                              (when (<= start (- min-end matched-length) end)
                                start)) regs)
-                     pos)
+                     (or pos)
+                     long)
             [ref' & alt'] (map
                            #(->> %2
                                  (take (inc (- (dec (+ pos (count %1))) pos')))

--- a/src/cljam/io/vcf/writer.clj
+++ b/src/cljam/io/vcf/writer.clj
@@ -190,8 +190,8 @@
 (defn- stringify-data-line-qual
   [x]
   (when x
-    (if (and (zero? (mod x 1))
-             (< x precise-integer-limit))
+    (if (and (zero? (float (mod x 1)))
+             (< (float x) precise-integer-limit))
       (str (int x))
       (str x))))
 

--- a/src/cljam/io/vcf/writer.clj
+++ b/src/cljam/io/vcf/writer.clj
@@ -169,7 +169,7 @@
 ;; Writing header
 ;; --------------
 
-(defn ^String stringify-header
+(defn stringify-header ^String
   [header]
   (str header-prefix (cstr/join \tab header)))
 
@@ -195,7 +195,7 @@
       (str (int x))
       (str x))))
 
-(defn- ^String stringify-data-line
+(defn- stringify-data-line ^String
   [m header]
   (let [m* (-> m
                (update :alt stringify-data-line-alt)

--- a/src/cljam/io/wig.clj
+++ b/src/cljam/io/wig.clj
@@ -106,8 +106,8 @@
                    "fixedStep"
                    (let [{:keys [chrom start span step]
                           :or {span 1, step 1}} (->> fields rest fields->map)
-                         step (as-long step)
-                         pre-start (- (as-long start) step)
+                         step (long (as-long step))
+                         pre-start (- (long (as-long start)) step)
                          span (as-long span)
                          track (assoc track :format :fixed-step
                                       :chr chrom
@@ -120,8 +120,8 @@
                              :variable-step
                              (let [{:keys [chr span]} track
                                    [start value] fields
-                                   start (as-long start)
-                                   end (dec (+ start span))
+                                   start (long (as-long start))
+                                   end (dec (+ start (long span)))
                                    value (str->wiggle-track-data value)]
                                {:track track
                                 :chr chr
@@ -131,8 +131,8 @@
 
                              :fixed-step
                              (let [{:keys [chr span step]} track
-                                   start (+ pre-start step)
-                                   end (dec (+ start span))
+                                   start (+ (long pre-start) (long step))
+                                   end (dec (+ start (long span)))
                                    value (-> fields first str->wiggle-track-data)]
                                {:track track
                                 :chr chr
@@ -168,7 +168,7 @@
                  (sequence
                   (comp
                    (partition-by (juxt (comp :format :track)
-                                       #(- (:end %) (:start %))))
+                                       #(- (long (:end %)) (long (:start %)))))
                    (map
                     (fn [[{{:keys [line format span step]} :track
                            chr :chr start :start} :as xs]]

--- a/src/cljam/io/wig.clj
+++ b/src/cljam/io/wig.clj
@@ -20,7 +20,7 @@
   protocols/IReader
   (reader-url [this] (.url this))
   (read [this] (read-fields this))
-  (read [this option] (read-fields this))
+  (read [this _] (read-fields this))
   (indexed? [_] false))
 
 (defrecord WIGWriter [^BufferedWriter writer ^URL url]
@@ -30,15 +30,17 @@
   protocols/IWriter
   (writer-url [this] (.url this)))
 
-(defn ^WIGReader reader
+(defn reader
   "Returns an open cljam.io.wig.WIGReader of f. Should be used inside with-open
   to ensure the reader is properly closed."
+  ^WIGReader
   [f]
   (WIGReader. (cio/reader (util/compressor-input-stream f)) (util/as-url f)))
 
-(defn ^WIGWriter writer
+(defn writer
   "Returns an open cljam.io.wig.WIGWriter of f. Should be used inside with-open
   to ensure the writer is properly closed."
+  ^WIGWriter
   [f]
   (WIGWriter. (cio/writer (util/compressor-output-stream f)) (util/as-url f)))
 

--- a/src/cljam/tools/cli.clj
+++ b/src/cljam/tools/cli.clj
@@ -25,7 +25,7 @@
 
 (defn- exit
   "Exits the program with the status after printing the message."
-  [status message]
+  [^long status message]
   (binding [*out* (if (zero? status) *out* *err*)]
     (println message))
   (System/exit status))

--- a/src/cljam/util.clj
+++ b/src/cljam/util.clj
@@ -73,10 +73,10 @@
 ;; string utils
 ;; ------------
 
-(defn ^"[B" string->bytes [^String s]
+(defn string->bytes ^"[B" [^String s]
   (.getBytes s))
 
-(defn ^String bytes->string [^bytes b]
+(defn bytes->string ^String [^bytes b]
   (String. b 0 (alength b)))
 
 (defn graph?
@@ -95,7 +95,7 @@
 ;; ---------
 
 
-(defn ^URL as-url
+(defn as-url ^URL
   [x]
   (try
     (cio/as-url x)
@@ -111,11 +111,12 @@
   {:gzip CompressorStreamFactory/GZIP
    :bzip2 CompressorStreamFactory/BZIP2})
 
-(defn ^java.io.InputStream compressor-input-stream
+(defn compressor-input-stream
   "Returns a compressor input stream from f, autodetecting the compressor type
   from the first few bytes of f. Returns java.io.BufferedInputStream if the
   compressor type is not known. Should be used inside with-open to ensure the
   InputStream is properly closed."
+  ^java.io.InputStream
   [f]
   (let [is (cio/input-stream f)]
     (try
@@ -123,19 +124,19 @@
       (catch CompressorException _
         is))))
 
-(defn ^java.io.OutputStream compressor-output-stream
+(defn compressor-output-stream
   "Returns a compressor output stream from `f` and a compressor type `k`. `k`
   must be selected from `:bgzip`, `:gzip` or `:bzip2`. Autodetects the
   compressor type from the extension of `f` if `k` is not passed. Returns
   `java.io.BufferedOutputStream` if the compressor type is not known. Should be
   used inside with-open to ensure the OutputStream is properly closed."
-  ([f]
+  (^java.io.OutputStream [f]
    (compressor-output-stream f (condp re-find (.getPath (as-url f))
                                  #"(?i)\.(bgz|bgzip|gz)$" :bgzip
                                  #"(?i)\.gzip$" :gzip
                                  #"(?i)\.(bz2|bzip2)$" :bzip2
                                  nil)))
-  ([f k]
+  (^java.io.OutputStream [f k]
    (if (= :bgzip k)
      (bgzf/make-bgzf-output-stream f)
      (let [os (cio/output-stream f)]

--- a/src/cljam/util.clj
+++ b/src/cljam/util.clj
@@ -66,7 +66,7 @@
 
 (defn ubyte
   "Casts to byte avoiding an error about out of range for byte."
-  [n]
+  [^long n]
   {:pre [(<= 0 n 255)]}
   (byte (if (< n 0x80) n (- n 0x100))))
 
@@ -82,7 +82,7 @@
 (defn graph?
   "Returns true if c is a visible character, false if not."
   [c]
-  (<= 0x20 (byte c) 0x7E))
+  (<= 0x20 (byte (int c)) 0x7E))
 
 (defn space?
   "Returns true if c is a character that creates \"white space\" in displayed

--- a/src/cljam/util/intervals.clj
+++ b/src/cljam/util/intervals.clj
@@ -6,7 +6,7 @@
 
 (deftype SortedMapIntervals [m]
   IIntervals
-  (find-overlap-intervals* [this start end]
+  (find-overlap-intervals* [_ start end]
     (mapcat (fn [[_ x]] (drop-while #(< (:end %) start) x))
             (subseq m <= end))))
 
@@ -27,7 +27,7 @@
 
 (deftype NclistIntervals [nclist]
   IIntervals
-  (find-overlap-intervals* [this start end]
+  (find-overlap-intervals* [_ start end]
     (find-nclist-overlap-intervals nclist start end)))
 
 (declare make-nclist*)

--- a/src/cljam/util/intervals.clj
+++ b/src/cljam/util/intervals.clj
@@ -7,8 +7,8 @@
 (deftype SortedMapIntervals [m]
   IIntervals
   (find-overlap-intervals* [_ start end]
-    (mapcat (fn [[_ x]] (drop-while #(< (:end %) start) x))
-            (subseq m <= end))))
+    (mapcat (fn [[_ x]] (drop-while #(< (long (:end %)) (long start)) x))
+            (subseq m <= (long end)))))
 
 (defn- make-sorted-map-intervals
   [intervals]
@@ -17,10 +17,10 @@
        (into (sorted-map))
        (->SortedMapIntervals)))
 
-(defn- find-nclist-overlap-intervals [nclist start end]
+(defn- find-nclist-overlap-intervals [nclist ^long start ^long end]
   (->> (subseq nclist >= start)
        (map second)
-       (take-while #(<= (:start (first %)) end))
+       (take-while #(<= (long (:start (first %))) end))
        (mapcat #(cons (first %)
                       (find-nclist-overlap-intervals (second %)
                                                      start end)))))

--- a/src/cljam/util/sequence.clj
+++ b/src/cljam/util/sequence.clj
@@ -4,11 +4,11 @@
 
 (def ^:private revcomp-table
   (let [ba (byte-array 128)]
-    (dotimes [i 128] (aset-byte ba i (byte \N)))
+    (dotimes [i 128] (aset-byte ba i (byte (int \N))))
     (doseq [s ["AT" "GC" "NN"]
             [a b] [(cstr/upper-case s) (cstr/lower-case s)]]
-      (aset-byte ba (int a) (byte b))
-      (aset-byte ba (int b) (byte a)))
+      (aset-byte ba (int a) (byte (int b)))
+      (aset-byte ba (int b) (byte (int a))))
     ba))
 
 (defn revcomp

--- a/src/cljam/util/whole_genome.clj
+++ b/src/cljam/util/whole_genome.clj
@@ -41,7 +41,8 @@
   "Transforms a region in whole-genome coordinate into a sequence of chromosomal
   regions."
   [offset->ref ^long start ^long end]
-  (let [wg-len (let [[o r] (first (rsubseq offset->ref >= 0))] (+ o (:len r)))]
+  (let [wg-len (let [[o r] (first (rsubseq offset->ref >= 0))]
+                 (+ (long o) (long (:len r))))]
     (when (and (<= start end)
                (or (pos? start) (pos? end))
                (or (<= start wg-len) (<= end wg-len)))
@@ -53,5 +54,7 @@
                   (fn [[_ r]] {:chr (:name r), :start 1, :end (:len r)})
                   (subseq offset->ref >= s-offset <= e-offset))]
         (-> regs
-            (assoc-in [0 :start] (- start' s-offset))
-            (update-in [(dec (count regs)) :end] min (- end' e-offset)))))))
+            (assoc-in [0 :start] (- start' (long s-offset)))
+            (update-in [(dec (count regs)) :end]
+                       min
+                       (- end' (long e-offset))))))))

--- a/test/cljam/io/bam/decoder_test.clj
+++ b/test/cljam/io/bam/decoder_test.clj
@@ -1,7 +1,6 @@
 (ns cljam.io.bam.decoder-test
   "Tests for cljam.io.bam.decoder."
   (:require [clojure.test :refer [deftest is are testing]]
-            [cljam.io.protocols]
             [cljam.io.bam.decoder :as decoder]
             [cljam.test-common :as test-common]))
 

--- a/test/cljam/io/bcf/writer_test.clj
+++ b/test/cljam/io/bcf/writer_test.clj
@@ -281,7 +281,7 @@
                 "##FILTER=<ID=PASS,Description=\"All filters passed\",IDX=0>"
                 (str "#" (cstr/join \tab header) \newline (char 0))]
                (cstr/join \newline))
-        _ (with-open [_ (bcf-writer/writer tmp {} header)])
+        _ (with-open [_ (bcf-writer/writer tmp {} header)] nil)
         bytes (bb->seq (bgzf->bb tmp))]
     (is (= (concat (.getBytes "BCF\2\2") [(.length s) 0 0 0] (.getBytes s))
            bytes))

--- a/test/cljam/io/pileup_test.clj
+++ b/test/cljam/io/pileup_test.clj
@@ -184,7 +184,7 @@
       {:base \A :reverse? true :end? true :deletion 4 :alignment {:flag 16 :mapq 40 :pos 5 :end 10}} "a-4nnnn$"))
   (testing "with-ref"
     (let [r (reify p/ISequenceReader
-              (p/read-sequence [this {:keys [start end]}]
+              (p/read-sequence [_ {:keys [start end]}]
                 (subs "ATGCATGCATGCATGCATGCATGCATGC" (dec start) end)))]
       (are [?in ?out]
            (= ?out (with-string-writer w
@@ -216,7 +216,7 @@
   (reify p/ISequenceReader
     (p/read-sequence [this region]
       (p/read-sequence this region {}))
-    (p/read-sequence [this {:keys [start end]} {:keys [mask?]}]
+    (p/read-sequence [_ {:keys [start end]} {:keys [mask?]}]
       ((if mask? identity cstr/upper-case)
        (subs s (dec start) end)))))
 

--- a/test/cljam/io/util/lsb_test.clj
+++ b/test/cljam/io/util/lsb_test.clj
@@ -71,13 +71,13 @@
 
     (.reset bb)
     (doseq [c "ABCDEFGH"]
-      (.put bb (byte c)))
+      (.put bb (byte (int c))))
     (.reset bb)
     (is (= (lsb/read-string bb 8) "ABCDEFGH"))
 
     (.reset bb)
     (doseq [c [\I \J \K \L 0 \M \N \O]]
-      (.put bb (byte c)))
+      (.put bb (byte (int c))))
     (.reset bb)
     (is (= (lsb/read-null-terminated-string bb) "IJKL"))))
 
@@ -89,9 +89,9 @@
         (let [bb (lsb/gen-byte-buffer 24)]
           (.putLong bb 0x789ABCDEF0123456)
           (doseq [c "ABCDEFGH"]
-            (.put bb (byte c)))
+            (.put bb (byte (int c))))
           (doseq [c [\I \J \K \L 0 \M \N \O]]
-            (.put bb (byte c)))
+            (.put bb (byte (int c))))
           (.write raf (.array bb))))
       (with-open [raf (RandomAccessFile. filename "r")]
         (.seek raf 0)
@@ -164,9 +164,9 @@
         (let [bb (lsb/gen-byte-buffer 24)]
           (.putLong bb 0x789ABCDEF0123456)
           (doseq [c "ABCDEFGH"]
-            (.put bb (byte c)))
+            (.put bb (byte (int c))))
           (doseq [c [\I \J \K \L 0 \M \N \O]]
-            (.put bb (byte c)))
+            (.put bb (byte (int c))))
           (.write raf (.array bb))))
       (with-open [fis (FileInputStream. filename)
                   dis (DataInputStream. fis)]
@@ -251,9 +251,9 @@
         (let [bb (lsb/gen-byte-buffer 24)]
           (.putLong bb 0x789ABCDEF0123456)
           (doseq [c "ABCDEFGH"]
-            (.put bb (byte c)))
+            (.put bb (byte (int c))))
           (doseq [c [\I \J \K \L 0 \M \N \O]]
-            (.put bb (byte c)))
+            (.put bb (byte (int c))))
           (.write bgzfos (.array bb))))
       (with-open [bgzfis (BGZFInputStream. (cio/file filename))]
         (.seek bgzfis 0)

--- a/test/cljam/test_common.clj
+++ b/test/cljam/test_common.clj
@@ -804,7 +804,7 @@
     (cio/copy in out)
     (.toByteArray out)))
 
-(defn ^NanoFakeServer http-server []
+(defn http-server ^NanoFakeServer []
   (let [gen-route? (fn [^File f]
                      (< (.length f) (* 1024 1024)))
         gen-route (fn [^File f]


### PR DESCRIPTION
I fixed  almost bad coding style, except Boxed-math, which I couldn't fix.
### Clj-kondo
#### master
``` sh
> find src/ |grep clj|xargs clj-kondo --lint
linting took 1340ms, errors: 1, warnings: 85
> find test/ |grep clj|xargs clj-kondo --lint
linting took 2115ms, errors: 1, warnings: 3
```
#### This PR
```sh
> find src/ |grep clj|xargs clj-kondo --lint
linting took 1325ms, errors: 0, warnings: 0
> find test/ |grep clj|xargs clj-kondo --lint
test/cljam/io/gff_test.clj:319:70: error: Unresolved symbol: ?str
linting took 2240ms, errors: 1, warnings: 0
```

### Eastwood (exclude boxed-math)
#### Master
``` sh
> lein eastwood "{:linters [:all] :exclude-linters [:keyword-typos :unused-namespaces :boxed-math] }"
== Warnings: 11. Exceptions thrown: 0
```
#### This PR
``` sh
> lein eastwood "{:linters [:all] :exclude-linters [:keyword-typos :unused-namespaces :boxed-math] }"
== Warnings: 0. Exceptions thrown: 0
```
