### PR TITLE
Misc performance tuning for cljam.algo.depth

### DIFF
--- a/src/cljam/algo/depth.clj
+++ b/src/cljam/algo/depth.clj
@@ -69,14 +69,15 @@
   (let [beg (int beg)
         end (int end)
         offset (int offset)]
-    (doseq [^SAMRegionBlock aln alns]
-      (let [left (Math/max ^int (.pos aln) beg)
-            right (unchecked-inc-int (.end aln))
-            left-index (unchecked-add-int (unchecked-subtract-int left beg) offset)
-            right-index (unchecked-add-int (unchecked-subtract-int right beg) offset)]
-        (aset pile left-index (unchecked-inc-int (aget pile left-index)))
-        (when (<= right end)
-          (aset pile right-index (unchecked-dec-int (aget pile right-index))))))
+    (run! (fn [^SAMRegionBlock aln]
+            (let [left (Math/max ^int (.pos aln) beg)
+                  right (unchecked-inc-int (.end aln))
+                  left-index (unchecked-add-int (unchecked-subtract-int left beg) offset)
+                  right-index (unchecked-add-int (unchecked-subtract-int right beg) offset)]
+              (aset pile left-index (unchecked-inc-int (aget pile left-index)))
+              (when (<= right end)
+                (aset pile right-index (unchecked-dec-int (aget pile right-index))))))
+          alns)
     (dotimes [i (- end beg)]
       (aset
        pile
@@ -92,14 +93,15 @@
   (let [beg (int beg)
         end (int end)
         offset (int offset)]
-    (doseq [aln alns]
-      (let [left (Math/max (int (:pos aln)) beg)
-            right (inc (or (long (:end aln)) (sam-util/get-end aln)))
-            left-index (+ (- left beg) offset)
-            right-index (+ (- right beg) offset)]
-        (aset pile left-index (inc (aget pile left-index)))
-        (when (<= right end)
-          (aset pile right-index (dec (aget pile right-index))))))
+    (run! (fn [aln]
+            (let [left (Math/max (int (:pos aln)) beg)
+                  right (inc (or (long (:end aln)) (sam-util/get-end aln)))
+                  left-index (+ (- left beg) offset)
+                  right-index (+ (- right beg) offset)]
+              (aset pile left-index (inc (aget pile left-index)))
+              (when (<= right end)
+                (aset pile right-index (dec (aget pile right-index))))))
+          alns)
     (dotimes [i (- end beg)]
       (aset pile (+ (inc i) offset) (+ (aget pile (+ i offset)) (aget pile (+ (inc i) offset)))))))
 


### PR DESCRIPTION
This PR includes the following two small changes to improve the performance of `cljam.algo.depth`:

- 736a9bc: Uses `run!` to avoid unnecessary sequence allocation
- 3b15a95: Reads BAM raw blocks into chunked seq, instead of cons, to improve the performance of later processing

The timing results are as follows:

```clojure
(time
 (with-open [r (sam/reader "DRR002191.chr1.bam")]
   (run! (constantly nil)
         (depth/depth r {:chr "chr1"} {:unchecked? true :n-threads 8}))))
;; before the changes
"Elapsed time: 4760.83475 msecs"
;; with 736a9bc
"Elapsed time: 4247.021042 msecs"
;; with 736a9bc + 3b15a95
"Elapsed time: 3983.6545 msecs"
```

The second change only shows a relatively small performance gain and might not need to be included in this PR.

For reference, here are the flamegraphs resulting from profiling:

<details><summary>Profiling results</summary>

- before the changes
<img width="500" alt="Profiling result at b7f7fa1" src="https://github.com/chrovis/cljam/assets/27441/5459e626-5f2d-4de1-aeac-8c02918fb053">

- with 736a9bc
<img width="500" alt="Profiling result at 736a9bc" src="https://github.com/chrovis/cljam/assets/27441/dc67e64b-72a3-4682-addc-72a9deaacd08">

- with 736a9bc + 3b15a95
<img width="500" alt="Profiling result at 3b15a95" src="https://github.com/chrovis/cljam/assets/27441/5d8fac17-b5ef-4143-a98e-254bc2635e46">
</details>