### PR TITLE
Fix overflow issues occurs when *unchecked-math* is disabled

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -32,7 +32,9 @@
              :1.8 {:dependencies [[org.clojure/clojure "1.8.0"]]}
              :1.9 {:dependencies [[org.clojure/clojure "1.9.0"]]}
              :1.10 {:dependencies [[org.clojure/clojure "1.10.3"]]}
-             :1.11 {:dependencies [[org.clojure/clojure "1.11.4"]]}}
+             :1.11 {:dependencies [[org.clojure/clojure "1.11.4"]]}
+             :test {:global-vars ^:replace {*warn-on-reflection* false
+                                            *unchecked-math* false}}}
   :deploy-repositories [["snapshots" {:url "https://clojars.org/repo/"
                                       :username [:env/clojars_username :gpg]
                                       :password [:env/clojars_password :gpg]}]]

--- a/src/cljam/io/cram/data_series.clj
+++ b/src/cljam/io/cram/data_series.clj
@@ -105,7 +105,7 @@
            (dotimes [i n]
              (let [b (bit-or (bit-shift-left (Character/digit (aget s (* 2 i)) 16) 4)
                              (Character/digit (aget s (inc (* 2 i))) 16))]
-               (aset arr i (byte b))))
+               (aset arr i (unchecked-byte b))))
            arr))
     \B (fn [^ByteBuffer bb]
          (let [tag-type' (char (.get bb))

--- a/src/cljam/io/cram/encode/structure.clj
+++ b/src/cljam/io/cram/encode/structure.clj
@@ -74,7 +74,7 @@
         out' (CheckedOutputStream. out crc)
         bb (bb/allocate-lsb-byte-buffer 4)]
     (f out')
-    (.putInt bb (int (.getValue crc)))
+    (.putInt bb (unchecked-int (.getValue crc)))
     (lsb/write-bytes out (.array bb))))
 
 (defn encode-container-header
@@ -145,7 +145,7 @@
       (let [r (nth all-bases i)
             codes (get m r)]
         (aset ret i
-              (byte
+              (unchecked-byte
                (loop [j 0, k 0, acc 0]
                  (if (< j 5)
                    (if (= i j)

--- a/src/cljam/io/util/lsb/io_stream.clj
+++ b/src/cljam/io/util/lsb/io_stream.clj
@@ -103,16 +103,12 @@
 (defn write-ubyte
   "Writes 1 byte."
   [^OutputStream stream b]
-  (let [bb (bb/allocate-lsb-byte-buffer)]
-    (.putShort bb b)
-    (.write stream (.array bb) 0 1)))
+  (.write stream (unchecked-byte b)))
 
 (defn write-char
   "Writes a 1-byte ascii character."
   [^OutputStream stream b]
-  (let [bb (bb/allocate-lsb-byte-buffer)]
-    (.putChar bb b)
-    (.write stream (.array bb) 0 1)))
+  (.write stream (unchecked-byte (int b))))
 
 (defn write-short
   "Writes a 2-byte short value."
@@ -125,7 +121,7 @@
   "Writes a 2-byte unsigned short value."
   [^OutputStream stream n]
   (let [bb (bb/allocate-lsb-byte-buffer)]
-    (.putInt bb n)
+    (.putShort bb (unchecked-short n))
     (.write stream (.array bb) 0 2)))
 
 (defn write-int

--- a/test/cljam/io/cram/data_series_test.clj
+++ b/test/cljam/io/cram/data_series_test.clj
@@ -131,15 +131,15 @@
                      :data (doto (bb/allocate-lsb-byte-buffer 8)
                              (.putShort 0x0123)
                              (.putShort 0x4567)
-                             (.putShort 0x89ab)
-                             (.putShort 0xcdef)
+                             (.putShort (unchecked-short 0x89ab))
+                             (.putShort (unchecked-short 0xcdef))
                              .flip)}
                     {:content-id 7697235
                      :data (doto (bb/allocate-lsb-byte-buffer 8)
                              (.putShort 0x0123)
                              (.putShort 0x4567)
-                             (.putShort 0x89ab)
-                             (.putShort 0xcdef)
+                             (.putShort (unchecked-short 0x89ab))
+                             (.putShort (unchecked-short 0xcdef))
                              .flip)}]
             decoders (ds/build-tag-decoders {:tags encodings} nil blocks)
             ss (get-in decoders [:ss \s])
@@ -171,15 +171,15 @@
                      :data (doto (bb/allocate-lsb-byte-buffer 16)
                              (.putInt 0)
                              (.putInt 0x01234567)
-                             (.putInt 0x89abcdef)
-                             (.putInt 0xffffffff)
+                             (.putInt (unchecked-int 0x89abcdef))
+                             (.putInt (unchecked-int 0xffffffff))
                              .flip)}
                     {:content-id 7694665
                      :data (doto (bb/allocate-lsb-byte-buffer 16)
                              (.putInt 0)
                              (.putInt 0x01234567)
-                             (.putInt 0x89abcdef)
-                             (.putInt 0xffffffff)
+                             (.putInt (unchecked-int 0x89abcdef))
+                             (.putInt (unchecked-int 0xffffffff))
                              .flip)}]
             decoders (ds/build-tag-decoders {:tags encodings} nil blocks)
             si (get-in decoders [:si \i])
@@ -275,7 +275,7 @@
                                          [0xfc 0xfd 0xfe 0xff]]]
                                (.put bb (byte (int \c)))
                                (.putInt bb 4)
-                               (doseq [v vs] (.put bb (byte v))))
+                               (doseq [v vs] (.put bb (unchecked-byte v))))
                              (.flip bb))}
                     {:content-id 7692866
                      :data (let [bb (bb/allocate-lsb-byte-buffer 36)]
@@ -285,7 +285,7 @@
                                          [0xfc 0xfd 0xfe 0xff]]]
                                (.put bb (byte (int \C)))
                                (.putInt bb 4)
-                               (doseq [v vs] (.put bb (byte v))))
+                               (doseq [v vs] (.put bb (unchecked-byte v))))
                              (.flip bb))}]
             decoders (ds/build-tag-decoders {:tags encodings} nil blocks)
             sb (get-in decoders [:sb \B])
@@ -321,7 +321,7 @@
                                          [0xfffe 0xffff]]]
                                (.put bb (byte (int \s)))
                                (.putInt bb 2)
-                               (doseq [v vs] (.putShort bb v)))
+                               (doseq [v vs] (.putShort bb (unchecked-short v))))
                              (.flip bb))}
                     {:content-id 7697218
                      :data (let [bb (bb/allocate-lsb-byte-buffer 36)]
@@ -331,7 +331,7 @@
                                          [0xfffe 0xffff]]]
                                (.put bb (byte (int \S)))
                                (.putInt bb 2)
-                               (doseq [v vs] (.putShort bb v)))
+                               (doseq [v vs] (.putShort bb (unchecked-short v))))
                              (.flip bb))}]
             decoders (ds/build-tag-decoders {:tags encodings} nil blocks)
             ss (get-in decoders [:ss \B])
@@ -369,7 +369,7 @@
                                          [0xfffffffe 0xffffffff]]]
                                (.put bb (byte (int \i)))
                                (.putInt bb 2)
-                               (doseq [v vs] (.putInt bb v)))
+                               (doseq [v vs] (.putInt bb (unchecked-int v))))
                              (.flip bb))}
                     {:content-id 7694658
                      :data (let [bb (bb/allocate-lsb-byte-buffer 52)]
@@ -379,7 +379,7 @@
                                          [0xfffffffe 0xffffffff]]]
                                (.put bb (byte (int \I)))
                                (.putInt bb 2)
-                               (doseq [v vs] (.putInt bb v)))
+                               (doseq [v vs] (.putInt bb (unchecked-int v))))
                              (.flip bb))}]
             decoders (ds/build-tag-decoders {:tags encodings} nil blocks)
             si (get-in decoders [:si \B])
@@ -903,7 +903,7 @@
                              (.put bb (byte (int \I)))
                              (.putInt bb (count encoded))
                              (run! #(.putInt bb %) encoded)
-                             (.put bb (byte 0xff))
+                             (.put bb (unchecked-byte 0xff))
                              (.array bb)))
                          vs)
                  (seq (decompress res)))))))

--- a/test/cljam/io/cram/encode/structure_test.clj
+++ b/test/cljam/io/cram/encode/structure_test.clj
@@ -21,7 +21,7 @@
   (let [crc (CRC32.)]
     (.update crc bs start end)
     (-> (bb/allocate-lsb-byte-buffer 4)
-        (.putInt (.getValue crc))
+        (.putInt (unchecked-int (.getValue crc)))
         .array)))
 
 (deftest encode-file-definition-test

--- a/test/cljam/io/util/byte_buffer_test.clj
+++ b/test/cljam/io/util/byte_buffer_test.clj
@@ -14,7 +14,7 @@
   (let [bb (doto (bb/allocate-lsb-byte-buffer 8)
              (.putLong 0x789ABCDEF0123456)
              (.flip))]
-    (is (= (int 0xF0123456) (.getInt bb)))
+    (is (= (unchecked-int 0xF0123456) (.getInt bb)))
     (is (= (int 0x789ABCDE) (.getInt bb)))))
 
 (deftest allocate-msb-byte-buffer-test
@@ -22,7 +22,7 @@
              (.putLong 0x789ABCDEF0123456)
              (.flip))]
     (is (= (int 0x789ABCDE) (.getInt bb)))
-    (is (= (int 0xF0123456) (.getInt bb)))))
+    (is (= (unchecked-int 0xF0123456) (.getInt bb)))))
 
 (deftest read-ops-test
   (let [bb (doto (bb/allocate-lsb-byte-buffer 8)

--- a/test/cljam/io/util/lsb/io_stream_test.clj
+++ b/test/cljam/io/util/lsb/io_stream_test.clj
@@ -133,7 +133,7 @@
         (is (= (seq ba) (seq ret)))))
 
     (with-open [baos (ByteArrayOutputStream. 8)]
-      (lsb/write-int baos 0xF0123456)
+      (lsb/write-int baos (unchecked-int 0xF0123456))
       (lsb/write-int baos 0x789ABCDE)
       (let [ret (.toByteArray baos)]
         (is (= (count ba) (count ret)))


### PR DESCRIPTION
fixes: #332 

This PR fixes issues found in https://github.com/chrovis/cljam/pull/330#pullrequestreview-2522682459

Some functions under `cljam.io.cram` and `cljam.io.util.lsb` used the **checked** narrowing conversions of numerical values (`byte`, `int`, ...) or implicit conversions with typed method callings of Java core library.
These narrowing of numeric types works fine as long as `*unchecked-math*` is set to `true` or only non-negative integers are involved. However, if `*unchecked-math*` is `false` (which is the default) and a negative integer is provided, an exception is thrown.
In this PR, I have explicitly applied unchecked narrowing (`unchecked-byte`, `unchecked-int`, ...) to bypass range checks and ensure the intended output.
I have also fixed the `:gloval-vars` option in the project to reset the compiler options while testing in CI.

I have confirmed that `lein test :all` passes.