### PR TITLE
Remove nth's linear search overhead in BCF reader

### DIFF
--- a/src/cljam/io/bcf/reader.clj
+++ b/src/cljam/io/bcf/reader.clj
@@ -144,13 +144,13 @@
          type-id (bit-and 0x0F type-byte)]
      (case type-id
        0 (repeat n-sample nil)
-       7 (doall (repeatedly n-sample
-                            #(bytes->strs (bb/read-bytes bb total-len))))
-       (->> #(read-typed-atomic-value bb type-id)
-            (repeatedly (* n-sample total-len))
-            (partition total-len)
-            (map (fn [xs] (take-while #(not= % :eov) xs)))
-            doall)))))
+       7  (mapv (fn [_] (bytes->strs (bb/read-bytes bb total-len)))
+                (range n-sample))
+       (into []
+             (comp (map (fn [_] (read-typed-atomic-value bb type-id)))
+                   (partition-all total-len)
+                   (map (fn [xs] (take-while #(not= % :eov) xs))))
+             (range (* n-sample total-len)))))))
 
 (defn- read-typed-kv
   "Reads a key-value pair."


### PR DESCRIPTION
When I was profiling the BCF reader before, I found that the invocation to [`nth`](https://github.com/chrovis/cljam/blob/d68c01dd0c0e1b8a61829ada9c0c5e9aa18f4257/src/cljam/io/bcf/reader.clj#L230) took up most of the time, which does linear search per sample.

This PR removes the overhead of the linear search and improve the performance of the BCF reader by replacing the sequential collection returned from `read-typed-value` with a vector, not a lazy sequence.

Here are the profiling results before and after the change:

| before change | after change |
| :---: | :---: |
| <a href="https://github.com/chrovis/cljam/assets/27441/fc96ce6e-d332-4832-8bc0-3b3e7db126ac"><img width="500" alt="before change" src="https://github.com/chrovis/cljam/assets/27441/fc96ce6e-d332-4832-8bc0-3b3e7db126ac"></a> | <a href="https://github.com/chrovis/cljam/assets/27441/028ccbb2-f99b-4345-8aff-f6e7a58bcc85"><img width="500" alt="after change" src="https://github.com/chrovis/cljam/assets/27441/028ccbb2-f99b-4345-8aff-f6e7a58bcc85"></a> |

By this fix, the BCF reader is now roughly 7x faster than before:

```clojure
(time
 (with-open [r (vcf/reader ".cavia/large.bcf")]
   (run! (constantly nil) (vcf/read-variants-randomly r {:chr "chr1" :end 30000000} {}))))

;; before change
"Elapsed time: 7973.314958 msecs"

;; after change
"Elapsed time: 1139.505833 msecs"
```