### PR TITLE
Remove `-Xbootlasspath/a` option of the cljam executable

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -46,8 +46,7 @@
                                       :username [:env/clojars_username :gpg]
                                       :password [:env/clojars_password :gpg]}]]
   :aliases {"docs" ["do" "codox" ["marg" "-d" "target/literate" "-m"]]}
-  :bin {:name "cljam"
-        :bootclasspath true}
+  :bin {:name "cljam"}
   :codox {:namespaces [#"^cljam\.(?!tools)[\w\-]+(\.[\w\-]+)?$"]
           :output-path "target/docs"
           :source-uri "https://github.com/chrovis/cljam/blob/{version}/{filepath}#L{line}"}


### PR DESCRIPTION
Fixes #295 

This PR removes `-Xbootclasspath/a` option from the header of the cljam executable built by `lein bin` to avoid a NPE from commons-compress >= 1.21.
The default value of `:bootclasspath` in `lein-binplus` is `false`.

> - [When loading the class `org.apache.commons.compress.utils.OsgiUtils`, its static initializer calls `getClassLoader`](https://github.com/apache/commons-compress/blob/b19df3e5b9a85000cf46be3afd998fc58c0ea538/src/main/java/org/apache/commons/compress/utils/OsgiUtils.java#L31) but the return value will be `null` when the class is loaded by a bootstrap classloader.
> - [`lein-binplus` adds the `-Xbootclasspath/a` option when `:bootclasspath` is truthy](https://github.com/BrunoBonacci/lein-binplus/blob/41071234e9695a6dfcdde77c0341be07406c5a27/src/leiningen/bin.clj#L19)
> - So this can be fixed by removing [`:bootclasspath true`](https://github.com/chrovis/cljam/blob/a514b2e957734bf7704bbe4f64149dc478e6128b/project.clj#L50) in project.clj