### PR TITLE
Misc performance improvements for CRAM reader

### DIFF
--- a/src/cljam/io/cram/codecs/rans4x8.clj
+++ b/src/cljam/io/cram/codecs/rans4x8.clj
@@ -62,8 +62,7 @@
 (defn- renormalize-state ^long [bb ^long state]
   (loop [state state]
     (if (< state 0x800000)
-      (recur (+ (bit-shift-left state 8)
-                (long (bb/read-ubyte bb))))
+      (recur (bit-or (bit-shift-left state 8) (long (bb/read-ubyte bb))))
       state)))
 
 (defn- decode0 [bb ^long n-out]

--- a/src/cljam/io/cram/codecs/rans4x8.clj
+++ b/src/cljam/io/cram/codecs/rans4x8.clj
@@ -2,44 +2,51 @@
   (:require [cljam.io.util.byte-buffer :as bb]
             [cljam.io.cram.itf8 :as itf8]))
 
-(defn- read-frequencies* [bb read-fn]
-  (loop [sym (long (bb/read-ubyte bb))
-         rle 0
-         freqs (transient {})]
-    (let [freqs' (assoc! freqs sym (read-fn bb))]
-      (if (pos? rle)
-        (recur (inc sym) (dec rle) freqs')
-        (let [sym' (long (bb/read-ubyte bb))
-              rle' (if (= sym' (inc sym))
-                     (long (bb/read-ubyte bb))
-                     rle)]
-          (if (zero? sym')
-            (persistent! freqs')
-            (recur sym' rle' freqs')))))))
+(defmacro ^:private read-frequencies* [bb init-expr read-expr]
+  `(let [ret# ~init-expr]
+     (loop [sym# (long (bb/read-ubyte ~bb))
+            rle# 0]
+       (aset ret# sym# ~read-expr)
+       (if (pos? rle#)
+         (recur (inc sym#) (dec rle#))
+         (let [sym'# (long (bb/read-ubyte ~bb))
+               rle'# (if (= sym'# (inc sym#))
+                       (long (bb/read-ubyte ~bb))
+                       rle#)]
+           (if (zero? sym'#)
+             ret#
+             (recur sym'# rle'#)))))))
 
-(defn- read-frequencies0 [bb]
-  (read-frequencies* bb itf8/decode-itf8))
+(defn- read-frequencies0 ^ints [bb]
+  (read-frequencies* bb (int-array 256) (int (itf8/decode-itf8 bb))))
 
-(defn- read-frequencies1 [bb]
-  (read-frequencies* bb read-frequencies0))
+(def ^:private int-array-type (type (int-array 0)))
 
-(defn- cumulative-frequencies [freqs]
-  (loop [i 0
-         sum 0
-         cum-freqs (transient [])]
-    (if (< i 256)
-      (let [f (get freqs i 0)]
-        (recur (inc i) (+ sum (long f)) (conj! cum-freqs sum)))
-      (persistent! (conj! cum-freqs sum)))))
+(defn- read-frequencies1 ^"[[I" [bb]
+  (read-frequencies* bb ^"[[I" (make-array int-array-type 256) (read-frequencies0 bb)))
 
-(defn- lookup-symbol ^long [cum-freqs ^long f]
+(def ^:private zero-int-array (int-array 256))
+
+(defn- cumulative-frequencies ^ints [^ints freqs]
+  (if (nil? freqs)
+    zero-int-array
+    (let [cum-freqs (int-array 256)]
+      (loop [i 0
+             sum 0]
+        (when (< i 256)
+          (let [f (aget freqs i)]
+            (aset cum-freqs i sum)
+            (recur (inc i) (+ sum (long f))))))
+      cum-freqs)))
+
+(defn- lookup-symbol ^long [^ints cum-freqs ^long f]
   (loop [l 0
-         r (dec (count cum-freqs))]
+         r (dec (alength cum-freqs))]
     (if (< l r)
       (let [m (quot (+ l r) 2)
-            fm (long (nth cum-freqs m))]
+            fm (long (aget cum-freqs m))]
         (cond (and (<= fm f)
-                   (< f (long (nth cum-freqs (inc m)))))
+                   (< f (long (aget cum-freqs (inc m)))))
               m
 
               (< f fm) (recur l (dec m))
@@ -69,7 +76,7 @@
             f (bit-and state 0xfff)
             sym (lookup-symbol cum-freqs f)
             state' (->> state
-                        (advance-step (nth cum-freqs sym) (get freqs sym 0))
+                        (advance-step (aget cum-freqs sym) (aget freqs sym))
                         (renormalize-state bb))]
         (aset out i (byte sym))
         (aset states j state')))
@@ -77,10 +84,9 @@
 
 (defn- decode1 [bb ^long n-out]
   (let [freqs (read-frequencies1 bb)
-        cum-freqs (persistent!
-                   (reduce-kv #(assoc! %1 %2 (cumulative-frequencies %3))
-                              (transient {})
-                              freqs))
+        ^"[[I" cum-freqs (make-array int-array-type 256)
+        _ (dotimes [i 256]
+            (aset cum-freqs i (cumulative-frequencies (aget freqs i))))
         quarter (quot n-out 4)
         truncated (* 4 quarter)
         states (bb/read-ints bb 4)
@@ -91,11 +97,11 @@
         (let [state (aget states j)
               f (bit-and state 0xfff)
               last-sym (aget last-syms j)
-              cfreqs (get cum-freqs last-sym)
+              ^ints cfreqs (aget cum-freqs last-sym)
               sym (lookup-symbol cfreqs f)
               state' (->> state
-                          (advance-step (nth cfreqs sym)
-                                        (get-in freqs [last-sym sym] 0))
+                          (advance-step (aget cfreqs sym)
+                                        (aget ^ints (aget freqs last-sym) sym))
                           (renormalize-state bb))]
           (aset out (+ i (* j quarter)) (byte sym))
           (aset states j state')
@@ -104,11 +110,11 @@
       (let [state (aget states 3)
             f (bit-and state 0xfff)
             last-sym (aget last-syms 3)
-            cfreq (get cum-freqs last-sym)
+            ^ints cfreq (aget cum-freqs last-sym)
             sym (lookup-symbol cfreq f)
             state' (->> state
-                        (advance-step (nth cfreq sym)
-                                      (get-in freqs [last-sym sym] 0))
+                        (advance-step (aget cfreq sym)
+                                      (aget ^ints (aget freqs last-sym) sym))
                         (renormalize-state bb))]
         (aset out (+ i truncated) (byte sym))
         (aset states 3 state')

--- a/src/cljam/io/cram/decode/record.clj
+++ b/src/cljam/io/cram/decode/record.clj
@@ -154,7 +154,7 @@
         (if (= len miss)
           "*"
           (String. (.array bb)))
-        (let [q (qs-decoder)]
+        (let [q (long (qs-decoder))]
           (.put bb (byte (qual-score q)))
           (recur (dec i) (cond-> miss (= q -1) inc)))))))
 

--- a/test/cljam/io/cram/codecs/rans4x8_test.clj
+++ b/test/cljam/io/cram/codecs/rans4x8_test.clj
@@ -77,6 +77,32 @@
                  (#'rans/read-frequencies1 bb))))
     (is (zero? (.remaining bb)))))
 
+(deftest cumulative-frequencies-test
+  (let [freqs (-> [0x000 0x747 0x000 0x2e8 0x000 0x174 0x174 0x2e8]
+                  (concat (repeat 248 0x000))
+                  int-array)]
+    (is (= (concat [0x000 0x000 0x747 0x747 0xa2f 0xa2f 0xba3 0xd17 0xfff 0xfff]
+                   (repeat 246 0xfff))
+           (vec (#'rans/cumulative-frequencies freqs))))))
+
+(deftest reverse-lookup-table-test
+  (let [freqs (-> [0x000 0x747 0x000 0x2e8 0x000 0x174 0x174 0x2e8]
+                  (concat (repeat 248 0x000))
+                  int-array)
+        cfreqs (#'rans/cumulative-frequencies freqs)
+        table ^bytes (#'rans/reverse-lookup-table cfreqs)]
+    (is (= 1 (aget table 0x000)))
+    (is (= 1 (aget table 0x746)))
+    (is (= 3 (aget table 0x747)))
+    (is (= 3 (aget table 0xa2e)))
+    (is (= 5 (aget table 0xa2f)))
+    (is (= 5 (aget table 0xba2)))
+    (is (= 6 (aget table 0xba3)))
+    (is (= 6 (aget table 0xd16)))
+    (is (= 7 (aget table 0xd17)))
+    (is (= 7 (aget table 0xffe)))
+    (is (= 255 (bit-and (aget table 0xfff) 0xff)))))
+
 (defn- read-as-buffer ^ByteBuffer [file]
   (with-open [in (FileInputStream. (io/file file))]
     (let [ch (.getChannel in)

--- a/test/cljam/io/cram/codecs/rans4x8_test.clj
+++ b/test/cljam/io/cram/codecs/rans4x8_test.clj
@@ -21,7 +21,8 @@
             0x63 0x174
             0x64 0x174
             0x72 0x2e8}
-           (#'rans/read-frequencies0 bb)))
+           (into {} (keep-indexed (fn [i x] (when (pos? x) [i x])))
+                 (#'rans/read-frequencies0 bb))))
     (is (zero? (.remaining bb)))))
 
 (deftest read-frequencies1-test
@@ -62,7 +63,18 @@
             0x63 {0x61 0xfff}
             0x64 {0x61 0xfff}
             0x72 {0x61 0xfff}}
-           (#'rans/read-frequencies1 bb)))
+           (into {}
+                 (keep-indexed
+                  (fn [i arr]
+                    (when-let [m (->> arr
+                                      (into {}
+                                            (keep-indexed
+                                             (fn [j x]
+                                               (when (pos? x)
+                                                 [j x]))))
+                                      not-empty)]
+                      [i m])))
+                 (#'rans/read-frequencies1 bb))))
     (is (zero? (.remaining bb)))))
 
 (defn- read-as-buffer ^ByteBuffer [file]


### PR DESCRIPTION
This PR tweaks the performance of the CRAM reader by the following changes:

- 16c4a00: Use lookup tables to look up rANS symbols, instead of doing binary search
- 2221b5e: Replace maps and vectors used in the rANS decoder with arrays
- 2dc6ae7: Coerce decoded quals to make `=` more efficient 
- 154426f: Replace `+` with `bit-or`

Overall, these changes make the CRAM reader roughly 4x faster than before on my environment:

```clojure
(with-open [r (reader "DRR002191.chr1.sorted.cram" {:reference ".cavia/hg38.2bit"})]
  (time (count (take 1000000 (read-alignments r)))))

;; before change
"Elapsed time: 22955.078416 msecs"

;; after change
"Elapsed time: 5079.17675 msecs"
```

Here are the profiling results before and after the change:

| before change | after change |
| :---: | :---: |
| <a href="https://github.com/chrovis/cljam/assets/27441/810ba84a-e566-43af-b76d-4486ba4d9387"><img width="500" alt="flamegraph before change" src="https://github.com/chrovis/cljam/assets/27441/810ba84a-e566-43af-b76d-4486ba4d9387"></a> | <a href="https://github.com/chrovis/cljam/assets/27441/615326c2-ffcb-47e8-8093-9a63f6436c19"><img width="500" alt="flamegraph after change" src="https://github.com/chrovis/cljam/assets/27441/615326c2-ffcb-47e8-8093-9a63f6436c19"></a> |
