### PR TITLE
Automatic read name generation for CRAM records

### DIFF
--- a/src/cljam/io/cram/reader.clj
+++ b/src/cljam/io/cram/reader.clj
@@ -14,7 +14,7 @@
 
 (declare read-alignments read-alignments-in-region)
 
-(deftype CRAMReader [url channel buffer header refs offset index seq-resolver]
+(deftype CRAMReader [url channel buffer header refs offset index seq-resolver qname-generator]
   Closeable
   (close [_]
     (when seq-resolver
@@ -90,6 +90,7 @@
         ds-decoders (ds/build-data-series-decoders compression-header bs-decoder blocks)
         tag-decoders (ds/build-tag-decoders compression-header bs-decoder blocks)]
     (record/decode-slice-records (seq-resolver-for-slice rdr slice-header blocks)
+                                 (.-qname-generator rdr)
                                  @(.-header rdr)
                                  compression-header
                                  slice-header


### PR DESCRIPTION
This PR enables the CRAM reader to automatically generate read names (QNAMEs) when they are absent in CRAM records.

## Specification

According to section [§10.3](https://github.com/samtools/hts-specs/blob/401e2ec3e8ecf19fa89def74e9c27c1e40df341e/CRAMv3.tex#L1382) of the CRAM specification v3.1:

- If the `RN` field in the compression header's preservation map of a slice is set to `true`, the decoder will decode read names from the `RN` data series
- If the `RN` field is set to `false` and a record has a detached flag (`0x2`) set in the `CF` field, the decoder will also decode its read name from the `RN` data series
- For all other records, the decoder will automatically generate read names
  - Although the CRAM specification does not define a specific method for generating read names, it suggests that names "are typically based on the file name and a numeric ID of the read, utilizing the record counter field from the slice header block"
  - Also, the decoder must generate consistent read names for mate reads

Due to the last condition, read name generation must occur after resolving mate reads.

## Implementation

This PR adds a "qname generator" to the CRAM reader. A qname generator is responsible for generating read names based on the file name and the global record counter. If the `RN` field is set to `false` in the compression header, the CRAM record decoder generates read names by calling the qname generator after mate read resolution.

The format for generated read names is `<file name>:<counter>`, which is aligned with [htslib](https://github.com/samtools/htslib/blob/deeb9f01376ca9416315e4c9f5fe489e6f03e05f/cram/cram_decode.c#L3032-L3043). The `<file name>` will be tweaked from the actual file name to ensure it complies with [the specification for QNAMEs in SAM](https://github.com/samtools/hts-specs/blob/401e2ec3e8ecf19fa89def74e9c27c1e40df341e/SAMv1.tex#L425), meaning it does not contain characters outside the `[!-?A-~]` range and does not exceed 254 characters in length.

## Note

The PR also includes new test code based on the `1001_name.cram` test file from [hts-specs](https://github.com/samtools/hts-specs/tree/401e2ec3e8ecf19fa89def74e9c27c1e40df341e/test/cram/3.0/passed).