### PR TITLE
Use ByteBuffer wrapper instead of LSB protocol

### DIFF
--- a/bench/cljam/io/vcf_bench.clj
+++ b/bench/cljam/io/vcf_bench.clj
@@ -1,0 +1,19 @@
+(ns cljam.io.vcf-bench
+  (:require [cljam.io.vcf :as vcf]
+            [cljam.test-common :as tcommon]
+            [libra.bench :refer [are defbench]]
+            [libra.criterium :as c]))
+
+(defbench decode-small-bcf-bench
+  (are [f]
+       (c/quick-bench
+        (with-open [r (vcf/reader f)]
+          (run! (constantly nil) (vcf/read-variants r))))
+    tcommon/test-bcf-complex-file))
+
+(defbench decode-large-bcf-bench
+  (are [f]
+       (c/quick-bench
+        (with-open [r (vcf/reader f)]
+          (run! (constantly nil) (vcf/read-variants-randomly r {:chr "chr1" :end 30000000} {}))))
+    tcommon/test-large-bcf-file))

--- a/src/cljam/io/util/byte_buffer.clj
+++ b/src/cljam/io/util/byte_buffer.clj
@@ -1,0 +1,68 @@
+(ns cljam.io.util.byte-buffer
+  {:clj-kondo/ignore [:missing-docstring]}
+  (:refer-clojure :exclude [read-string])
+  (:require [cljam.util :refer [string->bytes]])
+  (:import [java.nio Buffer ByteBuffer ByteOrder]))
+
+(defn make-lsb-byte-buffer ^ByteBuffer [^bytes data]
+  (.order (ByteBuffer/wrap data) ByteOrder/LITTLE_ENDIAN))
+
+(defn make-msb-byte-buffer ^ByteBuffer [^bytes data]
+  (.order (ByteBuffer/wrap data) ByteOrder/BIG_ENDIAN))
+
+(defn allocate-lsb-byte-buffer
+  (^ByteBuffer []
+   (.order (ByteBuffer/allocate 8) ByteOrder/LITTLE_ENDIAN))
+  (^ByteBuffer [size]
+   (.order (ByteBuffer/allocate (int size)) ByteOrder/LITTLE_ENDIAN)))
+
+(defn allocate-msb-byte-buffer
+  (^ByteBuffer []
+   (.order (ByteBuffer/allocate 8) ByteOrder/BIG_ENDIAN))
+  (^ByteBuffer [size]
+   (.order (ByteBuffer/allocate (int size)) ByteOrder/BIG_ENDIAN)))
+
+(defn skip [^ByteBuffer bb ^long length]
+  (.position ^Buffer bb (+ (.position bb) length)))
+
+(defn read-ubyte [^ByteBuffer bb]
+  (bit-and (.get bb) 0xFF))
+
+(defn read-ushort [^ByteBuffer bb]
+  (bit-and (.getShort bb) 0xFFFF))
+
+(defn read-uint [^ByteBuffer bb]
+  (bit-and (.getInt bb) 0xFFFFFFFF))
+
+(defn read-bytes
+  ([^ByteBuffer bb ^long length]
+   (let [ba (byte-array length)]
+     (.get bb ba)
+     ba))
+  ([^ByteBuffer bb buffer ^long offset ^long length]
+   (.get bb buffer (int offset) (int length))
+   buffer))
+
+(defn read-string [^ByteBuffer bb ^long length]
+  (let [ba (byte-array length)]
+    (.get bb ba)
+    (String. ba)))
+
+(defn read-null-terminated-string [^ByteBuffer bb]
+  (let [start (.position bb)
+        end (do (while (not (zero? (.get bb))))
+                (.position bb))
+        offset (.arrayOffset bb)]
+    (String. (.array bb) (+ offset start) (dec (- end start)))))
+
+(defn write-ubyte [^ByteBuffer bb b]
+  (.put bb (unchecked-byte b)))
+
+(defn write-ushort [^ByteBuffer bb n]
+  (.putShort bb (unchecked-short n)))
+
+(defn write-uint [^ByteBuffer bb n]
+  (.putInt bb (unchecked-int n)))
+
+(defn write-string [^ByteBuffer bb s]
+  (.put bb (string->bytes s)))

--- a/src/cljam/io/util/byte_buffer.clj
+++ b/src/cljam/io/util/byte_buffer.clj
@@ -1,40 +1,54 @@
 (ns cljam.io.util.byte-buffer
-  {:clj-kondo/ignore [:missing-docstring]}
   (:refer-clojure :exclude [read-string])
   (:require [cljam.util :refer [string->bytes]])
   (:import [java.nio Buffer ByteBuffer ByteOrder]))
 
-(defn make-lsb-byte-buffer ^ByteBuffer [^bytes data]
+(defn make-lsb-byte-buffer
+  "Creates a new little-endian byte buffer wrapping given data."
+  ^ByteBuffer [^bytes data]
   (.order (ByteBuffer/wrap data) ByteOrder/LITTLE_ENDIAN))
 
-(defn make-msb-byte-buffer ^ByteBuffer [^bytes data]
+(defn make-msb-byte-buffer
+  "Creates a new big-endian byte buffer wrapping given data."
+  ^ByteBuffer [^bytes data]
   (.order (ByteBuffer/wrap data) ByteOrder/BIG_ENDIAN))
 
 (defn allocate-lsb-byte-buffer
+  "Creates a new little-endian byte buffer with given capacity."
   (^ByteBuffer []
    (.order (ByteBuffer/allocate 8) ByteOrder/LITTLE_ENDIAN))
   (^ByteBuffer [size]
    (.order (ByteBuffer/allocate (int size)) ByteOrder/LITTLE_ENDIAN)))
 
 (defn allocate-msb-byte-buffer
+  "Creates a new big-endian byte buffer with given capacity."
   (^ByteBuffer []
    (.order (ByteBuffer/allocate 8) ByteOrder/BIG_ENDIAN))
   (^ByteBuffer [size]
    (.order (ByteBuffer/allocate (int size)) ByteOrder/BIG_ENDIAN)))
 
-(defn skip [^ByteBuffer bb ^long length]
+(defn skip
+  "Skips over 'length' bytes of data, discarding the skipped bytes."
+  [^ByteBuffer bb ^long length]
   (.position ^Buffer bb (+ (.position bb) length)))
 
-(defn read-ubyte [^ByteBuffer bb]
+(defn read-ubyte
+  "Reads 1 byte. Returns an unsigned byte value as long."
+  [^ByteBuffer bb]
   (bit-and (.get bb) 0xFF))
 
-(defn read-ushort [^ByteBuffer bb]
+(defn read-ushort
+  "Reads 2 bytes. Returns an unsigned short value as long."
+  [^ByteBuffer bb]
   (bit-and (.getShort bb) 0xFFFF))
 
-(defn read-uint [^ByteBuffer bb]
+(defn read-uint
+  "Reads 4 bytes. Returns an unsigned int value as long."
+  [^ByteBuffer bb]
   (bit-and (.getInt bb) 0xFFFFFFFF))
 
 (defn read-bytes
+  "Reads 'length' bytes to buffer starting from offset bytes. Returns a new byte-array if called without buffer."
   ([^ByteBuffer bb ^long length]
    (let [ba (byte-array length)]
      (.get bb ba)
@@ -43,26 +57,38 @@
    (.get bb buffer (int offset) (int length))
    buffer))
 
-(defn read-string [^ByteBuffer bb ^long length]
+(defn read-string
+  "Reads 'length' bytes. Returns a String."
+  [^ByteBuffer bb ^long length]
   (let [ba (byte-array length)]
     (.get bb ba)
     (String. ba)))
 
-(defn read-null-terminated-string [^ByteBuffer bb]
+(defn read-null-terminated-string
+  "Reads until next null character. Returns a String without the null."
+  [^ByteBuffer bb]
   (let [start (.position bb)
         end (do (while (not (zero? (.get bb))))
                 (.position bb))
         offset (.arrayOffset bb)]
     (String. (.array bb) (+ offset start) (dec (- end start)))))
 
-(defn write-ubyte [^ByteBuffer bb b]
+(defn write-ubyte
+  "Writes 1 byte."
+  [^ByteBuffer bb b]
   (.put bb (unchecked-byte b)))
 
-(defn write-ushort [^ByteBuffer bb n]
+(defn write-ushort
+  "Writes a 2-byte unsigned short value."
+  [^ByteBuffer bb n]
   (.putShort bb (unchecked-short n)))
 
-(defn write-uint [^ByteBuffer bb n]
+(defn write-uint
+  "Writes a 4-byte unsigned integer value."
+  [^ByteBuffer bb n]
   (.putInt bb (unchecked-int n)))
 
-(defn write-string [^ByteBuffer bb s]
+(defn write-string
+  "Writes a string as a sequence of ascii characters."
+  [^ByteBuffer bb s]
   (.put bb (string->bytes s)))

--- a/test/cljam/io/util/byte_buffer_test.clj
+++ b/test/cljam/io/util/byte_buffer_test.clj
@@ -1,0 +1,112 @@
+(ns cljam.io.util.byte-buffer-test
+  (:require [cljam.io.util.byte-buffer :as bb]
+            [clojure.test :refer [deftest is testing]]))
+
+(deftest make-lsb-byte-buffer-test
+  (let [bb (bb/make-lsb-byte-buffer (byte-array [0x01 0x23 0x45 0x67]))]
+    (is (= 0x67452301 (.getInt bb)))))
+
+(deftest make-msb-byte-buffer-test
+  (let [bb (bb/make-msb-byte-buffer (byte-array [0x01 0x23 0x45 0x67]))]
+    (is (= 0x01234567 (.getInt bb)))))
+
+(deftest allocate-lsb-byte-buffer-test
+  (let [bb (doto (bb/allocate-lsb-byte-buffer 8)
+             (.putLong 0x789ABCDEF0123456)
+             (.flip))]
+    (is (= (int 0xF0123456) (.getInt bb)))
+    (is (= (int 0x789ABCDE) (.getInt bb)))))
+
+(deftest allocate-msb-byte-buffer-test
+  (let [bb (doto (bb/allocate-msb-byte-buffer 8)
+             (.putLong 0x789ABCDEF0123456)
+             (.flip))]
+    (is (= (int 0x789ABCDE) (.getInt bb)))
+    (is (= (int 0xF0123456) (.getInt bb)))))
+
+(deftest read-ops-test
+  (let [bb (doto (bb/allocate-lsb-byte-buffer 8)
+             (.mark)
+             (.putLong 0x789ABCDEF0123456))]
+    (testing "read-ubyte"
+      (.reset bb)
+      (is (= 0x56 (bb/read-ubyte bb)))
+      (is (= 0x34 (bb/read-ubyte bb)))
+      (is (= 0x12 (bb/read-ubyte bb)))
+      (is (= 0xF0 (bb/read-ubyte bb)))
+      (is (= 0xDE (bb/read-ubyte bb)))
+      (is (= 0xBC (bb/read-ubyte bb)))
+      (is (= 0x9A (bb/read-ubyte bb)))
+      (is (= 0x78 (bb/read-ubyte bb))))
+
+    (testing "read-ushort"
+      (.reset bb)
+      (is (= 0x3456 (bb/read-ushort bb)))
+      (is (= 0xF012 (bb/read-ushort bb)))
+      (is (= 0xBCDE (bb/read-ushort bb)))
+      (is (= 0x789A (bb/read-ushort bb))))
+
+    (testing "read-unit"
+      (.reset bb)
+      (is (= 0xF0123456 (bb/read-uint bb)))
+      (is (= 0x789ABCDE (bb/read-uint bb))))
+
+    (testing "read-bytes"
+      (.reset bb)
+      (is (= [0x56 0x34 0x12 0xF0 0xDE 0xBC 0x9A 0x78]
+             (map #(bit-and % 0xFF) (bb/read-bytes bb 8))))
+
+      (.reset bb)
+      (bb/skip bb 1)
+      (is (= [0 0 0x34 0x12 0xF0 0]
+             (map #(bit-and % 0xFF) (bb/read-bytes bb (byte-array 6) 2 3)))))
+
+    (testing "read-string"
+      (.reset bb)
+      (doseq [c "ABCDEFGH"]
+        (.put bb (byte (int c))))
+      (.reset bb)
+      (is (= "ABCDEFGH" (bb/read-string bb 8))))
+
+    (testing "read-null-terminated-string"
+      (.reset bb)
+      (doseq [c [\I \J \K \L 0 \M \N \O]]
+        (.put bb (byte (int c))))
+      (.reset bb)
+      (is (= "IJKL" (bb/read-null-terminated-string bb))))))
+
+(deftest write-ops-test
+  (let [bb (bb/allocate-msb-byte-buffer 8)]
+    (testing "write-ubyte"
+      (bb/write-ubyte bb 0x78)
+      (bb/write-ubyte bb 0x9A)
+      (bb/write-ubyte bb 0xBC)
+      (bb/write-ubyte bb 0xDE)
+      (bb/write-ubyte bb 0xF0)
+      (bb/write-ubyte bb 0x12)
+      (bb/write-ubyte bb 0x34)
+      (bb/write-ubyte bb 0x56)
+      (.flip bb)
+      (is (= 0x789ABCDEF0123456 (.getLong bb))))
+
+    (testing "write-ushort"
+      (.flip bb)
+      (bb/write-ushort bb 0x789A)
+      (bb/write-ushort bb 0xBCDE)
+      (bb/write-ushort bb 0xF012)
+      (bb/write-ushort bb 0x3456)
+      (.flip bb)
+      (is (= 0x789ABCDEF0123456 (.getLong bb))))
+
+    (testing "write-uint"
+      (.flip bb)
+      (bb/write-uint bb 0x789ABCDE)
+      (bb/write-uint bb 0xF0123456)
+      (.flip bb)
+      (is (= 0x789ABCDEF0123456 (.getLong bb))))
+
+    (testing "write-string"
+      (.flip bb)
+      (bb/write-string bb "ABCDEFGH")
+      (.flip bb)
+      (is (= "ABCDEFGH" (bb/read-string bb 8))))))


### PR DESCRIPTION
This PR is the first step of #289.

It replaces the use of `ByteBuffer` as an LSB protocol implementation with a new thin wrapper utility for `ByteBuffer`.

The modification policy here is to use the bare `ByteBuffer` methods whenever possible. The new wrapper namespace only collects functions that do what a single method of `ByteBuffer` cannot do. Most of the implementation code comes from [the implementation of the LSB protocol](https://github.com/chrovis/cljam/blob/14e0deb16f4423686d5d68907e040fe9729d262d/src/cljam/io/util/lsb.clj#L36-L82).