### PR TITLE
Remove extra parens around static field references

### DIFF
--- a/test/cljam/io/bam_test.clj
+++ b/test/cljam/io/bam_test.clj
@@ -43,11 +43,11 @@
       \f -17.75
       \f 0.0
       \f 5.75
-      \f (Float/MAX_VALUE)
-      \f (Float/MIN_NORMAL)
-      \f (Float/MIN_VALUE)
-      \f (Float/NEGATIVE_INFINITY)
-      \f (Float/POSITIVE_INFINITY)))
+      \f Float/MAX_VALUE
+      \f Float/MIN_NORMAL
+      \f Float/MIN_VALUE
+      \f Float/NEGATIVE_INFINITY
+      \f Float/POSITIVE_INFINITY))
 
   (testing "NULL-terminated text"
     (are [?type ?value]


### PR DESCRIPTION
A recent update on clj-kondo has introduced a new linter [`java-static-field-call`](https://github.com/clj-kondo/clj-kondo/issues/2260), which checks if a reference to a Java static field has extra parens around it, and now it is enabled by default and will be reported as errors.

I found some portion of cljam code caught by the linter. This PR fixes it all.

```console
$ clj-kondo --lint src:test | grep error
src/cljam/io/wig.clj:92:31: error: Expected: throwable, received: string.
test/cljam/io/bam_test.clj:46:10: error: Static fields should be referenced without parens unless they are intended as function calls
test/cljam/io/bam_test.clj:47:10: error: Static fields should be referenced without parens unless they are intended as function calls
test/cljam/io/bam_test.clj:48:10: error: Static fields should be referenced without parens unless they are intended as function calls
test/cljam/io/bam_test.clj:49:10: error: Static fields should be referenced without parens unless they are intended as function calls
test/cljam/io/bam_test.clj:50:10: error: Static fields should be referenced without parens unless they are intended as function calls
test/cljam/io/gff_test.clj:319:70: error: Unresolved symbol: ?str
linting took 2004ms, errors: 7, warnings: 3
$
```