### PR TITLE
Explicitly install lein with setup-clojure for CI

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -14,6 +14,15 @@ jobs:
         key: ${{ runner.os }}-m2-${{ hashFiles('**/project.clj') }}
         restore-keys: |
           ${{ runner.os }}-m2-
+    - uses: actions/setup-java@v4
+      with:
+        java-version: '21'
+        distribution: 'temurin'
+        architecture: x64
+    - name: Setup Clojure
+      uses: DeLaGuardo/setup-clojure@13.1
+      with:
+        lein: latest
     - name: Install dependencies
       run: lein deps
     - name: Generate Coverage Report

--- a/.github/workflows/format.yml
+++ b/.github/workflows/format.yml
@@ -13,6 +13,10 @@ jobs:
         java-version: '21'
         distribution: 'temurin'
         architecture: x64
+    - name: Setup Clojure
+      uses: DeLaGuardo/setup-clojure@13.1
+      with:
+        lein: latest
     - name: Cache m2 repository
       uses: actions/cache@v4
       with:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -17,6 +17,10 @@ jobs:
         java-version: ${{ matrix.java }}
         distribution: 'temurin'
         architecture: x64
+    - name: Setup Clojure
+      uses: DeLaGuardo/setup-clojure@13.1
+      with:
+        lein: latest
     - name: Cache m2 repository
       uses: actions/cache@v4
       with:
@@ -49,6 +53,10 @@ jobs:
         java-version: '8'
         distribution: 'temurin'
         architecture: x64
+    - name: Setup Clojure
+      uses: DeLaGuardo/setup-clojure@13.1
+      with:
+        lein: latest
     - name: Deploy
       env:
         CLOJARS_USERNAME: ${{ secrets.CLOJARS_USERNAME }}


### PR DESCRIPTION
As mentioned in https://github.com/chrovis/cljam/pull/330#issuecomment-2572767463, Leiningen has been removed from the latest `ubuntu-latest` GitHub Action runner image. Some workflows in cljam rely on the `lein` installed in the `ubuntu-latest` image, which causes them to fail on the CI.

This PR updates those workflows by explicitly installing Leiningen with `DeLaGuardo/setup-clojure`. It also adds `actions/setup-java` to the `coverage` workflow to avoid depending on the `java` installed in the GA runner image, as in the other workflows.

