### PR TITLE
Use aset instead of aset-* for performance

### DIFF
--- a/src/cljam/algo/depth.clj
+++ b/src/cljam/algo/depth.clj
@@ -23,7 +23,7 @@
             right (min (long (:end aln)) end)
             left-index (- left beg)]
         (dotimes [i (inc (- right left))]
-          (aset-long pile (+ i left-index) (inc (aget pile (+ i left-index)))))))
+          (aset pile (+ i left-index) (inc (aget pile (+ i left-index)))))))
     (seq pile)))
 
 (defn- lazy-depth*
@@ -74,11 +74,11 @@
             right (unchecked-inc-int (.end aln))
             left-index (unchecked-add-int (unchecked-subtract-int left beg) offset)
             right-index (unchecked-add-int (unchecked-subtract-int right beg) offset)]
-        (aset-int pile left-index (unchecked-inc-int (aget pile left-index)))
+        (aset pile left-index (unchecked-inc-int (aget pile left-index)))
         (when (<= right end)
-          (aset-int pile right-index (unchecked-dec-int (aget pile right-index))))))
+          (aset pile right-index (unchecked-dec-int (aget pile right-index))))))
     (dotimes [i (- end beg)]
-      (aset-int
+      (aset
        pile
        (unchecked-add-int (unchecked-inc-int i) offset)
        (unchecked-add-int
@@ -97,11 +97,11 @@
             right (inc (or (long (:end aln)) (sam-util/get-end aln)))
             left-index (+ (- left beg) offset)
             right-index (+ (- right beg) offset)]
-        (aset-int pile left-index (inc (aget pile left-index)))
+        (aset pile left-index (inc (aget pile left-index)))
         (when (<= right end)
-          (aset-int pile right-index (dec (aget pile right-index))))))
+          (aset pile right-index (dec (aget pile right-index))))))
     (dotimes [i (- end beg)]
-      (aset-int pile (+ (inc i) offset) (+ (aget pile (+ i offset)) (aget pile (+ (inc i) offset)))))))
+      (aset pile (+ (inc i) offset) (+ (aget pile (+ i offset)) (aget pile (+ (inc i) offset)))))))
 
 (defn ^"[I" depth*
   "Internal depth function which returns an int-array."

--- a/src/cljam/io/fasta/reader.clj
+++ b/src/cljam/io/fasta/reader.clj
@@ -218,7 +218,7 @@
   [stream page-size seq-buf-size]
   (let [byte-map (byte-array (range 128))]
     (doseq [[i v] [[\a 1] [\A 1] [\c 2] [\C 2] [\g 3] [\G 3] [\t 4] [\T 4] [\n 5] [\N 5]]]
-      (aset-byte byte-map (byte (int i)) (byte v)))
+      (aset byte-map (int i) (byte v)))
     (sequential-read stream page-size seq-buf-size byte-map)))
 
 (defn sequential-read-string
@@ -227,7 +227,7 @@
   (let [byte-map (byte-array (range 128))]
     (when-not mask?
       (doseq [[i v] [[\a \A] [\c \C] [\g \G] [\t \T] [\n \N]]]
-        (aset-byte byte-map (byte (int i)) (byte (int v)))))
+        (aset byte-map (int i) (byte (int v)))))
     (map (fn [{^bytes name' :name
                ^bytes sequence' :sequence}]
            {:name (String. name') :sequence (String. sequence')})

--- a/src/cljam/io/pileup.clj
+++ b/src/cljam/io/pileup.clj
@@ -44,14 +44,14 @@
   upper-table
   (let [ba (byte-array 128)]
     (doseq [c "ATGCN"]
-      (aset-byte ba (byte (int c)) (byte (int c)))
-      (aset-byte ba
-                 (+ (byte (int c))
-                    (- (byte (int \a))
-                       (byte (int \A))))
-                 (byte (int c))))
+      (aset ba (byte (int c)) (byte (int c)))
+      (aset ba
+            (+ (byte (int c))
+               (- (byte (int \a))
+                  (byte (int \A))))
+            (byte (int c))))
     (doseq [[from to] [[\, -1] [\. -1] [\< \>] [\> \>] [\* \*]]]
-      (aset-byte ba (byte (int from)) (byte (int to))))
+      (aset ba (int from) (byte (int to))))
     ba))
 
 (defn- parse-bases-col

--- a/src/cljam/io/sam/util/sequence.clj
+++ b/src/cljam/io/sam/util/sequence.clj
@@ -13,16 +13,16 @@
   ;; Value: two bases (A,C) => nibbles (1,2) => 2r 0001 0010 => 18
   (let [ba (byte-array (bit-shift-left 1 14))
         byte-to-nibble-table (byte-array (bit-shift-left 1 7) (byte 15))]
-    (doseq [[i c] (map vector (range) nibble-to-base-table)]
-      (aset-byte byte-to-nibble-table (int c) i)
-      (aset-byte byte-to-nibble-table (int (.charAt (cstr/lower-case c) 0)) i))
+    (doseq [[^byte i c] (map vector (range) nibble-to-base-table)]
+      (aset byte-to-nibble-table (int c) i)
+      (aset byte-to-nibble-table (int (.charAt (cstr/lower-case c) 0)) i))
     (dotimes [i (alength ba)]
       (let [u (unchecked-byte (bit-and 0x7F (unsigned-bit-shift-right i 7)))
             l (unchecked-byte (bit-and 0x7F i))]
         (->> (aget byte-to-nibble-table l)
              (bit-or (bit-shift-left (aget byte-to-nibble-table u) 4))
              unchecked-byte
-             (aset-byte ba i))))
+             (aset ba i))))
     ba))
 
 (defn str->compressed-bases
@@ -71,6 +71,6 @@
   (dotimes [i (alength bases')]
     (let [b (aget bases' i)]
       (cond
-        (= b (byte (int \.))) (aset-byte bases' i (byte (int \N)))
-        (<= (byte (int \a)) b (byte (int \z))) (aset-byte bases' i (- b 32))))) ;; Upper-case ASCII offset
+        (= b (byte (int \.))) (aset bases' i (byte (int \N)))
+        (<= (byte (int \a)) b (byte (int \z))) (aset bases' i (byte (- b 32)))))) ;; Upper-case ASCII offset
   bases')

--- a/src/cljam/io/twobit/writer.clj
+++ b/src/cljam/io/twobit/writer.clj
@@ -95,12 +95,12 @@
 (def ^:private
   char->twobit
   (doto (byte-array 128)
-    (aset-byte (int \C) 1)
-    (aset-byte (int \c) 1)
-    (aset-byte (int \A) 2)
-    (aset-byte (int \a) 2)
-    (aset-byte (int \G) 3)
-    (aset-byte (int \g) 3)))
+    (aset (int \C) (byte 1))
+    (aset (int \c) (byte 1))
+    (aset (int \A) (byte 2))
+    (aset (int \a) (byte 2))
+    (aset (int \G) (byte 3))
+    (aset (int \g) (byte 3))))
 
 (defn write-twobit!
   "Encodes a sequence into twobit format."

--- a/src/cljam/util/sequence.clj
+++ b/src/cljam/util/sequence.clj
@@ -4,11 +4,11 @@
 
 (def ^:private revcomp-table
   (let [ba (byte-array 128)]
-    (dotimes [i 128] (aset-byte ba i (byte (int \N))))
+    (dotimes [i 128] (aset ba i (byte (int \N))))
     (doseq [s ["AT" "GC" "NN"]
             [a b] [(cstr/upper-case s) (cstr/lower-case s)]]
-      (aset-byte ba (int a) (byte (int b)))
-      (aset-byte ba (int b) (byte (int a))))
+      (aset ba (int a) (byte (int b)))
+      (aset ba (int b) (byte (int a))))
     ba))
 
 (defn revcomp


### PR DESCRIPTION
`aset-*` (`aset-int`, `aset-long`, etc.) is a set of reflective array operations that are tens of times slower than inline `aset` calls and can have a significant performance impact:

```clojure
user=> (let [arr (int-array 1000)] (cr/quick-bench (dotimes [i 1000] (aset arr i i))))
Evaluation count : 587442 in 6 samples of 97907 calls.
             Execution time mean : 1.012114 µs
    Execution time std-deviation : 5.606968 ns
   Execution time lower quantile : 1.005990 µs ( 2.5%)
   Execution time upper quantile : 1.020545 µs (97.5%)
                   Overhead used : 6.755950 ns
nil
user=> (let [arr (int-array 1000)] (cr/quick-bench (dotimes [i 1000] (aset-int arr i i))))
Evaluation count : 8418 in 6 samples of 1403 calls.
             Execution time mean : 73.125862 µs
    Execution time std-deviation : 1.971431 µs
   Execution time lower quantile : 71.480682 µs ( 2.5%)
   Execution time upper quantile : 75.451133 µs (97.5%)
                   Overhead used : 6.755950 ns
nil
user=>
```

This PR replaces all the invocations to `aset-*` in the codebase with `aset` for performance improvement.

This change contributes specifically to the performance improvement of `cljam.algo.depth`, which is more than 1.5x faster after the change:

```clojure
;; before change
user=> (time (dorun (with-open [r (sam/reader "sample.bam")] (depth/depth r {:chr "chr1"} {:unchecked? true}))))
"Elapsed time: 41775.877042 msecs"
nil
user=>

;; after change
user=> (time (dorun (with-open [r (sam/reader "sample.bam")] (depth/depth r {:chr "chr1"} {:unchecked? true}))))
"Elapsed time: 24674.470916 msecs"
nil
user=>
```

| before change | after change |
| :---: | :---: |
| <img width="400" alt="flamegraph-before-change" src="https://github.com/chrovis/cljam/assets/27441/f546f275-bc2b-44bb-9735-e3907d0fff66"> | <img width="400" alt="flamegraph-after-change" src="https://github.com/chrovis/cljam/assets/27441/e2428139-9fd7-4a3d-b031-f534f2af5fa5"> |
