### PR TITLE
Support reference embedding for CRAM writer

### DIFF
--- a/src/cljam/io/cram.clj
+++ b/src/cljam/io/cram.clj
@@ -72,13 +72,16 @@
         a tag keyword, returns a keyword or a set of keywords representing
         compression method. It may return another function to add more conditions
         for the tag type and/or block encoding.
-    - create-index?: If true, creates a .crai index file in the course of CRAM
-        file writing.
-    - skip-sort-order-check?: When creating a CRAM index for the CRAM file,
-        the CRAM writer, by default, checks if the header is declared as
-        `SO:coordinate` and raises an error if not.
-        If this option is set to true, the CRAM writer will skip the header check
-        and create an index file regardless of the header declaration."
+    - create-index?: If set to true, the CRAM writer creates a .crai index file
+        in the course of CRAM file writing.
+    - embed-reference?: If set to true, the CRAM writer embeds the reference
+        sequences into the resulting CRAM file, allowing it to be read without
+        needing an external reference file.
+    - skip-sort-order-check?: When creating a CRAM index or embedding reference
+        sequences into a CRAM file, the CRAM writer, by default, checks if
+        the header specifies `SO:coordinate` and raises an error if it does not.
+        If this option is set to true, the CRAM writer will skip this header
+        check and proceed regardless of the header's sort order declaration."
   (^CRAMWriter [f] (writer f {}))
   (^CRAMWriter [f option] (cram/writer f option)))
 

--- a/src/cljam/io/cram/data_series.clj
+++ b/src/cljam/io/cram/data_series.clj
@@ -147,42 +147,46 @@
 
 (def ^{:doc "Default encodings for all the data series"}
   default-data-series-encodings
-  {:BF {:content-id  1, :codec :external, :compressor :gzip}
-   :CF {:content-id  2, :codec :external, :compressor :gzip}
-   :RI {:content-id  3, :codec :external, :compressor :gzip}
-   :RL {:content-id  4, :codec :external, :compressor :gzip}
-   :AP {:content-id  5, :codec :external, :compressor :gzip}
-   :RG {:content-id  6, :codec :external, :compressor :gzip}
-   :RN {:content-id  7, :codec :byte-array-stop, :stop-byte (int \tab), :compressor :gzip}
-   :MF {:content-id  8, :codec :external, :compressor :gzip}
-   :NS {:content-id  9, :codec :external, :compressor :gzip}
-   :NP {:content-id 10, :codec :external, :compressor :gzip}
-   :TS {:content-id 11, :codec :external, :compressor :gzip}
-   :NF {:content-id 12, :codec :external, :compressor :gzip}
-   :TL {:content-id 13, :codec :external, :compressor :gzip}
-   :FN {:content-id 14, :codec :external, :compressor :gzip}
-   :FC {:content-id 15, :codec :external, :compressor :gzip}
-   :FP {:content-id 16, :codec :external, :compressor :gzip}
-   :DL {:content-id 17, :codec :external, :compressor :gzip}
+  {;; :embedded-ref is a pseudo data series and won't be used for the real encoding
+   ;; except for the value for :compressor, which is used when compressing embedded
+   ;; reference blocks
+   :embedded-ref {:content-id 1, :codec :external, :compressor :gzip}
+   :BF {:content-id  2, :codec :external, :compressor :gzip}
+   :CF {:content-id  3, :codec :external, :compressor :gzip}
+   :RI {:content-id  4, :codec :external, :compressor :gzip}
+   :RL {:content-id  5, :codec :external, :compressor :gzip}
+   :AP {:content-id  6, :codec :external, :compressor :gzip}
+   :RG {:content-id  7, :codec :external, :compressor :gzip}
+   :RN {:content-id  8, :codec :byte-array-stop, :stop-byte (int \tab), :compressor :gzip}
+   :MF {:content-id  9, :codec :external, :compressor :gzip}
+   :NS {:content-id 10, :codec :external, :compressor :gzip}
+   :NP {:content-id 11, :codec :external, :compressor :gzip}
+   :TS {:content-id 12, :codec :external, :compressor :gzip}
+   :NF {:content-id 13, :codec :external, :compressor :gzip}
+   :TL {:content-id 14, :codec :external, :compressor :gzip}
+   :FN {:content-id 15, :codec :external, :compressor :gzip}
+   :FC {:content-id 16, :codec :external, :compressor :gzip}
+   :FP {:content-id 17, :codec :external, :compressor :gzip}
+   :DL {:content-id 18, :codec :external, :compressor :gzip}
    :BB {:codec :byte-array-len
-        :len-encoding {:codec :external, :content-id 18, :compressor :gzip}
-        :val-encoding {:codec :external, :content-id 19, :compressor :gzip}}
+        :len-encoding {:codec :external, :content-id 19, :compressor :gzip}
+        :val-encoding {:codec :external, :content-id 20, :compressor :gzip}}
    :QQ {:codec :byte-array-len
-        :len-encoding {:codec :external, :content-id 20, :compressor :gzip}
-        :val-encoding {:codec :external, :content-id 21, :compressor :gzip}}
-   :BS {:content-id 22, :codec :external, :compressor :gzip}
+        :len-encoding {:codec :external, :content-id 21, :compressor :gzip}
+        :val-encoding {:codec :external, :content-id 22, :compressor :gzip}}
+   :BS {:content-id 23, :codec :external, :compressor :gzip}
    :IN {:codec :byte-array-len
-        :len-encoding {:codec :external, :content-id 23, :compressor :gzip}
-        :val-encoding {:codec :external, :content-id 24, :compressor :gzip}}
-   :RS {:content-id 25, :codec :external, :compressor :gzip}
-   :PD {:content-id 26, :codec :external, :compressor :gzip}
-   :HC {:content-id 27, :codec :external, :compressor :gzip}
+        :len-encoding {:codec :external, :content-id 24, :compressor :gzip}
+        :val-encoding {:codec :external, :content-id 25, :compressor :gzip}}
+   :RS {:content-id 26, :codec :external, :compressor :gzip}
+   :PD {:content-id 27, :codec :external, :compressor :gzip}
+   :HC {:content-id 28, :codec :external, :compressor :gzip}
    :SC {:codec :byte-array-len
-        :len-encoding {:codec :external, :content-id 28, :compressor :gzip}
-        :val-encoding {:codec :external, :content-id 29, :compressor :gzip}}
-   :MQ {:content-id 30, :codec :external, :compressor :gzip}
-   :BA {:content-id 31, :codec :external, :compressor :gzip}
-   :QS {:content-id 32, :codec :external, :compressor :gzip}})
+        :len-encoding {:codec :external, :content-id 29, :compressor :gzip}
+        :val-encoding {:codec :external, :content-id 30, :compressor :gzip}}
+   :MQ {:content-id 31, :codec :external, :compressor :gzip}
+   :BA {:content-id 32, :codec :external, :compressor :gzip}
+   :QS {:content-id 33, :codec :external, :compressor :gzip}})
 
 (defn- build-codec-encoder
   [{:keys [codec content-id compressor] :as params} data-type content-id->state]

--- a/src/cljam/io/cram/encode/structure.clj
+++ b/src/cljam/io/cram/encode/structure.clj
@@ -210,10 +210,13 @@
 (defn encode-compression-header-block
   "Encodes a compression header block to the given OutputStream."
   [out preservation-map subst-mat tag-dict ds-encodings tag-encodings]
-  (let [bs (with-out-byte-array
+  ;; ensure that ds-encodings does not contain the encoding for the :embedded-ref
+  ;; pseudo data series
+  (let [ds-encodings' (dissoc ds-encodings :embedded-ref)
+        bs (with-out-byte-array
              (fn [out']
                (encode-preservation-map out' preservation-map subst-mat tag-dict)
-               (encode-data-series-encodings out' ds-encodings)
+               (encode-data-series-encodings out' ds-encodings')
                (encode-tag-encoding-map out' tag-encodings)))]
     (encode-block out :raw 1 0 (alength bs) bs)))
 

--- a/test/cljam/io/cram/encode/record_test.clj
+++ b/test/cljam/io/cram/encode/record_test.clj
@@ -71,11 +71,11 @@
      4]))
 
 (defn- preprocess-slice-records [cram-header records]
-  (let [container-ctx (context/make-container-context cram-header test-seq-resolver)
+  (let [opts {:ds-compressor-overrides (constantly :raw)
+              :tag-compressor-overrides (constantly (constantly (constantly {:external :raw})))}
+        container-ctx (context/make-container-context cram-header test-seq-resolver opts)
         stats (record/preprocess-slice-records container-ctx records)]
-    (context/finalize-container-context container-ctx [stats]
-                                        (constantly :raw)
-                                        (constantly (constantly (constantly {:external :raw}))))))
+    (context/finalize-container-context container-ctx [stats])))
 
 (deftest preprocess-slice-records-test
   (let [cram-header {:SQ [{:SN "ref"}]}
@@ -192,129 +192,129 @@
              (into {} (:alignment-stats slice-ctx))))
 
       (is (= 1 (count (get ds-res :BF))))
-      (is (= 1 (get-in ds-res [:BF 0 :content-id])))
+      (is (= 2 (get-in ds-res [:BF 0 :content-id])))
       (is (= [0x43 0x43 0x80 0x91 0x80 0x93 0x41]
              (map #(bit-and % 0xff) (get-in ds-res [:BF 0 :data]))))
 
       (is (= 1 (count (get ds-res :CF))))
-      (is (= 2 (get-in ds-res [:CF 0 :content-id])))
+      (is (= 3 (get-in ds-res [:CF 0 :content-id])))
       (is (= [3 3 3 3 3] (seq (get-in ds-res [:CF 0 :data]))))
 
       (is (= 1 (count (get ds-res :RI))))
-      (is (= 3 (get-in ds-res [:RI 0 :content-id])))
+      (is (= 4 (get-in ds-res [:RI 0 :content-id])))
       (is (= [0 0 0 0 0] (seq (get-in ds-res [:RI 0 :data]))))
 
       (is (= 1 (count (get ds-res :RL))))
-      (is (= 4 (get-in ds-res [:RL 0 :content-id])))
+      (is (= 5 (get-in ds-res [:RL 0 :content-id])))
       (is (= [5 5 5 5 5] (seq (get-in ds-res [:RL 0 :data]))))
 
       (is (= 1 (count (get ds-res :AP))))
-      (is (= 5 (get-in ds-res [:AP 0 :content-id])))
+      (is (= 6 (get-in ds-res [:AP 0 :content-id])))
       (is (= [0 4 5 5 5] (seq (get-in ds-res [:AP 0 :data]))))
 
       (is (= 1 (count (get ds-res :RG))))
-      (is (= 6 (get-in ds-res [:RG 0 :content-id])))
+      (is (= 7 (get-in ds-res [:RG 0 :content-id])))
       (is (= [0 0 1 1 0xff 0xff 0xff 0xff 0x0f]
              (map #(bit-and % 0xff) (get-in ds-res [:RG 0 :data]))))
 
       (is (= 1 (count (get ds-res :RN))))
-      (is (= 7 (get-in ds-res [:RN 0 :content-id])))
+      (is (= 8 (get-in ds-res [:RN 0 :content-id])))
       (is (= "q001\tq002\tq003\tq004\tq005\t" (String. ^bytes (get-in ds-res [:RN 0 :data]))))
 
       (is (= 1 (count (get ds-res :MF))))
-      (is (= 8 (get-in ds-res [:MF 0 :content-id])))
+      (is (= 9 (get-in ds-res [:MF 0 :content-id])))
       (is (= [1 1 1 0 2] (seq (get-in ds-res [:MF 0 :data]))))
 
       (is (= 1 (count (get ds-res :NS))))
-      (is (= 9 (get-in ds-res [:NS 0 :content-id])))
+      (is (= 10 (get-in ds-res [:NS 0 :content-id])))
       (is (= [0 0 1 0 0xff 0xff 0xff 0xff 0x0f]
              (map #(bit-and % 0xff) (get-in ds-res [:NS 0 :data]))))
 
       (is (= 1 (count (get ds-res :NP))))
-      (is (= 10 (get-in ds-res [:NP 0 :content-id])))
+      (is (= 11 (get-in ds-res [:NP 0 :content-id])))
       (is (= [0x80 0x97 0x0f 0x64 0x05 0x00]
              (map #(bit-and % 0xff) (get-in ds-res [:NP 0 :data]))))
 
       (is (= 1 (count (get ds-res :TS))))
-      (is (= 11 (get-in ds-res [:TS 0 :content-id])))
+      (is (= 12 (get-in ds-res [:TS 0 :content-id])))
       (is (= [0x80 0x96 0x0f 0x00 0xff 0xff 0xff 0xff 0x01 0x00]
              (map #(bit-and % 0xff) (get-in ds-res [:TS 0 :data]))))
 
       (is (= 1 (count (get ds-res :NF))))
-      (is (= 12 (get-in ds-res [:NF 0 :content-id])))
+      (is (= 13 (get-in ds-res [:NF 0 :content-id])))
       (is (zero? (count (get-in ds-res [:NF 0 :data]))))
 
       (is (= 1 (count (get ds-res :TL))))
-      (is (= 13 (get-in ds-res [:TL 0 :content-id])))
+      (is (= 14 (get-in ds-res [:TL 0 :content-id])))
       (is (= [0 0 0 0 1] (seq (get-in ds-res [:TL 0 :data]))))
 
       (is (= 1 (count (get ds-res :FN))))
-      (is (= 14 (get-in ds-res [:FN 0 :content-id])))
+      (is (= 15 (get-in ds-res [:FN 0 :content-id])))
       (is (= [1 1 0 2 0] (seq (get-in ds-res [:FN 0 :data]))))
 
       (is (= 1 (count (get ds-res :FC))))
-      (is (= 15 (get-in ds-res [:FC 0 :content-id])))
+      (is (= 16 (get-in ds-res [:FC 0 :content-id])))
       (is (= [(int \X) (int \S) (int \I) (int \D)]
              (seq (get-in ds-res [:FC 0 :data]))))
 
       (is (= 1 (count (get ds-res :FP))))
-      (is (= 16 (get-in ds-res [:FP 0 :content-id])))
+      (is (= 17 (get-in ds-res [:FP 0 :content-id])))
       (is (= [3 1 2 2] (seq (get-in ds-res [:FP 0 :data]))))
 
       (is (= 1 (count (get ds-res :DL))))
-      (is (= 17 (get-in ds-res [:DL 0 :content-id])))
+      (is (= 18 (get-in ds-res [:DL 0 :content-id])))
       (is (= [1] (seq (get-in ds-res [:DL 0 :data]))))
 
       (is (= 2 (count (get ds-res :BB))))
-      (is (= 18 (get-in ds-res [:BB 0 :content-id])))
+      (is (= 19 (get-in ds-res [:BB 0 :content-id])))
       (is (zero? (count (get-in ds-res [:BB 0 :data]))))
-      (is (= 19 (get-in ds-res [:BB 1 :content-id])))
+      (is (= 20 (get-in ds-res [:BB 1 :content-id])))
       (is (zero? (count (get-in ds-res [:BB 1 :data]))))
 
       (is (= 2 (count (get ds-res :QQ))))
-      (is (= 20 (get-in ds-res [:QQ 0 :content-id])))
+      (is (= 21 (get-in ds-res [:QQ 0 :content-id])))
       (is (zero? (count (get-in ds-res [:QQ 0 :data]))))
-      (is (= 21 (get-in ds-res [:QQ 1 :content-id])))
+      (is (= 22 (get-in ds-res [:QQ 1 :content-id])))
       (is (zero? (count (get-in ds-res [:QQ 1 :data]))))
 
       (is (= 1 (count (get ds-res :BS))))
-      (is (= 22 (get-in ds-res [:BS 0 :content-id])))
+      (is (= 23 (get-in ds-res [:BS 0 :content-id])))
       (is (= [0] (seq (get-in ds-res [:BS 0 :data]))))
 
       (is (= 2 (count (get ds-res :IN))))
-      (is (= 23 (get-in ds-res [:IN 0 :content-id])))
+      (is (= 24 (get-in ds-res [:IN 0 :content-id])))
       (is (= [1] (seq (get-in ds-res [:IN 0 :data]))))
-      (is (= 24 (get-in ds-res [:IN 1 :content-id])))
+      (is (= 25 (get-in ds-res [:IN 1 :content-id])))
       (is (= "A" (String. ^bytes (get-in ds-res [:IN 1 :data]))))
 
       (is (= 1 (count (get ds-res :RS))))
-      (is (= 25 (get-in ds-res [:RS 0 :content-id])))
+      (is (= 26 (get-in ds-res [:RS 0 :content-id])))
       (is (zero? (count (get-in ds-res [:RS 0 :data]))))
 
       (is (= 1 (count (get ds-res :PD))))
-      (is (= 26 (get-in ds-res [:PD 0 :content-id])))
+      (is (= 27 (get-in ds-res [:PD 0 :content-id])))
       (is (zero? (count (get-in ds-res [:PD 0 :data]))))
 
       (is (= 1 (count (get ds-res :HC))))
-      (is (= 27 (get-in ds-res [:HC 0 :content-id])))
+      (is (= 28 (get-in ds-res [:HC 0 :content-id])))
       (is (zero? (count (get-in ds-res [:HC 0 :data]))))
 
       (is (= 2 (count (get ds-res :SC))))
-      (is (= 28 (get-in ds-res [:SC 0 :content-id])))
+      (is (= 29 (get-in ds-res [:SC 0 :content-id])))
       (is (= [2] (seq (get-in ds-res [:SC 0 :data]))))
-      (is (= 29 (get-in ds-res [:SC 1 :content-id])))
+      (is (= 30 (get-in ds-res [:SC 1 :content-id])))
       (is (= "CC" (String. ^bytes (get-in ds-res [:SC 1 :data]))))
 
       (is (= 1 (count (get ds-res :MQ))))
-      (is (= 30 (get-in ds-res [:MQ 0 :content-id])))
+      (is (= 31 (get-in ds-res [:MQ 0 :content-id])))
       (is (= [0 15 60 15 0] (seq (get-in ds-res [:MQ 0 :data]))))
 
       (is (= 1 (count (get ds-res :BA))))
-      (is (= 31 (get-in ds-res [:BA 0 :content-id])))
+      (is (= 32 (get-in ds-res [:BA 0 :content-id])))
       (is (zero? (count (get-in ds-res [:BA 0 :data]))))
 
       (is (= 1 (count (get ds-res :QS))))
-      (is (= 32 (get-in ds-res [:QS 0 :content-id])))
+      (is (= 33 (get-in ds-res [:QS 0 :content-id])))
       (is (= "HFHHH##AACCCCFFEBBFFAEEEE"
              (->> (get-in ds-res [:QS 0 :data])
                   (map #(+ (long %) 33))
@@ -363,16 +363,16 @@
              (into {} (:alignment-stats slice-ctx))))
 
       (is (= 1 (count (get ds-res :BF))))
-      (is (= 1 (get-in ds-res [:BF 0 :content-id])))
+      (is (= 2 (get-in ds-res [:BF 0 :content-id])))
       (is (= [0x45 0x80 0x85 0x45 0x80 0x85 0x45]
              (map #(bit-and % 0xff) (get-in ds-res [:BF 0 :data]))))
 
       (is (= 1 (count (get ds-res :CF))))
-      (is (= 2 (get-in ds-res [:CF 0 :content-id])))
+      (is (= 3 (get-in ds-res [:CF 0 :content-id])))
       (is (= [3 3 3 3 3] (seq (get-in ds-res [:CF 0 :data]))))
 
       (is (= 1 (count (get ds-res :RI))))
-      (is (= 3 (get-in ds-res [:RI 0 :content-id])))
+      (is (= 4 (get-in ds-res [:RI 0 :content-id])))
       (is (= [0xff 0xff 0xff 0xff 0x0f
               0xff 0xff 0xff 0xff 0x0f
               0xff 0xff 0xff 0xff 0x0f
@@ -381,15 +381,15 @@
              (map #(bit-and % 0xff) (get-in ds-res [:RI 0 :data]))))
 
       (is (= 1 (count (get ds-res :RL))))
-      (is (= 4 (get-in ds-res [:RL 0 :content-id])))
+      (is (= 5 (get-in ds-res [:RL 0 :content-id])))
       (is (= [5 5 5 5 5] (seq (get-in ds-res [:RL 0 :data]))))
 
       (is (= 1 (count (get ds-res :AP))))
-      (is (= 5 (get-in ds-res [:AP 0 :content-id])))
+      (is (= 6 (get-in ds-res [:AP 0 :content-id])))
       (is (= [0 0 0 0 0] (seq (get-in ds-res [:AP 0 :data]))))
 
       (is (= 1 (count (get ds-res :RG))))
-      (is (= 6 (get-in ds-res [:RG 0 :content-id])))
+      (is (= 7 (get-in ds-res [:RG 0 :content-id])))
       (is (= [0xff 0xff 0xff 0xff 0x0f
               0xff 0xff 0xff 0xff 0x0f
               0xff 0xff 0xff 0xff 0x0f
@@ -398,15 +398,15 @@
              (map #(bit-and % 0xff) (get-in ds-res [:RG 0 :data]))))
 
       (is (= 1 (count (get ds-res :RN))))
-      (is (= 7 (get-in ds-res [:RN 0 :content-id])))
+      (is (= 8 (get-in ds-res [:RN 0 :content-id])))
       (is (= "q001\tq001\tq002\tq002\tq003\t" (String. ^bytes (get-in ds-res [:RN 0 :data]))))
 
       (is (= 1 (count (get ds-res :MF))))
-      (is (= 8 (get-in ds-res [:MF 0 :content-id])))
+      (is (= 9 (get-in ds-res [:MF 0 :content-id])))
       (is (= [2 2 2 2 2] (seq (get-in ds-res [:MF 0 :data]))))
 
       (is (= 1 (count (get ds-res :NS))))
-      (is (= 9 (get-in ds-res [:NS 0 :content-id])))
+      (is (= 10 (get-in ds-res [:NS 0 :content-id])))
       (is (= [0xff 0xff 0xff 0xff 0x0f
               0xff 0xff 0xff 0xff 0x0f
               0xff 0xff 0xff 0xff 0x0f
@@ -415,88 +415,88 @@
              (map #(bit-and % 0xff) (get-in ds-res [:NS 0 :data]))))
 
       (is (= 1 (count (get ds-res :NP))))
-      (is (= 10 (get-in ds-res [:NP 0 :content-id])))
+      (is (= 11 (get-in ds-res [:NP 0 :content-id])))
       (is (= [0 0 0 0 0] (seq (get-in ds-res [:NP 0 :data]))))
 
       (is (= 1 (count (get ds-res :TS))))
-      (is (= 11 (get-in ds-res [:TS 0 :content-id])))
+      (is (= 12 (get-in ds-res [:TS 0 :content-id])))
       (is (= [0 0 0 0 0] (seq (get-in ds-res [:TS 0 :data]))))
 
       (is (= 1 (count (get ds-res :NF))))
-      (is (= 12 (get-in ds-res [:NF 0 :content-id])))
+      (is (= 13 (get-in ds-res [:NF 0 :content-id])))
       (is (zero? (count (get-in ds-res [:NF 0 :data]))))
 
       (is (= 1 (count (get ds-res :TL))))
-      (is (= 13 (get-in ds-res [:TL 0 :content-id])))
+      (is (= 14 (get-in ds-res [:TL 0 :content-id])))
       (is (= [0 0 0 0 0] (seq (get-in ds-res [:TL 0 :data]))))
 
       (is (= 1 (count (get ds-res :FN))))
-      (is (= 14 (get-in ds-res [:FN 0 :content-id])))
+      (is (= 15 (get-in ds-res [:FN 0 :content-id])))
       (is (zero? (count (get-in ds-res [:FN 0 :data]))))
 
       (is (= 1 (count (get ds-res :FC))))
-      (is (= 15 (get-in ds-res [:FC 0 :content-id])))
+      (is (= 16 (get-in ds-res [:FC 0 :content-id])))
       (is (zero? (count (get-in ds-res [:FC 0 :data]))))
 
       (is (= 1 (count (get ds-res :FP))))
-      (is (= 16 (get-in ds-res [:FP 0 :content-id])))
+      (is (= 17 (get-in ds-res [:FP 0 :content-id])))
       (is (zero? (count (get-in ds-res [:FP 0 :data]))))
 
       (is (= 1 (count (get ds-res :DL))))
-      (is (= 17 (get-in ds-res [:DL 0 :content-id])))
+      (is (= 18 (get-in ds-res [:DL 0 :content-id])))
       (is (zero? (count (get-in ds-res [:DL 0 :data]))))
 
       (is (= 2 (count (get ds-res :BB))))
-      (is (= 18 (get-in ds-res [:BB 0 :content-id])))
+      (is (= 19 (get-in ds-res [:BB 0 :content-id])))
       (is (zero? (count (get-in ds-res [:BB 0 :data]))))
-      (is (= 19 (get-in ds-res [:BB 1 :content-id])))
+      (is (= 20 (get-in ds-res [:BB 1 :content-id])))
       (is (zero? (count (get-in ds-res [:BB 1 :data]))))
 
       (is (= 2 (count (get ds-res :QQ))))
-      (is (= 20 (get-in ds-res [:QQ 0 :content-id])))
+      (is (= 21 (get-in ds-res [:QQ 0 :content-id])))
       (is (zero? (count (get-in ds-res [:QQ 0 :data]))))
-      (is (= 21 (get-in ds-res [:QQ 1 :content-id])))
+      (is (= 22 (get-in ds-res [:QQ 1 :content-id])))
       (is (zero? (count (get-in ds-res [:QQ 1 :data]))))
 
       (is (= 1 (count (get ds-res :BS))))
-      (is (= 22 (get-in ds-res [:BS 0 :content-id])))
+      (is (= 23 (get-in ds-res [:BS 0 :content-id])))
       (is (zero? (count (get-in ds-res [:BS 0 :data]))))
 
       (is (= 2 (count (get ds-res :IN))))
-      (is (= 23 (get-in ds-res [:IN 0 :content-id])))
+      (is (= 24 (get-in ds-res [:IN 0 :content-id])))
       (is (zero? (count (get-in ds-res [:IN 0 :data]))))
-      (is (= 24 (get-in ds-res [:IN 1 :content-id])))
+      (is (= 25 (get-in ds-res [:IN 1 :content-id])))
       (is (zero? (count (get-in ds-res [:IN 1 :data]))))
 
       (is (= 1 (count (get ds-res :RS))))
-      (is (= 25 (get-in ds-res [:RS 0 :content-id])))
+      (is (= 26 (get-in ds-res [:RS 0 :content-id])))
       (is (zero? (count (get-in ds-res [:RS 0 :data]))))
 
       (is (= 1 (count (get ds-res :PD))))
-      (is (= 26 (get-in ds-res [:PD 0 :content-id])))
+      (is (= 27 (get-in ds-res [:PD 0 :content-id])))
       (is (zero? (count (get-in ds-res [:PD 0 :data]))))
 
       (is (= 1 (count (get ds-res :HC))))
-      (is (= 27 (get-in ds-res [:HC 0 :content-id])))
+      (is (= 28 (get-in ds-res [:HC 0 :content-id])))
       (is (zero? (count (get-in ds-res [:HC 0 :data]))))
 
       (is (= 2 (count (get ds-res :SC))))
-      (is (= 28 (get-in ds-res [:SC 0 :content-id])))
+      (is (= 29 (get-in ds-res [:SC 0 :content-id])))
       (is (zero? (count (get-in ds-res [:SC 0 :data]))))
-      (is (= 29 (get-in ds-res [:SC 1 :content-id])))
+      (is (= 30 (get-in ds-res [:SC 1 :content-id])))
       (is (zero? (count (get-in ds-res [:SC 1 :data]))))
 
       (is (= 1 (count (get ds-res :MQ))))
-      (is (= 30 (get-in ds-res [:MQ 0 :content-id])))
+      (is (= 31 (get-in ds-res [:MQ 0 :content-id])))
       (is (zero? (count (get-in ds-res [:MQ 0 :data]))))
 
       (is (= 1 (count (get ds-res :BA))))
-      (is (= 31 (get-in ds-res [:BA 0 :content-id])))
+      (is (= 32 (get-in ds-res [:BA 0 :content-id])))
       (is (= "AATCCATTGTTGGTATCTTGGCACA"
              (String. ^bytes (get-in ds-res [:BA 0 :data]))))
 
       (is (= 1 (count (get ds-res :QS))))
-      (is (= 32 (get-in ds-res [:QS 0 :content-id])))
+      (is (= 33 (get-in ds-res [:QS 0 :content-id])))
       (is (= "CCFFFBDFADADDHFDDDFDBCCFD"
              (->> (get-in ds-res [:QS 0 :data])
                   (map #(+ (long %) 33))


### PR DESCRIPTION
This PR adds support for reference embedding during CRAM file writing.

## Specification

The CRAM specification for reference embedding is as outlined in the PR for [reference embedding support in the CRAM reader](https://github.com/chrovis/cljam/pull/307#issue-2258310138).

## Usage

This PR adds a new option `:embed-reference?` to enable reference embedding when writing CRAM files. By default, reference embedding is disabled. To enable it:

```clojure
(require '[cljam.io.cram :as cram])

(with-open [w (cram/writer "path/to/cram/file" { ..., :embed-reference? true, ... })]
   ... )
```

Reference embedding is only applicable when writing a CRAM file with the `SO:coordinate` declaration in the CRAM header. If the CRAM header lacks this declaration, an error will be raised. Like [CRAM index generation](https://github.com/chrovis/cljam/pull/317), this `SO:coordinate` check can be skipped by specifying `:skip-sort-order-check? true`:

```clojure
(with-open [w (cram/writer "path/to/cram/file"
                           { ...
                            :embed-reference true
                            :skip-sort-order-check? true
                            ... })]
  ... )
```

Blocks allocated for reference embedding are compressed using `:gzip` by default. The compression method can be overridden via `:ds-compressor-overrides`, as is done for regular data series, by specifying the pseudo data series `:embedded-ref`:

```clojure
(with-open [w (cram/writer "path/to/cram/file"
                           { ...
                            :embed-reference true
                            :ds-compressor-overrides {:embedded-ref :raw}
                            ... })]
  ... )
```

## Implementation

The CRAM writer reserves content ID `1` for blocks used for reference embedding (referred to as "embedded reference blocks"). When `:embed-reference? true` is specified, the CRAM writer writes the reference sequence covered by each slice into the embedded reference block and sets the `:embedded-reference` field in the slice header to content ID `1`. If `:embed-reference? true` is not specified, the blocks associated with content ID `1` are not used.

When reference embedding is enabled, the `RR` flag in the compression header (indicating whether a reference file is required for reading) is always set to `false`.

Additionally, the CRAM writer ensures that no multiple reference (multi-ref) slices are created when reference embedding is enabled. This is because reference embedding is incompatible with multi-ref slices. Allowing multi-ref slices would negate the benefits of reference embedding by partly requiring a reference file when reading the written CRAM file, which would be inconvenient and confusing.
