### PR TITLE
Disable :missing-docstring linter for test code

### DIFF
--- a/.clj-kondo/config.edn
+++ b/.clj-kondo/config.edn
@@ -25,4 +25,7 @@
            libra.bench/defbench clojure.test/deftest,
            libra.bench/is clojure.test/is,
            libra.bench/are clojure.test/are,
-           com.climate.claypoole/with-shutdown! clojure.core/with-open}}
+           com.climate.claypoole/with-shutdown! clojure.core/with-open}
+ :ns-groups [{:pattern ".*-test|cljam\\.test-common"
+              :name test-namespaces}]
+ :config-in-ns {test-namespaces {:linters {:missing-docstring {:level :off}}}}}


### PR DESCRIPTION
PR #282 has turned on the `:missing-docstring` linter, but it's not so much beneficial to enable it for the test code (Especially, `cljam.test-common` has lots of definitions without docstring, which is overwhelming the linter on my editor 🥹).

This PR narrows down the scope of the `:missing-docstring` linter to the product code.