### PR TITLE
Block compression support for CRAM writer

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -6,6 +6,7 @@
   :dependencies [[org.clojure/core.memoize "1.1.266"]
                  [org.clojure/tools.logging "1.3.0"]
                  [org.apache.commons/commons-compress "1.26.1"]
+                 [org.tukaani/xz "1.9"] ; necessary for CRAM LZMA compression
                  [digest "1.4.10"]
                  [bgzf4j "0.1.2"]
                  [com.climate/claypoole "1.1.4"]

--- a/src/cljam/io/cram.clj
+++ b/src/cljam/io/cram.clj
@@ -58,6 +58,14 @@
         a sequence reader that reads sequences from the reference file.
         This may be omitted only when the CRAM file to be read does not require
         a reference file.
+    - ds-compressor-overrides: A function to override data series compressors.
+        Given a data series keyword, returns a keyword or a set of keywords
+        representing compression method. It may return another function to add
+        more conditions for the block encoding.
+    - tag-compressor-overrides: A function to override tag compressors. Given
+        a tag keyword, returns a keyword or a set of keywords representing
+        compression method. It may return another function to add more conditions
+        for the tag type and/or block encoding.
     - create-index?: If true, creates a .crai index file in the course of CRAM
         file writing.
     - skip-sort-order-check?: When creating a CRAM index for the CRAM file,

--- a/src/cljam/io/cram/core.clj
+++ b/src/cljam/io/cram/core.clj
@@ -77,15 +77,8 @@
 (defn writer
   "Creates a new CRAM writer that writes to a CRAM file f.
 
-  Takes an option map as the second argument. An option map consists of:
-    - reference: A string representing the path to a reference file
-    - create-index?: If true, creates a .crai index file in the course of CRAM
-        file writing.
-    - skip-sort-order-check?: When creating a CRAM index for the CRAM file,
-        the CRAM writer, by default, checks if the header is declared as
-        `SO:coordinate` and raises an error if not.
-        If this option is set to true, the CRAM writer will skip the header check
-        and create an index file regardless of the header declaration."
+  Takes an option map as the second argument. See the docstring for `cljam.io.cram/writer`
+  for more details on the option map."
   ^CRAMWriter [f {:keys [reference create-index?] :as opts}]
   (let [file (cio/file f)
         url (cio/as-url file)

--- a/src/cljam/io/cram/encode/compressor.clj
+++ b/src/cljam/io/cram/encode/compressor.clj
@@ -1,0 +1,96 @@
+(ns cljam.io.cram.encode.compressor
+  (:import [java.io ByteArrayOutputStream OutputStream]
+           [org.apache.commons.compress.compressors.bzip2 BZip2CompressorOutputStream]
+           [org.apache.commons.compress.compressors.gzip GzipCompressorOutputStream]
+           [org.apache.commons.compress.compressors.lzma LZMACompressorOutputStream]
+           [org.apache.commons.io.output CountingOutputStream]))
+
+(defprotocol ICompressor
+  (compressor-output-stream [this])
+  (->compressed-result [this]))
+
+(deftype RawCompressor [^ByteArrayOutputStream out]
+  ICompressor
+  (compressor-output-stream [_] out)
+  (->compressed-result [_]
+    {:compressor :raw, :data (.toByteArray out)}))
+
+(deftype GzipCompressor
+         [^GzipCompressorOutputStream out ^ByteArrayOutputStream baos]
+  ICompressor
+  (compressor-output-stream [_] out)
+  (->compressed-result [_]
+    (.finish out)
+    {:compressor :gzip, :data (.toByteArray baos)}))
+
+(deftype BZip2Compressor
+         [^BZip2CompressorOutputStream out ^ByteArrayOutputStream baos]
+  ICompressor
+  (compressor-output-stream [_] out)
+  (->compressed-result [_]
+    (.finish out)
+    {:compressor :bzip, :data (.toByteArray baos)}))
+
+(deftype LZMACompressor
+         [^LZMACompressorOutputStream out ^ByteArrayOutputStream baos]
+  ICompressor
+  (compressor-output-stream [_] out)
+  (->compressed-result [_]
+    (.finish out)
+    {:compressor :lzma, :data (.toByteArray baos)}))
+
+(defn- compress-with [f ^bytes uncompressed]
+  (let [out (ByteArrayOutputStream.)]
+    (with-open [^OutputStream os (f out)]
+      (.write os uncompressed))
+    (.toByteArray out)))
+
+(deftype SelectiveCompressor [^ByteArrayOutputStream out alternatives]
+  ICompressor
+  (compressor-output-stream [_] out)
+  (->compressed-result [_]
+    (let [uncompressed (.toByteArray out)
+          [k v] (->> alternatives
+                     (into {}
+                           (map (fn [method]
+                                  [method
+                                   (case method
+                                     :raw uncompressed
+                                     :gzip (compress-with #(GzipCompressorOutputStream. %)
+                                                          uncompressed)
+                                     :bzip (compress-with #(BZip2CompressorOutputStream. %)
+                                                          uncompressed)
+                                     :lzma (compress-with #(LZMACompressorOutputStream. %)
+                                                          uncompressed)
+                                     (throw
+                                      (ex-info (str "compression method " method
+                                                    " not supported")
+                                               {:method method})))])))
+                     (apply min-key #(alength ^bytes (val %))))]
+      {:compressor k, :data v})))
+
+(defn compressor
+  "Returns a corresponding compressor implementation depending on the specified
+  compression method(s)."
+  [method-or-methods]
+  (let [baos (ByteArrayOutputStream.)
+        compr (case method-or-methods
+                :raw (->RawCompressor baos)
+                :gzip (->GzipCompressor (GzipCompressorOutputStream. baos) baos)
+                :bzip (->BZip2Compressor (BZip2CompressorOutputStream. baos) baos)
+                :lzma (->LZMACompressor (LZMACompressorOutputStream. baos) baos)
+                :best (->SelectiveCompressor baos #{:raw :gzip :bzip :lzma})
+                (if (set? method-or-methods)
+                  (->SelectiveCompressor baos method-or-methods)
+                  (throw
+                   (ex-info (str "compression method " (pr-str method-or-methods)
+                                 " not supported")
+                            {:method method-or-methods}))))
+        out (CountingOutputStream. (compressor-output-stream compr))]
+    (reify ICompressor
+      (compressor-output-stream [_] out)
+      (->compressed-result [_]
+        (let [raw-size (.getByteCount out)]
+          (if (zero? raw-size)
+            {:compressor :raw, :data nil, :raw-size 0}
+            (assoc (->compressed-result compr) :raw-size raw-size)))))))

--- a/src/cljam/io/cram/encode/context.clj
+++ b/src/cljam/io/cram/encode/context.clj
@@ -25,12 +25,15 @@
   "Finalizes the builders in the container context and returns a new container
   context containing those builders' results. This operation must be done before
   creating a slice context."
-  [{:keys [tag-dict-builder] :as container-ctx}]
-  (let [tag-dict (tag-dict/build-tag-dict tag-dict-builder)
-        tag-encodings (tag-dict/build-tag-encodings tag-dict)]
+  [container-ctx ds-compressor-overrides tag-compressor-overrides]
+  (let [ds-encodings (-> ds/default-data-series-encodings
+                         (ds/apply-ds-compressor-overrides ds-compressor-overrides))
+        tag-dict (tag-dict/build-tag-dict (:tag-dict-builder container-ctx))
+        tag-encodings (-> (tag-dict/build-tag-encodings tag-dict)
+                          (ds/apply-tag-compressor-overrides tag-compressor-overrides))]
     (assoc container-ctx
+           :ds-encodings ds-encodings
            :tag-dict tag-dict
-           :ds-encodings ds/default-data-series-encodings
            :tag-encodings tag-encodings)))
 
 (defn make-slice-context

--- a/test/cljam/io/cram/encode/record_test.clj
+++ b/test/cljam/io/cram/encode/record_test.clj
@@ -72,7 +72,9 @@
 (defn- preprocess-slice-records [cram-header records]
   (let [container-ctx (context/make-container-context cram-header {} test-seq-resolver)]
     (record/preprocess-slice-records container-ctx records)
-    (context/finalize-container-context container-ctx)))
+    (context/finalize-container-context container-ctx
+                                        (constantly :raw)
+                                        (constantly (constantly (constantly {:external :raw}))))))
 
 (deftest preprocess-slice-records-test
   (let [cram-header {:SQ [{:SN "ref"}]}
@@ -136,13 +138,16 @@
            (:tag-dict container-ctx)))
     (is (= {:MD {\Z {:codec :byte-array-len
                      :len-encoding {:codec :external
-                                    :content-id (#'tag-dict/tag-id {:tag :MD, :type \Z})}
+                                    :content-id (#'tag-dict/tag-id {:tag :MD, :type \Z})
+                                    :compressor :raw}
                      :val-encoding {:codec :external
-                                    :content-id (#'tag-dict/tag-id {:tag :MD, :type \Z})}}}
+                                    :content-id (#'tag-dict/tag-id {:tag :MD, :type \Z})
+                                    :compressor :raw}}}
             :NM {\c {:codec :byte-array-len
                      :len-encoding {:codec :huffman, :alphabet [1], :bit-len [0]}
                      :val-encoding {:codec :external
-                                    :content-id (#'tag-dict/tag-id {:tag :NM, :type \c})}}}}
+                                    :content-id (#'tag-dict/tag-id {:tag :NM, :type \c})
+                                    :compressor :raw}}}}
            (:tag-encodings container-ctx)))))
 
 (deftest encode-slice-records-test


### PR DESCRIPTION
This PR adds support for block compression to the CRAM writer.

The primary features are as follows:

- Blocks are compressed using the compression method specified for each data series and tag encoding
  - The currently available compression methods are `:raw`, `:gzip`, `:bzip`, `:lzma`, and `:best`, which automatically selects the compression method with the highest compression rate
- The default compression methods are:
  - data series: `:gzip`, although the default compression method for each data series may be tuned in the future
  - tags: `:best`
- The compression methods for data series and tags can be overridden using the `ds-compressor-overrides` and `tag-compressor-overrides` options, respectively (explained below)

Block compression is applied along with record encoding rather than after all the records have been fully encoded.

## Compressor overrides

To override the compression method for data series and tags, specify the `ds-compressor-overrides` and `tag-compressor-overrides` options to the CRAM writer:

```clojure
(require '[cljam.io.cram :as cram])

(def writer
  (cram/writer "path/to/cram/file"
               { ...
                :ds-compressor-overrides <ds compressor overrides>
                :tag-compressor-overrides <tag compressor overrides>
                ... }))
```

The full specification of the `ds-compressor-overrides`/`tag-compressor-overrides` is somewhat intricate. The description here does not aim to be exhaustive but rather to provide the big picture and offer some practical examples of usage.

### `ds-compressor-overrides`

`ds-compressor-overrides` is a function that takes a keyword representing a data series and returns a keyword representing a compression method. Here are some examples:

- To compress only the `BF` and `CF` data series with `:bzip` and leave the others with their default methods
  ```clojure
  :ds-compressor-overrides (fn [ds] (when (#{:BF :CF} ds) :bzip))
  ```
- Since Clojure maps also behave like functions, the same thing can be written using a map
  ```clojure
  :ds-compressor-overrides {:BF :bzip, :CF :bzip}
  ```
- To change the compression method for all data series to `:bzip`
  ```clojure
  :ds-compressor-overrides (constantly :bzip)
  ```

The function can also return a set of compression method keywords. In this case, the compression method with the highest compression rate will be selected from the specified methods:
  
- To compress the `BF` series with both `:bzip` and `:lzma`, and choose the more efficient one
  ```clojure
  :ds-compressor-overrides {:BF #{:bzip :lzma}}
  ```

Additionally, the function can return another function to further condition the compression method based on the codec:

- To compress all the blocks encoded with the `:external` codec using the `:bzip` compression method:
  ```clojure
  :ds-compressor-overrides (constantly {:external :bzip})
  ```
- To compress all the blocks allocated for the `:len-encoding` of the `:byte-array-len` codec using `:lzma` and the blocks for the `:val-encoding` using `:bzip`
  ```clojure
  :ds-compressor-overrides (constantly {:byte-array-len/len :lzma, :byte-array-len/val :bzip})
  ```

For more detailed usage, see [the test code for `ds-compressor-overrides`](https://github.com/chrovis/cljam/blob/3643da81552ea2e7540374786c94e5e32d92eaab/test/cljam/io/cram/data_series_test.clj#L504-L606).

### `tag-compressor-overrides`

`tag-compressor-overrides` works similarly to `ds-compressor-overrides`, but can also add conditions based on tag types by returning a function:

- To change the compression method for all tags to `:bzip`
  ```clojure
  :tag-compressor-overrides (constantly :bzip)
  ```
- To compress the `XA:c` tag with `:gzip` and the `XA:i` tag with `:bzip`
  ```clojure
  :tag-compressor-overrides {:XA {\c :gzip, \i :bzip}}
  ```
- To compress all the blocks allocated for the `:val-encoding` of all the tags of type `Z` using `:bzip`
  ```clojure
  :tag-compressor-overrides (constantly {\Z {:byte-array-len/val :bzip}})
  ```

For more detailed usage, see [the test code for `tag-compressor-overrides`](https://github.com/chrovis/cljam/blob/3643da81552ea2e7540374786c94e5e32d92eaab/test/cljam/io/cram/data_series_test.clj#L940-L998).