### PR TITLE
Stop using cache in CI

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -7,13 +7,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v7
-    - name: Cache m2 repository
-      uses: actions/cache@v6
-      with:
-        path: ~/.m2
-        key: ${{ runner.os }}-m2-${{ hashFiles('**/project.clj') }}
-        restore-keys: |
-          ${{ runner.os }}-m2-
     - uses: actions/setup-java@v5
       with:
         java-version: '21'

--- a/.github/workflows/format.yml
+++ b/.github/workflows/format.yml
@@ -17,13 +17,6 @@ jobs:
       uses: DeLaGuardo/setup-clojure@13.5
       with:
         lein: latest
-    - name: Cache m2 repository
-      uses: actions/cache@v6
-      with:
-        path: ~/.m2
-        key: ${{ runner.os }}-m2-${{ hashFiles('**/project.clj') }}
-        restore-keys: |
-          ${{ runner.os }}-m2-
     - name: Install dependencies
       run: lein deps
     - name: Run cljfmt

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -21,13 +21,6 @@ jobs:
       uses: DeLaGuardo/setup-clojure@13.5
       with:
         lein: latest
-    - name: Cache m2 repository
-      uses: actions/cache@v6
-      with:
-        path: ~/.m2
-        key: ${{ runner.os }}-m2-${{ hashFiles('**/project.clj') }}
-        restore-keys: |
-          ${{ runner.os }}-m2-
     - name: Install dependencies
       run: lein deps
     - name: Run lein check


### PR DESCRIPTION
Removed `actions/cache` from `.github/workflows`.