### PR TITLE
Revert "Bump codecov/codecov-action from 3 to 4"

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -21,7 +21,7 @@ jobs:
         lein cloverage --codecov
         bash <(curl -s https://codecov.io/bash) -f target/coverage/codecov.json
     - name: Coverage Graph
-      uses: codecov/codecov-action@v4
+      uses: codecov/codecov-action@v3
       with:
         token: ${{ secrets.CODECOV_TOKEN }}
         file: ./target/coverage/codecov.json


### PR DESCRIPTION
Reverts chrovis/cljam#284
Codecov v4 is a beta version, there is no release itself , so I think it is better to revert it.