### PR TITLE
Support for CRAM beta coding

### DIFF
--- a/src/cljam/io/cram/bit_stream.clj
+++ b/src/cljam/io/cram/bit_stream.clj
@@ -1,0 +1,31 @@
+(ns cljam.io.cram.bit-stream
+  (:import [java.nio ByteBuffer]))
+
+(defprotocol IBitStreamDecoder
+  (read-bits [_ m]))
+
+(definline ^:private right-nbits-of [x nbits]
+  `(bit-and (long ~x) (dec (bit-shift-left 1 (long ~nbits)))))
+
+(deftype BitStreamDecoder
+         [^ByteBuffer bb
+          ^:unsynchronized-mutable ^long buffer
+          ^:unsynchronized-mutable ^long nbits]
+  IBitStreamDecoder
+  (read-bits [_ m]
+    (let [m (long m)]
+      (if (zero? m)
+        m
+        (loop [m m, buf buffer, n nbits, acc 0]
+          (if (<= m n)
+            (do (set! buffer buf)
+                (set! nbits (- n m))
+                (bit-or acc (right-nbits-of (unsigned-bit-shift-right buf nbits) m)))
+            (let [m' (- m n)
+                  acc' (bit-or acc (bit-shift-left (right-nbits-of buf n) m'))]
+              (recur m' (long (.get bb)) 8 acc'))))))))
+
+(defn make-bit-stream-decoder
+  "Creates a new bit stream decoder based on the given byte buffer."
+  [bb]
+  (->BitStreamDecoder bb 0 0))

--- a/test/cljam/io/cram/bit_stream_test.clj
+++ b/test/cljam/io/cram/bit_stream_test.clj
@@ -1,0 +1,12 @@
+(ns cljam.io.cram.bit-stream-test
+  (:require [cljam.io.cram.bit-stream :as bs]
+            [cljam.io.util.byte-buffer :as bb]
+            [clojure.test :refer [deftest is]]))
+
+(deftest read-bits-test
+  (let [bb (bb/make-lsb-byte-buffer (byte-array [0x31 0x41 0x59 0x26]))
+        bs-decoder (bs/make-bit-stream-decoder bb)]
+    (is (= [3 1 4 1 5 9 2 6] (repeatedly 8 #(bs/read-bits bs-decoder 4)))))
+  (let [bb (bb/make-lsb-byte-buffer (byte-array [2r11001110 2r10101110]))
+        bs-decoder (bs/make-bit-stream-decoder bb)]
+    (is (= [6 3 5 2 7] (repeatedly 5 #(bs/read-bits bs-decoder 3))))))


### PR DESCRIPTION
This PR adds support for CRAM beta coding.

For more information on beta coding, see [the CRAM specification](https://github.com/samtools/hts-specs/blob/401e2ec3e8ecf19fa89def74e9c27c1e40df341e/CRAMv3.tex#L2147-L2191).

The core of this PR is the `BitStreamDecoder`, which is a bit stream decoder. The `BitStreamDecoder` manages two states `buffer` (the byte value already read) and `nbits` (indicating how many bits of the `buffer` are still "alive") and prepares for reading the next bit sequence.

The CRAM reader creates a `BitStreamDecoder` based on the core block (the only bit-encoded data block) and shares it between data series that are declared to be beta-encoded (Although the CRAM specification does not explicitly state that a core block may be associated with multiple data series, it seems to be guaranteed by the fact that a test file  (`1101_BETA.cram`) provided by [hts-specs](https://github.com/samtools/hts-specs/tree/master/test/cram/3.0/passed) is encoded as such).
