### PR TITLE
Add a function to read mate alignments

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -5,7 +5,7 @@
             :url "https://www.apache.org/licenses/LICENSE-2.0"}
   :dependencies [[org.clojure/core.memoize "1.1.266"]
                  [org.clojure/tools.logging "1.3.0"]
-                 [org.apache.commons/commons-compress "1.26.1"]
+                 [org.apache.commons/commons-compress "1.27.1"]
                  [org.tukaani/xz "1.9"] ; necessary for CRAM LZMA compression
                  [digest "1.4.10"]
                  [bgzf4j "0.1.2"]

--- a/project.clj
+++ b/project.clj
@@ -6,7 +6,7 @@
   :dependencies [[org.clojure/core.memoize "1.1.266"]
                  [org.clojure/tools.logging "1.3.0"]
                  [org.apache.commons/commons-compress "1.27.1"]
-                 [org.tukaani/xz "1.9"] ; necessary for CRAM LZMA compression
+                 [org.tukaani/xz "1.10"] ; necessary for CRAM LZMA compression
                  [digest "1.4.10"]
                  [bgzf4j "0.1.2"]
                  [com.climate/claypoole "1.1.4"]

--- a/project.clj
+++ b/project.clj
@@ -12,7 +12,7 @@
                  [com.climate/claypoole "1.1.4"]
                  [camel-snake-kebab "0.4.3"]
                  [proton "0.2.3"]]
-  :profiles {:dev {:dependencies [[org.clojure/clojure "1.11.3"]
+  :profiles {:dev {:dependencies [[org.clojure/clojure "1.12.0"]
                                   [cavia "0.5.1"]
                                   [criterium "0.4.6"]
                                   [net.totakke/libra "0.1.1"]
@@ -31,7 +31,8 @@
              :1.7 {:dependencies [[org.clojure/clojure "1.7.0"]]}
              :1.8 {:dependencies [[org.clojure/clojure "1.8.0"]]}
              :1.9 {:dependencies [[org.clojure/clojure "1.9.0"]]}
-             :1.10 {:dependencies [[org.clojure/clojure "1.10.3"]]}}
+             :1.10 {:dependencies [[org.clojure/clojure "1.10.3"]]}
+             :1.11 {:dependencies [[org.clojure/clojure "1.11.4"]]}}
   :deploy-repositories [["snapshots" {:url "https://clojars.org/repo/"
                                       :username [:env/clojars_username :gpg]
                                       :password [:env/clojars_password :gpg]}]]

--- a/src/cljam/io/bam_index.clj
+++ b/src/cljam/io/bam_index.clj
@@ -19,6 +19,19 @@
   [bai ref-idx beg end]
   (util-bin/get-spans bai ref-idx beg end))
 
+(defn get-spans-for-regions
+  "Returns a sequence of [start end) pairs of virtual file offsets of a BAM file
+  that may contain alignments overlapping one of the given genomic `regions`
+  which is a sequence of pairs of integers, begin and end."
+  [bai ^long ref-idx regions]
+  (util-bin/get-spans-for-regions bai ref-idx regions))
+
+(defn get-unplaced-spans
+  "Returns a sequence of [start end) pairs of virtual file offsets that may
+  contain alignments that don't have RNAME."
+  [bai]
+  (bai-core/get-unplaced-spans bai))
+
 (defn bam-index
   "Returns a cljam.bam-index.core.BAMIndex."
   [f]

--- a/src/cljam/io/protocols.clj
+++ b/src/cljam/io/protocols.clj
@@ -31,6 +31,8 @@
     "Returns references of the SAM/BAM file.")
   (read-alignments [this] [this region]
     "Reads alignments of the SAM/BAM file, returning the alignments as an eduction.")
+  (read-mate-alignments [this alignments] [this option alignments]
+    "Reads mate alignments of given `alignments`.")
   (read-blocks [this] [this region] [this region option]
     "Reads alignment blocks of the SAM/BAM file, returning the blocks as an eduction."))
 

--- a/test/cljam/io/bam/reader_test.clj
+++ b/test/cljam/io/bam/reader_test.clj
@@ -1,0 +1,101 @@
+(ns cljam.io.bam.reader-test
+  (:require [clojure.java.io :as io]
+            [clojure.test :refer [deftest is testing]]
+            [cljam.util :as util]
+            [cljam.util.chromosome :as chr]
+            [cljam.io.protocols :as prot]
+            [cljam.io.bam.core :as bam.core]
+            [cljam.io.sam.util.flag :as flag]))
+
+(defn- conj-flag [flag & xs]
+  (flag/encode (apply conj (flag/decode flag) xs)))
+
+(defn- unmap [xs]
+  (let [[unmapped mapped] (if (< (double (rand)) 0.5)
+                            [0 1]
+                            [1 0])]
+    (-> xs
+        (update unmapped assoc
+                :rname "*" :pos 0 :end 0
+                :mapq 0 :cigar "" :tlen 0)
+        (update-in [unmapped :flag] conj-flag :unmapped)
+        (update-in [unmapped :rnext] #(if (= "=" %)
+                                        (:rname (first xs))
+                                        %))
+        (update mapped assoc
+                :rnext "*" :pnext 0 :tlen 0)
+        (update-in [mapped :flag] conj-flag :next-unmapped))))
+
+(defn- generate-paired-bam [n]
+  (let [refs (->>
+              (range 24)
+              (map (fn [i] {:SN (str "chr" (inc (long i))),
+                            :LN (+ 100000000 (long (rand-int 50000000)))}))
+              (sort-by (comp chr/chromosome-order-key :SN)))]
+    (->>
+     (range n)
+     (map
+      (fn [i]
+        (let [{:keys [SN LN] :as r} (rand-nth refs)
+              pos (int (rand-int (- (long LN) 300)))
+              chimeric? (< (double (rand)) 0.3)
+              unmapped? (< (double (rand)) 0.2)
+              rnext (if chimeric?
+                      (rand-nth (filterv (complement #{r}) refs))
+                      r)
+              pnext (int (if chimeric?
+                           (rand-int (- (long (:LN rnext)) 300))
+                           (+ pos (int 70) (int (rand-int 200)))))
+              qname (str "read" (inc (long i)))]
+          (cond-> [(prot/->SAMAlignment
+                    qname (flag/encode #{:multiple :first})
+                    SN pos (int (+ pos 150)) 60 "151M"
+                    (if chimeric? (:SN rnext) "=") pnext 0 "*" "*" [])
+                   (prot/->SAMAlignment
+                    qname (flag/encode #{:multiple :last})
+                    (:SN rnext) pnext (int (+ pnext 150)) 60 "151M"
+                    (if chimeric? SN "=") pos 0 "*" "*" [])]
+            unmapped? unmap))))
+     (apply concat)
+     (sort-by (juxt (comp chr/chromosome-order-key :rname) :pos))
+     (vector {:HD {:VN "1.4", :SO "coordinate"}, :SQ refs}))))
+
+(defn- generate-test-case [n alignments]
+  (let [in (->> alignments
+                shuffle
+                (take n)
+                (group-by :qname)
+                vals
+                (map first)) ; take either R1 or R2
+        mate? (into #{} (map (juxt :qname (comp not flag/r1? :flag)) in))]
+    [in (filter (comp mate? (juxt :qname (comp flag/r1? :flag))) alignments)]))
+
+(deftest read-mate-alignments-test
+  ;; 1. Generates a sequence of paired alignments with random positions.
+  ;; 2. Write the alignments to a BAM file with an index.
+  ;; 3. Randomly pick some subsets of the alignments as queries.
+  ;; 4. Compute the mate alignments for each query using (1).
+  ;; 5. Read the mate alignments from (2) and compare with (4).
+  (util/with-temp-dir [d "read-pairs-test"]
+    (let [temp-bam (io/file d "tmp.bam")
+          n-total-alignments 10000
+          n-query-alignments 50
+          n-tests 5
+          [header alignments] (generate-paired-bam n-total-alignments)]
+
+      ;; write a BAM with a BAI
+      (with-open [w (bam.core/writer temp-bam true)]
+        (doto w
+          (prot/write-header header)
+          (prot/write-refs header)
+          (prot/write-alignments alignments header)))
+
+      ;; read and compare
+      (with-open [r (bam.core/reader temp-bam)]
+        (doseq [[i [input expected]] (->> #(generate-test-case
+                                            n-query-alignments alignments)
+                                          (repeatedly n-tests)
+                                          (map vector (range)))]
+          (testing (inc (long i))
+            (is (= expected
+                   (prot/read-mate-alignments r input)))))))))

--- a/test/cljam/io/sam_test.clj
+++ b/test/cljam/io/sam_test.clj
@@ -468,3 +468,14 @@
       temp-bam-file
       (cio/file temp-bam-file)
       (cio/as-url (cio/file temp-bam-file)))))
+
+(deftest make-pairs-test
+  (testing "BAM"
+    (with-open [r (sam/reader test-sorted-bam-file)]
+      (let [[r001 r002 r003 r004 r003' r001'] (vec (sam/read-alignments r))]
+        (is (= [[r001 r001']]
+               (sam/make-pairs r [r001])))
+        (is (= [[r001 r001']]
+               (sam/make-pairs r [r001 r001'])))
+        (is (= [[r001 r001']] ;; r003 is not flagged as paired
+               (sam/make-pairs r [r001  r002 r003 r003' r004])))))))

--- a/test/cljam/io/util/bin_test.clj
+++ b/test/cljam/io/util/bin_test.clj
@@ -197,3 +197,16 @@
                       (number? (first %))
                       (number? (second %)))
                 (util-bin/get-spans csi* 0 1 100000)))))
+
+(deftest get-spans-for-regions-test
+  (testing "tabix"
+    (let [tabix (tabix/read-index test-tabix-file)]
+      (is (= [[0 50872]]
+             (util-bin/get-spans-for-regions tabix 0 [[1 100]])))
+      (is (= [[0 50872]]
+             (util-bin/get-spans-for-regions
+              tabix 0 [[1 10] [10 20] [30 40] [40 50] [50 100]])))))
+  (testing "csi"
+    (let [csi (csi/read-index test-csi-file)]
+      (is (= [[3904 3973]]
+             (util-bin/get-spans-for-regions csi 0 [[1 100000]]))))))


### PR DESCRIPTION
#### Summary
This PR adds a function `cljam.io.sam/read-mate-alignments` for BAM file which reads R1/R2 counterpart alignments of given alignments.

#### Added functions
This function can be used for collecting alignments around some regions keeping pairs like `samtools view --fetch-pairs`.

```clj
(let [xs (sam/read-alignments reader {:chr "chr1", :start 1, :end 100000})]
  (concat xs (sam/read-mate-alignments reader xs))
```

In the example above, it is necessary to recheck which alignment pairs with which. To make things easier, I added another function `cljam.io.sam/make-pairs` that returns a sequence with paired alignments grouped together.

```clj
(let [xs (sam/read-alignments reader {:chr "chr1", :start 1, :end 100000})]
  (sam/make-pairs reader xs))
```

To achieve these functionalities, I implemented a function `cljam.io.bam-index/get-spans-for-regions` that queries chunks corresponding to multiple regions at once against the BAI index.

#### Implementation details
`cljam.io.sam/read-mate-alignments` for SAM and CRAM is not supported yet.

When searching for mates, a large number of alignment blocks that do not meet the criteria must be discarded. Therefore, the current implementation decodes only the minimal set of fields necessary for condition evaluation and immediately rejects blocks that do not satisfy the criteria.

As a result, a significant part of the execution time is spent decompressing BGZF blocks, so reducing the number of chunks accessed would make a big difference.
However, the current implementation is limited to what can be achieved by combining existing functionalities, leaving room for further optimization in the future.

#### Tests
Since we don't have a good BAM file with paired reads of appropriate size, I added auto-generated test cases for `cljam.io.sam/read-mate-alignments`. It writes a temporary BAM file containing paired alignments on the fly, and then perform reading and checking.