### PR TITLE
Fix/shadowing var

### DIFF
--- a/.clj-kondo/config.edn
+++ b/.clj-kondo/config.edn
@@ -1,6 +1,8 @@
 {:linters
  {:single-key-in {:level :warning}
   :aliased-namespace-symbol {:level :warning}
+  :shadowed-var {:level :warning
+                 :exclude [meta-info version]}
   :type-mismatch
   {:namespaces
    {clojure.core

--- a/src/cljam/algo/dedupe.clj
+++ b/src/cljam/algo/dedupe.clj
@@ -6,8 +6,8 @@
             [cljam.io.sam.util.flag :as flag]))
 
 (defn- refs->regions [refs]
-  (for [{:keys [name len]} refs]
-    {:chr name :start 1 :end len}))
+  (for [{:keys [len] name' :name} refs]
+    {:chr name' :start 1 :end len}))
 
 (defn- sum-quals [a]
   (when-let [q ^String (:qual a)]

--- a/src/cljam/algo/pileup.clj
+++ b/src/cljam/algo/pileup.clj
@@ -303,8 +303,8 @@
      (let [regs (if region
                   [region]
                   (map
-                   (fn [{:keys [name len]}]
-                     {:chr name :start 1 :end len})
+                   (fn [{:keys [len] name' :name}]
+                     {:chr name' :start 1 :end len})
                    (sam/read-refs s)))]
        (doseq [reg regs]
          (plpio/write-piles w (pileup s reg options)))))))

--- a/src/cljam/io/bam/reader.clj
+++ b/src/cljam/io/bam/reader.clj
@@ -138,10 +138,10 @@
                (if (zero? i)
                  ret
                  (let [l-name (int (lsb/read-int rdr))
-                       name   (lsb/read-string rdr l-name)
+                       name'  (lsb/read-string rdr l-name)
                        l-ref  (lsb/read-int rdr)]
                    (recur (dec i)
-                          (conj ret {:name (subs name 0 (dec l-name))
+                          (conj ret {:name (subs name' 0 (dec l-name))
                                      :len  l-ref})))))]
     {:header header
      :refs refs}))

--- a/src/cljam/io/bam/writer.clj
+++ b/src/cljam/io/bam/writer.clj
@@ -70,11 +70,11 @@
     (when @(.index wtr)
       (reset! (.refs wtr) refs))
     (lsb/write-int w (count refs))
-    (doseq [ref refs]
-      (lsb/write-int w (inc (count (:name ref))))
-      (lsb/write-string w (:name ref))
+    (doseq [{:keys [len] name' :name} refs]
+      (lsb/write-int w (inc (count name')))
+      (lsb/write-string w name')
       (lsb/write-bytes w (byte-array 1 (byte 0)))
-      (lsb/write-int w (:len ref)))))
+      (lsb/write-int w len))))
 
 (defn write-alignments* [^BAMWriter wtr alns header]
   (let [dw (.data-writer wtr)

--- a/src/cljam/io/bam_index/writer.clj
+++ b/src/cljam/io/bam_index/writer.clj
@@ -181,9 +181,9 @@
   (lsb/write-int w bin)
   ;; chunks
   (lsb/write-int w (count chunks))
-  (doseq [^Chunk chunk chunks]
-    (lsb/write-long w (.beg chunk))
-    (lsb/write-long w (.end chunk))))
+  (doseq [^Chunk chunk' chunks]
+    (lsb/write-long w (.beg chunk'))
+    (lsb/write-long w (.end chunk'))))
 
 (defn- write-meta-data
   [w meta-data]
@@ -242,7 +242,7 @@
   Returned index is still intermediate. It must be passed to finalize function
   in the final stage."
   [alns]
-  (loop [[^BAMPointerBlock aln & rest] alns
+  (loop [[^BAMPointerBlock aln & rest'] alns
          rid (.ref-id aln)
          idx-status (init-index-status)
          no-coordinate-alns 0
@@ -258,7 +258,7 @@
             indices' (if new-ref?
                        (assoc indices rid idx-status)
                        indices)]
-        (recur rest rid' idx-status' no-coordinate-alns' indices'))
+        (recur rest' rid' idx-status' no-coordinate-alns' indices'))
       (assoc indices rid idx-status
              :no-coordinate-alns no-coordinate-alns))))
 

--- a/src/cljam/io/bcf/writer.clj
+++ b/src/cljam/io/bcf/writer.clj
@@ -264,11 +264,11 @@
 
 (defn- meta->map
   "Creates a map for searching meta-info with (f id)."
-  [meta f]
+  [meta-info f]
   (into {} (map
             (fn [{:keys [id] t :type :as m}]
               [(f id) (cond-> (update m :idx #(Integer/parseInt %))
-                        t (assoc :type-kw (type-kws t)))])) meta))
+                        t (assoc :type-kw (type-kws t)))])) meta-info))
 
 (defn write-variants
   "Writes data lines on writer. Returns nil. `variants` must be a sequence of

--- a/src/cljam/io/bed.clj
+++ b/src/cljam/io/bed.clj
@@ -208,10 +208,10 @@
   Currently, this function affects only :end and :name fields."
   [xs]
   (region/merge-regions-with
-   (fn [x {:keys [name end]}]
+   (fn [x {:keys [end] name' :name}]
      (-> x
          (update :end max end)
-         (update-some :name str "+" name)))
+         (update-some :name str "+" name')))
    0
    (sort-fields xs)))
 

--- a/src/cljam/io/bigwig.clj
+++ b/src/cljam/io/bigwig.clj
@@ -9,7 +9,8 @@
   (:import [java.net URL]
            [java.io Closeable IOException RandomAccessFile]
            [java.nio ByteBuffer ByteOrder]
-           [java.util.zip Inflater]))
+           [java.util.zip Inflater])
+  (:refer-clojure :exclude [name]))
 
 (def ^:private bigwig-magic 0x888ffc26)
 
@@ -67,9 +68,9 @@
   ^BIGWIGReader
   [f]
   (let [f (.getAbsolutePath (cio/file f))
-        reader (RandomAccessFile. f "r")
-        headers (read-all-headers reader)]
-    (BIGWIGReader. reader (util/as-url f) headers)))
+        rdr (RandomAccessFile. f "r")
+        headers (read-all-headers rdr)]
+    (BIGWIGReader. rdr (util/as-url f) headers)))
 
 (defn- check-bigwig-magic
   "Checks if the magic is right for bigWig format. Otherwise, throws IOException."
@@ -97,8 +98,8 @@
 
 (defn- check-auto-sql-offset
   "For bigWig 0. Throws IOException if the autoSqlOffset is invalid."
-  [^long long]
-  (when-not (zero? long)
+  [^long auto-sql-offset]
+  (when-not (zero? auto-sql-offset)
     (throw (IOException. "Invalid bigWig autoSqlOffset"))))
 
 (defn- read-fixed-width-header

--- a/src/cljam/io/csi.clj
+++ b/src/cljam/io/csi.clj
@@ -117,10 +117,10 @@
 
 (defn- concatenate-offsets [offsets]
   (reduce
-   (fn [res chunk]
-     (if (= (:file-end (peek res)) (:file-beg chunk))
-       (assoc-in res [(dec (count res)) :file-end] (:file-end chunk))
-       (conj res chunk)))
+   (fn [res chunk']
+     (if (= (:file-end (peek res)) (:file-beg chunk'))
+       (assoc-in res [(dec (count res)) :file-end] (:file-end chunk'))
+       (conj res chunk')))
    []
    (sort-by :file-beg offsets)))
 
@@ -229,6 +229,6 @@
              (get loffset (util-bin/bin-beg bin (.min-shift csi) (.depth csi)))
              0))
           (lsb/write-int w (count chunks))
-          (doseq [chunk chunks]
-            (lsb/write-long w (:beg chunk))
-            (lsb/write-long w (:end chunk))))))))
+          (doseq [chunk' chunks]
+            (lsb/write-long w (:beg chunk'))
+            (lsb/write-long w (:end chunk'))))))))

--- a/src/cljam/io/dict/writer.clj
+++ b/src/cljam/io/dict/writer.clj
@@ -27,45 +27,45 @@
 
 (defn- make-hash
   "Normalizes the sequence string, calculates its MD5 hash, and returns it."
-  [sequence]
-  (let [bases ^bytes (string->bytes sequence)]
+  [sequence']
+  (let [bases' ^bytes (string->bytes sequence')]
     (loop [i 0]
-      (when (< i (count bases))
-        (aset bases i ^byte (upper-case (nth bases i)))
+      (when (< i (count bases'))
+        (aset bases' i ^byte (upper-case (nth bases' i)))
         (recur (inc i))))
-    (digest/md5 bases)))
+    (digest/md5 bases')))
 
 (defn- init-dict-status
   []
   {:sequence "", :len 0})
 
 (defn- update-dict-status
-  [dict-status sequence]
-  {:sequence (str (:sequence dict-status) sequence)
-   :len (+ (long (:len dict-status)) (count (filter graph? sequence)))})
+  [dict-status sequence']
+  {:sequence (str (:sequence dict-status) sequence')
+   :len (+ (long (:len dict-status)) (count (filter graph? sequence')))})
 
 (defn make-dict
   "Calculates sequence dictionary from the headers and sequences, returning it
   as a map."
   [_headers sequences ur]
-  (loop [[seq* & rest] sequences
-         name (:name seq*)
+  (loop [[seq* & rest'] sequences
+         name' (:name seq*)
          dict-status (init-dict-status)
          dicts {}]
     (if seq*
-      (let [name' (:name seq*)
-            new? (not= name' name)
+      (let [name'' (:name seq*)
+            new? (not= name'' name')
             dict-status' (update-dict-status
                           (if new? (init-dict-status) dict-status) (:sequence seq*))
             dicts' (if new?
-                     (assoc dicts name {:blen (:len dict-status)
-                                        :ur ur
-                                        :m5 (make-hash (:sequence dict-status))})
+                     (assoc dicts name' {:blen (:len dict-status)
+                                         :ur ur
+                                         :m5 (make-hash (:sequence dict-status))})
                      dicts)]
-        (recur rest name' dict-status' dicts'))
-      (assoc dicts name {:blen (:len dict-status)
-                         :ur ur
-                         :m5 (make-hash (:sequence dict-status))}))))
+        (recur rest' name'' dict-status' dicts'))
+      (assoc dicts name' {:blen (:len dict-status)
+                          :ur ur
+                          :m5 (make-hash (:sequence dict-status))}))))
 
 ;; Writing
 ;; -------
@@ -76,8 +76,8 @@
   (.newLine wtr))
 
 (defn- write-sequence!
-  [^BufferedWriter wtr name blen ur m5]
-  (.write wtr (str "@SQ\tSN:" name "\tLN:" blen "\tM5:" m5 "\tUR:" ur))
+  [^BufferedWriter wtr name' blen ur m5]
+  (.write wtr (str "@SQ\tSN:" name' "\tLN:" blen "\tM5:" m5 "\tUR:" ur))
   (.newLine wtr))
 
 (defn- write-dict*!

--- a/src/cljam/io/fasta/core.clj
+++ b/src/cljam/io/fasta/core.clj
@@ -66,10 +66,8 @@
 (defn read-seq-summaries
   "Read summaries of sequences in this FASTA file."
   [^FASTAReader rdr]
-  (mapv
-   (fn [{:keys [name len]}]
-     {:name name, :len len})
-   (fai/get-indices @(.index-delay rdr))))
+  (mapv #(select-keys % [:name :len])
+        (fai/get-indices @(.index-delay rdr))))
 
 (defn read-indices
   [^FASTAReader rdr]

--- a/src/cljam/io/fasta/writer.clj
+++ b/src/cljam/io/fasta/writer.clj
@@ -23,9 +23,9 @@
 (defn writer [f {:keys [cols create-index?]
                  :or {cols 80 create-index? true}}]
   (let [abs-f (.getAbsolutePath (cio/file f))
-        writer (cio/writer (util/compressor-output-stream abs-f))
+        wtr (cio/writer (util/compressor-output-stream abs-f))
         index-writer (when create-index? (cio/writer (str abs-f ".fai")))]
-    (FASTAWriter. (util/as-url abs-f) cols writer index-writer (volatile! 0))))
+    (FASTAWriter. (util/as-url abs-f) cols wtr index-writer (volatile! 0))))
 
 (defn- write-name
   ^long [^FASTAWriter w ^String n]
@@ -58,9 +58,12 @@
         [seq-len written]))))
 
 (defn- write-sequence
-  [^FASTAWriter w {:keys [name rname seq sequence]}]
-  (let [chr-name (or name rname)
-        seq-data (or seq sequence)
+  [^FASTAWriter w {:keys [rname]
+                   name' :name
+                   sequence' :sequence
+                   seq' :seq}]
+  (let [chr-name (or name' rname)
+        seq-data (or seq' sequence')
         name-bytes (write-name w chr-name)
         [seq-len seq-bytes] (if (string? seq-data)
                               (write-seq-str w seq-data)

--- a/src/cljam/io/fasta_index/core.clj
+++ b/src/cljam/io/fasta_index/core.clj
@@ -38,9 +38,9 @@
    (util/as-url f)))
 
 (defn get-header
-  [^FAIReader fai name]
-  (merge {:name name}
-         (get (.indices fai) name nil)))
+  [^FAIReader fai name']
+  (merge {:name name'}
+         (get (.indices fai) name' nil)))
 
 (defn get-headers
   [^FAIReader fai]
@@ -63,14 +63,14 @@
 
 (defn get-span
   "Calculate byte spans for FASTA file"
-  [^FAIReader fai name ^long start ^long end]
+  [^FAIReader fai name' ^long start ^long end]
   (let [start (max 0 start)
         end (max 0 end)]
     (when-let [{^long index-offset :offset
                 ^long index-len :len
                 ^long index-line-len :line-len
                 ^long index-line-blen :line-blen}
-               (get (.indices fai) name nil)]
+               (get (.indices fai) name' nil)]
       (let [start (min index-len start)
             end (min index-len end)
             proj (fn [^long pos]

--- a/src/cljam/io/fastq.clj
+++ b/src/cljam/io/fastq.clj
@@ -5,7 +5,8 @@
             [cljam.io.protocols :as protocols]
             [cljam.util :as util])
   (:import [java.io Closeable]
-           [java.nio Buffer CharBuffer]))
+           [java.nio Buffer CharBuffer])
+  (:refer-clojure :exclude [name sequence]))
 
 (declare read-sequences write-sequences)
 
@@ -79,7 +80,7 @@
   ([rdr]
    (read-sequences rdr {}))
   ([^FASTQReader rdr opts]
-   (sequence
+   (clojure.core/sequence
     (comp (map string/trim)
           (partition-all 4)
           (map #(deserialize-fastq % opts)))

--- a/src/cljam/io/protocols.clj
+++ b/src/cljam/io/protocols.clj
@@ -1,6 +1,6 @@
 (ns cljam.io.protocols
   "Protocols of reader/writer for various file formats."
-  (:refer-clojure :exclude [read indexed?]))
+  (:refer-clojure :exclude [read indexed? seq]))
 
 (defrecord SAMAlignment
            [qname ^int flag rname ^int pos ^int end ^int mapq cigar rnext ^int pnext ^int tlen seq qual options])

--- a/src/cljam/io/sam/util.clj
+++ b/src/cljam/io/sam/util.clj
@@ -14,12 +14,12 @@
 (defn parse-alignment
   "Parse an alignment line, returning a map of the alignment."
   [line]
-  (let [[qname flag rname pos-str mapq cigar rnext pnext tlen seq qual & options] (cstr/split line #"\t")
+  (let [[qname flag rname pos-str mapq cigar rnext pnext tlen seq' qual & options] (cstr/split line #"\t")
         pos (Integer/parseInt pos-str)
         ref-length (int (cigar/count-ref cigar))
         end (if (zero? ref-length) 0 (int (dec (+ pos ref-length))))]
     (SAMAlignment. qname (Integer/parseInt flag) rname pos end (Integer/parseInt mapq)
-                   cigar rnext (Integer/parseInt pnext) (Integer/parseInt tlen) (cstr/upper-case seq)
+                   cigar rnext (Integer/parseInt pnext) (Integer/parseInt tlen) (cstr/upper-case seq')
                    qual (map opt/parse-optional-field options))))
 
 ;;; stringify

--- a/src/cljam/io/sam/util/option.clj
+++ b/src/cljam/io/sam/util/option.clj
@@ -5,30 +5,30 @@
 
 ;;; parse
 
-(defn- parse-tag-single [val-type val]
+(defn- parse-tag-single [val-type val']
   (case val-type
-    \Z val
-    \A (first val)
-    \I (p/as-long val)
-    \i (p/as-long val)
-    \s (p/as-long val)
-    \S (p/as-long val)
-    \c (p/as-long val)
-    \C (p/as-long val)
-    \f (p/as-double val)
-    \H (p/hex->bytes val)
+    \Z val'
+    \A (first val')
+    \I (p/as-long val')
+    \i (p/as-long val')
+    \s (p/as-long val')
+    \S (p/as-long val')
+    \c (p/as-long val')
+    \C (p/as-long val')
+    \f (p/as-double val')
+    \H (p/hex->bytes val')
     (-> "Unrecognized tag type: %s, for value: %s"
-        (format val-type val)
+        (format val-type val')
         Exception.
         throw)))
 
 (defn parse-optional-field [op]
-  (let [[tag val-type-str val] (cstr/split op #":" 3)
+  (let [[tag val-type-str val'] (cstr/split op #":" 3)
         val-type (first val-type-str)]
     {(keyword tag) {:type val-type-str
                     :value (if (= val-type \B)
-                             val
-                             (parse-tag-single val-type val))}}))
+                             val'
+                             (parse-tag-single val-type val'))}}))
 
 ;;; stringify
 
@@ -36,8 +36,8 @@
   (->> options
        (map
         (fn [op]
-          (let [[tag {:keys [type value]}] (first (seq op))]
-            (cstr/join \: [(name tag) type value]))))
+          (let [[tag {:keys [value] type' :type}] (first (seq op))]
+            (cstr/join \: [(name tag) type' value]))))
        (cstr/join \tab)))
 
 ;;; accessors

--- a/src/cljam/io/sam/util/refs.clj
+++ b/src/cljam/io/sam/util/refs.clj
@@ -13,8 +13,8 @@
    (:SQ hdr)))
 
 (defn- ref-id*
-  [refs name]
-  (some #(when (= name (:name (second %))) (first %))
+  [refs name']
+  (some #(when (= name' (:name (second %))) (first %))
         (map-indexed vector refs)))
 
 (def ref-id
@@ -31,5 +31,5 @@
 
 (defn ref-by-name
   "Returns the first reference which has the specified name."
-  [refs name]
-  (some #(when (= (:name %) name) %) refs))
+  [refs name']
+  (some #(when (= (:name %) name') %) refs))

--- a/src/cljam/io/sam/util/sequence.clj
+++ b/src/cljam/io/sam/util/sequence.clj
@@ -67,10 +67,10 @@
 (defn normalize-bases
   "Converts bases in given buffer to upper-case. Also converts '.' to 'N'.
    Bases are represented as buffer of ASCII characters."
-  ^bytes [^bytes bases]
-  (dotimes [i (alength bases)]
-    (let [b (aget bases i)]
+  ^bytes [^bytes bases']
+  (dotimes [i (alength bases')]
+    (let [b (aget bases' i)]
       (cond
-        (= b (byte (int \.))) (aset-byte bases i (byte (int \N)))
-        (<= (byte (int \a)) b (byte (int \z))) (aset-byte bases i (- b 32))))) ;; Upper-case ASCII offset
-  bases)
+        (= b (byte (int \.))) (aset-byte bases' i (byte (int \N)))
+        (<= (byte (int \a)) b (byte (int \z))) (aset-byte bases' i (- b 32))))) ;; Upper-case ASCII offset
+  bases')

--- a/src/cljam/io/tabix.clj
+++ b/src/cljam/io/tabix.clj
@@ -7,7 +7,8 @@
             [clojure.string :as cstr])
   (:import java.util.Arrays
            [java.io DataInputStream IOException]
-           [cljam.io.util.chunk Chunk]))
+           [cljam.io.util.chunk Chunk])
+  (:refer-clojure :exclude [meta seq]))
 
 (def ^:const linear-index-shift 14)
 (def ^:const linear-index-depth 5)

--- a/src/cljam/io/twobit/reader.clj
+++ b/src/cljam/io/twobit/reader.clj
@@ -5,7 +5,8 @@
            [java.util TreeMap HashMap]
            [java.nio Buffer CharBuffer ByteBuffer ByteOrder]
            [java.nio.channels FileChannel FileChannel$MapMode]
-           [java.nio.file Paths OpenOption StandardOpenOption]))
+           [java.nio.file Paths OpenOption StandardOpenOption])
+  (:refer-clojure :exclude [name]))
 
 (deftype TwoBitReader [buf url index]
   Closeable

--- a/src/cljam/io/util/bin.clj
+++ b/src/cljam/io/util/bin.clj
@@ -57,9 +57,9 @@
   "Returns all overlapping bins for the specified region [`beg`, `end`] as a
   vector."
   [^long beg ^long end ^long min-shift ^long depth]
-  (let [max-pos (max-pos min-shift depth)
-        beg (dec (Math/min max-pos (Math/max 1 beg)))
-        end (dec (Math/min max-pos (Math/max 1 end)))]
+  (let [max-pos' (max-pos min-shift depth)
+        beg (dec (Math/min max-pos' (Math/max 1 beg)))
+        end (dec (Math/min max-pos' (Math/max 1 end)))]
     (into [0]
           (mapcat
            (fn [^long d]
@@ -74,9 +74,9 @@
 (defn reg->bin
   "Calculates the smallest bin containing the given region [`beg`, `end`]."
   ^long [^long beg ^long end ^long min-shift ^long depth]
-  (let [max-pos (max-pos min-shift depth)
-        beg (dec (Math/min max-pos (Math/max 1 beg)))
-        end (dec (Math/min max-pos (Math/max 1 end)))]
+  (let [max-pos' (max-pos min-shift depth)
+        beg (dec (Math/min max-pos' (Math/max 1 beg)))
+        end (dec (Math/min max-pos' (Math/max 1 end)))]
     (loop [level depth]
       (if-not (neg? level)
         (let [beg-bins (leading-bins-at-level beg level min-shift depth)]

--- a/src/cljam/io/vcf.clj
+++ b/src/cljam/io/vcf.clj
@@ -147,13 +147,13 @@
                                 [\"CHROM\" \"POS\" \"ID\" \"REF\" \"ALT\" ...])]
       (WRITING-VCF))"
   ^VCFWriter
-  [f meta-info header]
+  [f meta-info' header']
   (doto (VCFWriter. (util/as-url f)
                     (cio/writer (util/compressor-output-stream f))
-                    meta-info
-                    header)
-    (vcf-writer/write-meta-info meta-info)
-    (vcf-writer/write-header header)))
+                    meta-info'
+                    header')
+    (vcf-writer/write-meta-info meta-info')
+    (vcf-writer/write-header header')))
 
 (defn bcf-writer
   "Returns an open cljam.io.bcf.writer.BCFWriter of f. Meta-information lines
@@ -165,17 +165,17 @@
                                  [\"CHROM\" \"POS\" \"ID\" \"REF\" \"ALT\" ...])]
        (WRITING-BCF))"
   ^BCFWriter
-  [f meta-info header]
-  (bcf-writer/writer f meta-info header))
+  [f meta-info' header']
+  (bcf-writer/writer f meta-info' header'))
 
 (defn writer
   "Selects suitable writer from f's extension, returning the open writer. This
   function supports VCF and BCF formats."
   ^Closeable
-  [f meta-info header]
+  [f meta-info' header']
   (case (io-util/file-type f)
-    :vcf (vcf-writer f meta-info header)
-    :bcf (bcf-writer f meta-info header)
+    :vcf (vcf-writer f meta-info' header')
+    :bcf (bcf-writer f meta-info' header')
     (throw (IllegalArgumentException. "Invalid file type"))))
 
 (defn write-variants

--- a/src/cljam/io/vcf/reader.clj
+++ b/src/cljam/io/vcf/reader.clj
@@ -228,11 +228,13 @@
             repeatedly
             (take-while identity)
             (filter
-             (fn [{chr' :chr :keys [^long pos ref info]}]
+             (fn [{chr' :chr
+                   ref' :ref
+                   :keys [^long pos info]}]
                (and (= chr' chr)
                     (<= pos end)
                     (<= start
-                        (long (get info :END (dec (+ pos (count ref)))))))))))
+                        (long (get info :END (dec (+ pos (count ref')))))))))))
      spans)))
 
 (defn read-file-offsets
@@ -253,13 +255,13 @@
                 (let [end-pointer (.getFilePointer input-stream)]
                   (if (or (meta-line? line) (header-line? line))
                     (lazy-seq (step contigs end-pointer))
-                    (let [{:keys [chr pos ref info]} (parse line)
+                    (let [{:keys [chr pos info] ref' :ref} (parse line)
                           contigs' (if (contains? contigs chr)
                                      contigs
                                      (assoc contigs chr (count contigs)))]
                       (cons {:file-beg beg-pointer, :file-end end-pointer
                              :chr-index (contigs' chr), :beg pos, :chr chr,
                              :end (or (:END info)
-                                      (dec (+ (long pos) (count ref))))}
+                                      (dec (+ (long pos) (count ref'))))}
                             (lazy-seq (step contigs' end-pointer))))))))]
       (step meta-info-contigs 0))))

--- a/src/cljam/io/vcf/util/check.clj
+++ b/src/cljam/io/vcf/util/check.clj
@@ -3,8 +3,8 @@
 
 (defn same-ref?
   "Checks if a REF allele matches the reference sequence."
-  [seq-reader {:keys [chr ^long pos ^String ref]}]
-  (let [ref-len (.length ref)
+  [seq-reader {:keys [chr ^long pos] ^String ref' :ref}]
+  (let [ref-len (.length ref')
         ref-region {:chr chr :start pos :end (dec (+ pos ref-len))}
         ref-seq (io-seq/read-sequence seq-reader ref-region {:mask? false})]
-    (and ref-seq (.equalsIgnoreCase ^String ref-seq ref))))
+    (and ref-seq (.equalsIgnoreCase ^String ref-seq ref'))))

--- a/src/cljam/io/wig.clj
+++ b/src/cljam/io/wig.clj
@@ -86,8 +86,8 @@
                  (case (first fields)
                    ; track definition line
                    "track"
-                   (let [type (->> fields rest fields->map :type)]
-                     (if (= type "wiggle_0")
+                   (let [type' (->> fields rest fields->map :type)]
+                     (if (= type' "wiggle_0")
                        (deserialize (rest lines) pre-start {:line line})
                        (throw "The track type with version must be `wiggle_0`")))
 
@@ -159,9 +159,9 @@
          (map (fn [wig] (every? some? ((apply juxt wig-fields) wig))) wigs)
          ;; There are two options for formatting wiggle data.
          (map (fn [wig]
-                (let [format (-> wig :track :format)]
-                  (or (= format :fixed-step)
-                      (= format :variable-step))))
+                (let [format' (-> wig :track :format)]
+                  (or (= format' :fixed-step)
+                      (= format' :variable-step))))
               wigs)]}
   (letfn [(serialize [wigs]
             (->> wigs
@@ -170,9 +170,9 @@
                    (partition-by (juxt (comp :format :track)
                                        #(- (long (:end %)) (long (:start %)))))
                    (map
-                    (fn [[{{:keys [line format span step]} :track
+                    (fn [[{{:keys [line span step] format' :format} :track
                            chr :chr start :start} :as xs]]
-                      (case format
+                      (case format'
                         :variable-step
                         (let [declaration-line (->> (cond-> ["variableStep"
                                                              (str "chrom=" chr)]

--- a/src/cljam/util/chromosome.clj
+++ b/src/cljam/util/chromosome.clj
@@ -52,7 +52,7 @@
 
 (defn chromosome-order-key [s]
   (if-let [[_ _ chr suffix] (re-find #"(?i)^(chr)?([1-9][0-9]*|X|Y|MT|M)(\S*)" s)]
-    (if-let [num (proton/as-int chr)]
-      [num suffix]
+    (if-let [num' (proton/as-int chr)]
+      [num' suffix]
       [(- Integer/MAX_VALUE (case chr "X" 4 "Y" 3 "M" 2 "MT" 1)) suffix])
     [Integer/MAX_VALUE s]))

--- a/src/cljam/util/region.clj
+++ b/src/cljam/util/region.clj
@@ -118,8 +118,8 @@
   Returns a lazy sequence of map containing {:chr :start :end}."
   [refs step]
   (mapcat
-   (fn [{:keys [name len]}]
-     (map (fn [[s e]] {:chr name :start s :end e})
+   (fn [{:keys [len] name' :name}]
+     (map (fn [[s e]] {:chr name' :start s :end e})
           (divide-region 1 len step)))
    refs))
 

--- a/src/cljam/util/whole_genome.clj
+++ b/src/cljam/util/whole_genome.clj
@@ -32,10 +32,10 @@
   "Transforms a whole-genome position to a vector of a chromosome name and a
   position in the chromosome."
   [offset->ref ^long wg-pos]
-  (when-let [[^long offset {:keys [name len]}]
+  (when-let [[^long offset {:keys [len] name' :name}]
              (first (rsubseq offset->ref <= (dec wg-pos)))]
     (when (<= 1 (- wg-pos offset) len)
-      [name (- wg-pos offset)])))
+      [name' (- wg-pos offset)])))
 
 (defn ->regions
   "Transforms a region in whole-genome coordinate into a sequence of chromosomal

--- a/test/cljam/io/bcf/writer_test.clj
+++ b/test/cljam/io/bcf/writer_test.clj
@@ -220,10 +220,10 @@
      0x02 0x04]))
 
 (defn- bgzf->bb ^ByteBuffer [f]
-  (with-open [is (bgzf/bgzf-input-stream f)
+  (with-open [input-stream (bgzf/bgzf-input-stream f)
               baos (ByteArrayOutputStream.)]
-    (while (pos? (.available is))
-      (.write baos (.read is)))
+    (while (pos? (.available input-stream))
+      (.write baos (.read input-stream)))
     (.flush baos)
     (doto (ByteBuffer/wrap (.toByteArray baos))
       (.order ByteOrder/LITTLE_ENDIAN))))
@@ -282,7 +282,7 @@
                 (str "#" (cstr/join \tab header) \newline (char 0))]
                (cstr/join \newline))
         _ (with-open [_ (bcf-writer/writer tmp {} header)] nil)
-        bytes (bb->seq (bgzf->bb tmp))]
+        bytes' (bb->seq (bgzf->bb tmp))]
     (is (= (concat (.getBytes "BCF\2\2") [(.length s) 0 0 0] (.getBytes s))
-           bytes))
+           bytes'))
     (.delete tmp)))

--- a/test/cljam/io/pileup_test.clj
+++ b/test/cljam/io/pileup_test.clj
@@ -150,11 +150,11 @@
 ;; Writer
 ;; ------
 
-(defmacro with-string-writer [symbol & exprs]
+(defmacro with-string-writer [sym & exprs]
   `(with-open [sw# (StringWriter.)
-               ~symbol (cio/writer sw#)]
+               ~sym (cio/writer sw#)]
      ~@exprs
-     (.flush ~symbol)
+     (.flush ~sym)
      (str sw#)))
 
 (deftest write-mpileup-alignment!

--- a/test/cljam/io/sam/util/cigar_test.clj
+++ b/test/cljam/io/sam/util/cigar_test.clj
@@ -3,11 +3,11 @@
             [cljam.io.sam.util.cigar :as cigar])
   (:import [java.nio ByteBuffer ByteOrder]))
 
-(defn- ints->bytes ^bytes [ints]
-  (let [b (ByteBuffer/allocate (* 4 (count ints)))
+(defn- ints->bytes ^bytes [ints']
+  (let [b (ByteBuffer/allocate (* 4 (count ints')))
         _ (.order b ByteOrder/LITTLE_ENDIAN)
         ib (.asIntBuffer b)]
-    (doseq [i ints]
+    (doseq [i ints']
       (.put ib (unchecked-int i)))
     (.array b)))
 

--- a/test/cljam/io/sam_test.clj
+++ b/test/cljam/io/sam_test.clj
@@ -290,15 +290,15 @@
   (are [target-sam]
        (with-before-after {:before (prepare-cache!)
                            :after (clean-cache!)}
-         (let [temp-bam-file (.getAbsolutePath (cio/file temp-dir "test.bam"))]
+         (let [temp-bam-file' (.getAbsolutePath (cio/file temp-bam-file))]
            (with-open [sam-rdr (sam/reader target-sam)]
              (let [alignments (sam/read-alignments sam-rdr)
                    header (sam/read-header sam-rdr)]
-               (with-open [bam-wtr (sam/bam-writer temp-bam-file)]
+               (with-open [bam-wtr (sam/bam-writer temp-bam-file')]
                  (sam/write-header bam-wtr header)
                  (sam/write-refs bam-wtr header)
                  (sam/write-alignments bam-wtr alignments header))
-               (with-open [bam-rdr (sam/reader temp-bam-file)]
+               (with-open [bam-rdr (sam/reader temp-bam-file')]
                  (is (= (seq alignments)
                         (seq (sam/read-alignments bam-rdr)))))))))
     test-sam-file
@@ -310,15 +310,15 @@
   (are [target-bam]
        (with-before-after {:before (prepare-cache!)
                            :after (clean-cache!)}
-         (let [temp-sam-file (.getAbsolutePath (cio/file temp-dir "test.sam"))]
+         (let [temp-sam-file' (.getAbsolutePath (cio/file temp-sam-file))]
            (with-open [bam-rdr (sam/reader target-bam)]
              (let [alignments (sam/read-alignments bam-rdr)
                    header (sam/read-header bam-rdr)]
-               (with-open [sam-wtr (sam/sam-writer temp-sam-file)]
+               (with-open [sam-wtr (sam/sam-writer temp-sam-file')]
                  (sam/write-header sam-wtr header)
                  (sam/write-refs sam-wtr header)
                  (sam/write-alignments sam-wtr alignments header))
-               (with-open [sam-rdr (sam/reader temp-sam-file)]
+               (with-open [sam-rdr (sam/reader temp-sam-file')]
                  (is (= (seq alignments)
                         (seq (sam/read-alignments sam-rdr)))))))))
     test-bam-file

--- a/test/cljam/io/sequence_test.clj
+++ b/test/cljam/io/sequence_test.clj
@@ -63,10 +63,10 @@
               t (cseq/reader medium-twobit-file)]
     (let [xs (cseq/read-seq-summaries f)]
       (is (->> (repeatedly
-                #(let [{:keys [name len]} (rand-nth xs)
+                #(let [{:keys [len] name' :name} (rand-nth xs)
                        [s e] (sort [(inc (rand-int len))
                                     (inc (rand-int len))])]
-                   {:chr name :start s :end e}))
+                   {:chr name' :start s :end e}))
                (take 100)
                (pmap
                 (fn [region]

--- a/test/cljam/util_test.clj
+++ b/test/cljam/util_test.clj
@@ -102,8 +102,8 @@
                buf (byte-array (count ?data))]
            (with-open [os (util/compressor-output-stream f)]
              (.write os (.getBytes "compressor-output-stream-test")))
-           (with-open [is (cio/input-stream f)]
-             (.read is buf))
+           (with-open [input-stream (cio/input-stream f)]
+             (.read input-stream buf))
            (= (map unchecked-byte ?data) (seq buf))))
     ;; BGZF
     "test.gz"    [0x1f 0x8b 0x08 0x04 0x00 0x00 0x00 0x00


### PR DESCRIPTION
This PR fix shadowing variables.
I've fixed what's in the comment (https://github.com/chrovis/cljam/pull/279#pullrequestreview-1489657143 ) here in this PR.
- Variable `meta-info` of `cljam.io.bcf.reader` seemed difficult, so I removed it from the check target.
- Variable `version` of `cljam.io.bcf.reader` could be renamed, but it is also excluded from inspection because the code becomes complicated.